### PR TITLE
Fix rendering of VocPub SKOS Collections at /v/collection/<id>

### DIFF
--- a/prez/renderers/renderer.py
+++ b/prez/renderers/renderer.py
@@ -196,7 +196,7 @@ def generate_prez_links(graph, predicates_for_link_addition):
 
 def generate_object_endpoint_link(graph, predicates_for_link_addition):
     all_preds = (
-        predicates_for_link_addition["child"] + predicates_for_link_addition["parent"]
+        predicates_for_link_addition["ib_par"] + predicates_for_link_addition["ob_par"] + predicates_for_link_addition["ib_chi"] + predicates_for_link_addition["ob_chi"]
     )
     objects_for_links = graph.triples_choices((None, all_preds, None))
     for o in objects_for_links:
@@ -213,7 +213,7 @@ async def return_profiles(
     classes: frozenset,
     prez_type: str,
     request: Optional[Request] = None,
-    prof_and_mt_info: Optional = None,
+    prof_and_mt_info: Optional[ProfilesMediatypesInfo] = None,
 ) -> Response:
     from prez.cache import profiles_graph_cache
 

--- a/tests/data/vocprez/expected_responses/collection_listing_item.ttl
+++ b/tests/data/vocprez/expected_responses/collection_listing_item.ttl
@@ -1,0 +1,199 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ns1: <https://prez.dev/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+dcterms:identifier rdfs:label "Identifier"@en ;
+    dcterms:description "Recommended practice is to identify the resource by means of a string conforming to an identification system. Examples include International Standard Book Number (ISBN), Digital Object Identifier (DOI), and Uniform Resource Name (URN).  Persistent identifiers should be provided as HTTP URIs."@en .
+
+dcterms:provenance rdfs:label "Provenance"@en ;
+    dcterms:description "The statement may include a description of any changes successive custodians made to the resource."@en .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype> a skos:Collection ;
+    dcterms:identifier "contacttype"^^xsd:token ;
+    dcterms:provenance "this vocabulary" ;
+    skos:definition "All Concepts in this vocabulary" ;
+    skos:member <http://resource.geosciml.org/classifier/cgi/contacttype/alteration_facies_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/angular_unconformable_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/buttress_unconformity>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/chronostratigraphic_zone_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/conductivity_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/conformable_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/deformation_zone_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/density_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/depositional_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/disconformable_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/faulted_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/geologic_province_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/geophysical_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/glacial_stationary_line>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/igneous_intrusive_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/igneous_phase_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/impact_structure_boundary>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/lithogenetic_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_polarity_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_susceptiblity_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/magnetization_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/metamorphic_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/metamorphic_facies_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/metasomatic_facies_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/mineralisation_assemblage_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/nonconformable_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/paraconformable_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/radiometric_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/sedimentary_facies_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/sedimentary_intrusive_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/seismic_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/unconformable_contact>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/volcanic_subsidence_zone_boundary>,
+        <http://resource.geosciml.org/classifier/cgi/contacttype/weathering_contact> ;
+    skos:prefLabel "Contact Type - All Concepts"@en .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/alteration_facies_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "alteration facies contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/alteration_facies_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/angular_unconformable_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "angular unconformable contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/angular_unconformable_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/buttress_unconformity> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "buttress unconformity"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/buttress_unconformity" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/chronostratigraphic_zone_contact> dcterms:provenance "FGDC"@en ;
+    skos:prefLabel "chronostratigraphic-zone contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/chronostratigraphic_zone_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/conductivity_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "conductivity contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/conductivity_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/conformable_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "conformable contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/conformable_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/contact> dcterms:provenance "adapted from Jackson, 1997, page 137, NADM C1 2004"@en ;
+    skos:prefLabel "contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/deformation_zone_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "deformation zone contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/deformation_zone_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/density_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "density contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/density_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/depositional_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "depositional contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/depositional_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/disconformable_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "disconformable contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/disconformable_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/faulted_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "faulted contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/faulted_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/geologic_province_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "geologic province contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/geologic_province_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/geophysical_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "geophysical contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/geophysical_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/glacial_stationary_line> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "glacial stationary line"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/glacial_stationary_line" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/igneous_intrusive_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "igneous intrusive contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/igneous_intrusive_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/igneous_phase_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "igneous phase contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/igneous_phase_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/impact_structure_boundary> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "impact structure boundary"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/impact_structure_boundary" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/lithogenetic_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "lithogenetic contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/lithogenetic_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "magnetic contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_polarity_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "magnetic polarity contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_polarity_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_susceptiblity_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "magnetic susceptiblity contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/magnetic_susceptiblity_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/magnetization_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "magnetization contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/magnetization_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/metamorphic_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "metamorphic contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/metamorphic_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/metamorphic_facies_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "metamorphic facies contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/metamorphic_facies_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/metasomatic_facies_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "metasomatic facies contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/metasomatic_facies_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/mineralisation_assemblage_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "mineralisation assemblage contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/mineralisation_assemblage_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/nonconformable_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "nonconformable contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/nonconformable_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/paraconformable_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "paraconformable contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/paraconformable_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/radiometric_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "radiometric contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/radiometric_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/sedimentary_facies_contact> dcterms:provenance "base on Nichols, Gary, 1999, Sedimentology and stratigraphy, Blackwell, p. 62-63."@en ;
+    skos:prefLabel "sedimentary facies contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/sedimentary_facies_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/sedimentary_intrusive_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "sedimentary intrusive contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/sedimentary_intrusive_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/seismic_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "seismic contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/seismic_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/unconformable_contact> dcterms:provenance "Neuendorf, K.K.E, Mehl, J.P. & Jackson, J.A. (eds), 2005. Glossary of geology, 5th Edition. American Geological Institute, Alexandria, 779 p."@en ;
+    skos:prefLabel "unconformable contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/unconformable_contact" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/volcanic_subsidence_zone_boundary> dcterms:provenance "this vocabulary, concept to encompass boundary of caldron, caldera, or crater."@en ;
+    skos:prefLabel "volcanic subsidence zone boundary"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/volcanic_subsidence_zone_boundary" .
+
+<http://resource.geosciml.org/classifier/cgi/contacttype/weathering_contact> dcterms:provenance "this vocabulary"@en ;
+    skos:prefLabel "weathering contact"@en ;
+    ns1:link "/v/object?uri=http://resource.geosciml.org/classifier/cgi/contacttype/weathering_contact" .
+
+

