### PR TITLE
Update VocPub profile to display item status, publisher and derivation mode. Fix listing pagination, add listing to include predicate statements and add support for multiple sh:sequencePaths

### DIFF
--- a/prez/reference_data/profiles/vocprez_default_profiles.ttl
+++ b/prez/reference_data/profiles/vocprez_default_profiles.ttl
@@ -11,6 +11,7 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
 
 
 prez:VocPrezProfile
@@ -103,7 +104,21 @@ prez:VocPrezProfile
         a sh:NodeShape ;
         sh:targetClass skos:Concept ;
         altr-ext:outboundParents skos:inScheme ;
-    ]
+    ] ;
+    altr-ext:hasNodeShape [
+        a sh:NodeShape ;
+        sh:targetClass prez:SchemesList ;
+        sh:path dcterms:publisher, reg:status ;
+        sh:sequencePath (
+            prov:qualifiedDerivation
+            prov:hadRole
+        ) ;
+    ] ;
+    altr-ext:hasNodeShape [
+        a sh:NodeShape ;
+        sh:targetClass prez:VocPrezCollectionList ;
+        sh:path skos:definition ;
+    ] ;
 .
 
 <https://schema.org>

--- a/prez/reference_data/profiles/vocprez_default_profiles.ttl
+++ b/prez/reference_data/profiles/vocprez_default_profiles.ttl
@@ -113,6 +113,10 @@ prez:VocPrezProfile
             prov:qualifiedDerivation
             prov:hadRole
         ) ;
