### PR TITLE
Fix loading remote profiles

### DIFF
--- a/.github/workflows/on_push_to_feature.yaml
+++ b/.github/workflows/on_push_to_feature.yaml
@@ -59,4 +59,5 @@ jobs:
           cd tests/spaceprez && poetry run pytest
           cd ../vocprez && poetry run pytest
           cd ../catprez && poetry run pytest
+          cd ../profiles && poetry run pytest
 #          cd ../local_sparql_store && poetry run pytest

--- a/dev/dev-setup.py
+++ b/dev/dev-setup.py
@@ -5,7 +5,7 @@ import requests
 
 os.system("docker context use default")
 response = os.system(
-    "docker run -d -v ${PWD}/dev/dev-config.ttl:/fuseki/config.ttl -p 3030:3030 ghcr.io/zazuko/fuseki-geosparql:4.7.0"
+    "docker run -d -v ${PWD}/dev/dev-config.ttl:/fuseki/config.ttl -p 3030:3030 ghcr.io/zazuko/fuseki-geosparql"
 )
 
 time.sleep(15)
@@ -61,6 +61,14 @@ def setup_sp():
             (
                 "dublin_core_terms.ttl",
                 open("tests/data/vocprez/input/dublin_core_terms.ttl", "rb"),
+                "application/octet-stream",
+            ),
+        ),
+        (
+            "myfile7",
+            (
+                "remote_profile.ttl",
+                open("tests/data/profiles/remote_profile.ttl", "rb"),
                 "application/octet-stream",
             ),
         ),

--- a/prez/services/generate_profiles.py
+++ b/prez/services/generate_profiles.py
@@ -59,7 +59,8 @@ async def create_profiles_graph() -> Graph:
         r = await sparql_construct(remote_profiles_query, p)
         if r[0] and r[1]:
             any_remote_profiles = True
-            profiles_graph_cache.__add__(r[1])
+            for triple in r[1]:
+                profiles_graph_cache.add(triple)
             log.info(f"Remote profiles found and added for {p}")
     if not any_remote_profiles:
         log.info("No remote profiles found")

--- a/prez/services/generate_profiles.py
+++ b/prez/services/generate_profiles.py
@@ -59,8 +59,7 @@ async def create_profiles_graph() -> Graph:
         r = await sparql_construct(remote_profiles_query, p)
         if r[0] and r[1]:
             any_remote_profiles = True
-            for triple in r[1]:
-                profiles_graph_cache.add(triple)
+            profiles_graph_cache.__iadd__(r[1])
             log.info(f"Remote profiles found and added for {p}")
     if not any_remote_profiles:
         log.info("No remote profiles found")

--- a/tests/data/profiles/remote_profile.ttl
+++ b/tests/data/profiles/remote_profile.ttl
@@ -1,0 +1,19 @@
+PREFIX altr-ext: <http://www.w3.org/ns/dx/conneg/altr-ext#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prez: <https://prez.dev/>
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+<https://example.com/profile>
+    a prof:Profile , prez:SpacePrezProfile ;
+    dcterms:description "an example profile" ;
+    dcterms:identifier "exprof"^^xsd:token ;
+    dcterms:title "Example" ;
+    .

--- a/tests/local_sparql_store/store.py
+++ b/tests/local_sparql_store/store.py
@@ -19,6 +19,7 @@ def load_catprez_graph():
         "*.ttl"
     ):
         g.parse(f)
+    load_profiles_graph(g)
     return g
 
 
@@ -29,6 +30,7 @@ def load_spaceprez_graph():
         "*.ttl"
     ):
         g.parse(f)
+    load_profiles_graph(g)
     return g
 
 
@@ -39,13 +41,19 @@ def load_vocprez_graph():
         "*.ttl"
     ):
         g.parse(f)
+    load_profiles_graph(g)
     return g
 
+def load_profiles_graph(g):
+    print("loading Profiles graph")
+    for f in Path(Path(__file__).parent.parent / "data" / "profiles").glob(
+        "*.ttl"
+    ):
+        g.parse(f)
 
 catprez_graph = load_catprez_graph()
 vocprez_graph = load_vocprez_graph()
 spaceprez_graph = load_spaceprez_graph()
-
 
 class SparqlServer(BaseHTTPRequestHandler):
     """A small SPARQL Protocol server for Prez testing.

--- a/tests/profiles/conftest.py
+++ b/tests/profiles/conftest.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ["TEST_MODE"] = "true"
+os.environ["SPACEPREZ_SPARQL_ENDPOINT"] = "http://localhost:3032/spaceprez"
+PREZ_DIR = Path(__file__).parent.parent.parent.parent.absolute() / "prez"
+os.environ["PREZ_DIR"] = str(PREZ_DIR)
+os.environ["LOCAL_SPARQL_STORE"] = str(
+    Path(Path(__file__).parent.parent / "local_sparql_store/store.py")
+)
+
+sys.path.insert(0, str(PREZ_DIR.absolute()))

--- a/tests/profiles/test_endpoints_profiles.py
+++ b/tests/profiles/test_endpoints_profiles.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+from pathlib import Path
+from time import sleep
+
+import pytest
+from rdflib import Graph, URIRef, RDFS
+
+PREZ_DIR = os.getenv("PREZ_DIR")
+LOCAL_SPARQL_STORE = os.getenv("LOCAL_SPARQL_STORE")
+from fastapi.testclient import TestClient
+
+# https://www.python-httpx.org/advanced/#calling-into-python-web-apps
+
+
+@pytest.fixture(scope="module")
+def sp_test_client(request):
+    print("Run Local SPARQL Store")
+    p1 = subprocess.Popen(["python", str(LOCAL_SPARQL_STORE), "-p", "3032"])
+    sleep(1)
+
+    def teardown():
+        print("\nDoing teardown")
+        p1.kill()
+
+    request.addfinalizer(teardown)
+
+    # must only import app after config.py has been altered above so config is retained
+    from prez.app import app
+
+    return TestClient(app)
+
+
+def test_profile(sp_test_client):
+    with sp_test_client as client:
+        # check the example remote profile is loaded
+        r = client.get("/profiles")
+        g = Graph().parse(data=r.text)
+        assert (URIRef("https://prez.dev/ProfilesList"),
+                URIRef("http://www.w3.org/2000/01/rdf-schema#member"),
+                URIRef("https://example.com/profile")) in g


### PR DESCRIPTION
The `profiles_graph_cache` is using the `__add__` method which returns the combined statements in a new `Graph` instead of adding the new statements into `profiles_graph_cache`. This is why the remote profiles are never loaded.

Since `profiles_graph_cache` is a global variable imported elsewhere, we are not able to update its value. This is why something like the below won't work.

```python
profiles_graph_cache += r[1]
```

Instead, we add the triples from `r[1]` directly into `profiles_graph_cache`.