--- a/tests/vocprez/test_endpoints_vocprez.py
+++ b/tests/vocprez/test_endpoints_vocprez.py
@@ -1,11 +1,10 @@
 import os
-import re
 import subprocess
 from pathlib import Path
 from time import sleep
 
 import pytest
-from rdflib import Graph, URIRef, RDFS, DCTERMS, RDF, SKOS
+from rdflib import Graph, URIRef, RDF, SKOS
 
 PREZ_DIR = os.getenv("PREZ_DIR")
 LOCAL_SPARQL_STORE = os.getenv("LOCAL_SPARQL_STORE")

--- a/tests/vocprez/test_endpoints_vocprez.py
+++ b/tests/vocprez/test_endpoints_vocprez.py
@@ -5,6 +5,7 @@ from time import sleep
 
 import pytest
 from rdflib import Graph, URIRef, RDF, SKOS
+from rdflib.compare import isomorphic
 
 PREZ_DIR = os.getenv("PREZ_DIR")
 LOCAL_SPARQL_STORE = os.getenv("LOCAL_SPARQL_STORE")
@@ -100,3 +101,15 @@ def test_collection_listing(vp_test_client):
         assert response_graph.isomorphic(expected_graph), print(
             f"Graph delta:{(expected_graph - response_graph).serialize()}"
         )
+
+
+def test_collection_listing_item(vp_test_client):
+    with vp_test_client as client:
+        r = client.get("/v/collection/cgi:contacttype")
+        assert r.status_code == 200
+        response_graph = Graph().parse(data=r.text, format="turtle")
+        expected_graph = Graph().parse(
+            Path(__file__).parent
+            / "../data/vocprez/expected_responses/collection_listing_item.ttl"
+        )
+        assert isomorphic(response_graph, expected_graph)


### PR DESCRIPTION
The endpoint at `/v/collection/<path-id>` throws a KeyError when accessing the dict that contains the inbound and outbound child links. This change fixes it by updating it to the new key values.