+        sh:sequencePath (
+            prov:qualifiedDerivation
+            prov:entity
+        ) ;
     ] ;
     altr-ext:hasNodeShape [
         a sh:NodeShape ;

--- a/prez/routers/catprez.py
+++ b/prez/routers/catprez.py
@@ -9,7 +9,7 @@ from prez.models.catprez_listings import CatalogMembers
 from prez.models.profiles_and_mediatypes import ProfilesMediatypesInfo
 from prez.renderers.renderer import return_from_queries, return_profiles
 from prez.sparql.objects_listings import (
-    generate_listing_construct_from_uri,
+    generate_listing_construct,
     generate_listing_count_construct,
     generate_item_construct,
 )
@@ -42,7 +42,7 @@ async def catalogs_endpoint(
             prez_type="SpacePrez",
             prof_and_mt_info=prof_and_mt_info,
         )
-    list_query, predicates_for_link_addition = generate_listing_construct_from_uri(
+    list_query, predicates_for_link_addition = generate_listing_construct(
         catprez_members, prof_and_mt_info.profile, page, per_page
     )
     count_query = generate_listing_count_construct(catprez_members)
@@ -90,7 +90,7 @@ async def item_endpoint(request: Request, cp_item: Optional[CatalogItem] = None)
     (
         item_members_query,
         predicates_for_link_addition,
-    ) = generate_listing_construct_from_uri(cp_item, prof_and_mt_info.profile, 1, 20)
+    ) = generate_listing_construct(cp_item, prof_and_mt_info.profile, 1, 20)
     return await return_from_queries(
         [item_query, item_members_query],
         prof_and_mt_info.mediatype,

--- a/prez/routers/profiles.py
+++ b/prez/routers/profiles.py
@@ -7,7 +7,7 @@ from prez.models.profiles_listings import ProfilesMembers
 from prez.cache import profiles_graph_cache
 from prez.renderers.renderer import return_profiles, return_from_graph
 from prez.sparql.objects_listings import (
-    generate_listing_construct_from_uri,
+    generate_listing_construct,
     generate_listing_count_construct,
     generate_item_construct,
 )
@@ -37,7 +37,7 @@ async def profiles(
             prez_type="GenericPrez",
             prof_and_mt_info=prof_and_mt_info,
         )
-    list_query, predicates_for_link_addition = generate_listing_construct_from_uri(
+    list_query, predicates_for_link_addition = generate_listing_construct(
         profiles_members, prof_and_mt_info.profile, page, per_page
     )
     count_query = generate_listing_count_construct(profiles_members)

--- a/prez/routers/spaceprez.py
+++ b/prez/routers/spaceprez.py
@@ -10,7 +10,7 @@ from prez.models.spaceprez_listings import SpatialMembers
 from prez.renderers.renderer import return_from_queries, return_profiles
 from prez.sparql.objects_listings import (
     generate_item_construct,
-    generate_listing_construct_from_uri,
+    generate_listing_construct,
     generate_listing_count_construct,
 )
 
@@ -40,7 +40,7 @@ async def list_items(
             prez_type="SpacePrez",
             prof_and_mt_info=prof_and_mt_info,
         )
-    list_query, predicates_for_link_addition = generate_listing_construct_from_uri(
+    list_query, predicates_for_link_addition = generate_listing_construct(
         spatial_item, prof_and_mt_info.profile, page, per_page
     )
     count_query = generate_listing_count_construct(spatial_item)
@@ -127,9 +127,7 @@ async def item_endpoint(request: Request, spatial_item: Optional[SpatialItem] = 
     (
         item_members_query,
         predicates_for_link_addition,
-    ) = generate_listing_construct_from_uri(
-        spatial_item, prof_and_mt_info.profile, 1, 20
-    )
+    ) = generate_listing_construct(spatial_item, prof_and_mt_info.profile, 1, 20)
     return await return_from_queries(
         [item_query, item_members_query],
         prof_and_mt_info.mediatype,

--- a/prez/routers/vocprez.py
+++ b/prez/routers/vocprez.py
@@ -10,7 +10,7 @@ from prez.models.vocprez_item import VocabItem
 from prez.models.vocprez_listings import VocabMembers
 from prez.renderers.renderer import return_from_queries, return_profiles
 from prez.sparql.objects_listings import (
-    generate_listing_construct_from_uri,
+    generate_listing_construct,
     generate_listing_count_construct,
     generate_item_construct,
 )
@@ -47,7 +47,7 @@ async def schemes_endpoint(
             prez_type="VocPrez",
             prof_and_mt_info=prof_and_mt_info,
         )
-    list_query, predicates_for_link_addition = generate_listing_construct_from_uri(
+    list_query, predicates_for_link_addition = generate_listing_construct(
         vocprez_members, prof_and_mt_info.profile, page, per_page
     )
     count_query = generate_listing_count_construct(vocprez_members)
@@ -111,7 +111,7 @@ async def item_endpoint(request: Request, vp_item: Optional[VocabItem] = None):
     (
         item_members_query,
         predicates_for_link_addition,
-    ) = generate_listing_construct_from_uri(vp_item, prof_and_mt_info.profile, 1, 5000)
+    ) = generate_listing_construct(vp_item, prof_and_mt_info.profile, 1, 5000)
     return await return_from_queries(
         [item_query, item_members_query],
         prof_and_mt_info.mediatype,

--- a/tests/data/vocprez/expected_responses/collection_listing_anot.ttl
+++ b/tests/data/vocprez/expected_responses/collection_listing_anot.ttl
@@ -4,6 +4,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://resource.geosciml.org/classifier/cgi/contacttype> a skos:Collection ;
+    skos:definition "All Concepts in this vocabulary" ;
     dcterms:provenance "this vocabulary" ;
     skos:prefLabel "Contact Type - All Concepts"@en ;
     ns1:link "/v/collection/cgi:contacttype" .

--- a/tests/data/vocprez/expected_responses/vocab_listing_anot.ttl
+++ b/tests/data/vocprez/expected_responses/vocab_listing_anot.ttl
@@ -1,10 +1,14 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix ns1: <https://prez.dev/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+dcterms:publisher rdfs:label "Publisher"@en .
+
 <http://resource.geosciml.org/classifierscheme/cgi/2016.01/contacttype> a skos:ConceptScheme ;
     dcterms:provenance "Original set of terms from the GeosciML standard" ;
+    dcterms:publisher <https://linked.data.gov.au/org/cgi> ;
     skos:prefLabel "Contact Type"@en ;
     ns1:link "/v/vocab/2016.01:contacttype" .
 

--- a/tests/sparql/test_sparql_new.py
+++ b/tests/sparql/test_sparql_new.py
@@ -13,7 +13,7 @@ from prez.sparql.objects_listings import (
     generate_include_predicates,
     get_annotations_from_tbox_cache,
     get_item_predicates,
-    generate_listing_construct_from_uri,
+    generate_listing_construct,
 )
 
 PREZ_DIR = os.getenv("PREZ_DIR")
@@ -143,7 +143,7 @@ def test_get_labels_from_tbox_cache():
 
 def test_generate_listing_construct_datasets():
     item = SpatialItem(uri=URIRef("http://example.com"))
-    returned = generate_listing_construct_from_uri(item, profile, page=1, per_page=20)
+    returned = generate_listing_construct(item, profile, page=1, per_page=20)
     expected = """PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>


### PR DESCRIPTION
Prez's VocPub profile now retrieves:
- `dcterms:publisher`
- `reg:status`
- via `prov:qualifiedDerivation`, `prov:hadRole`
- via `prov:qualifiedDerivation`, `prov:entity`

Example result for Borehole Status vocabulary in Prez listing API response:

```turtle
cs: a skos:ConceptScheme ;
    dcterms:provenance "Compiled by the Geological Survey of Queensland for the Government Geoscience Information Committee (GGIC) in a Borehole information harmonisation initiative in 2023" ;
    dcterms:publisher <https://linked.data.gov.au/org/gsq> ;
    reg:status agldwgstatus:experimental ;
    skos:prefLabel "Borehole Status"@en ;
    prov:qualifiedDerivation [ prov:entity <https://linked.data.gov.au/def/site-status> ;
            prov:hadRole <https://linked.data.gov.au/def/vocab-derivation-modes/subsetting-and-extension> ] ;
    prez:link "/v/vocab/def:borehole-status" .
```

Fixes and enhancements to the listing construct query:
- Support multiple `sh:sequencePath` for each `sh:NodeShape`
- Support "include predicates" using `sh:path` within an `sh:NodeShape`
- Fix pagination in listing construct query by moving the limit and offset into a subquery