### PR TITLE
Remove deprecated GH Actions set-output usage. Update container image release tags

### DIFF
--- a/.github/workflows/on_push_to_main.yaml
+++ b/.github/workflows/on_push_to_main.yaml
@@ -81,7 +81,9 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ steps.patch.outputs.patch }}-${{ steps.hash.outputs.value }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.patch.outputs.patch }}-${{ steps.hash.outputs.value }}
+            ${{ env.IMAGE_NAME }}:dev
           # Set provenance to false due to issue documented here: https://github.com/docker/build-push-action/issues/778
           provenance: false
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/on_push_to_main.yaml
+++ b/.github/workflows/on_push_to_main.yaml
@@ -16,6 +16,54 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Get latest tag
+        id: latest-tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: "0.1.0"
+
+      - name: Tag starts with v
+        id: tag-starts-with-v
+        if: ${{ startsWith(steps.latest-tag.outputs.tag, 'v') }}
+        uses: mad9000/actions-find-and-replace-string@4
+        with:
+          source: ${{ steps.latest-tag.outputs.tag }}
+          find: "v"
+          replace: ""
+
+      - name: Tag value
+        id: tag-value
+        uses: haya14busa/action-cond@v1
+        with:
+          cond: ${{ startsWith(steps.latest-tag.outputs.tag, 'v') }}
+          if_true: ${{ steps.tag-starts-with-v.outputs.value }}
+          if_false: ${{ steps.latest-tag.outputs.tag }}
+
+      - name: Get next semver patch version
+        id: patch
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.tag-value.outputs.value }}
+
+      - name: Get git commits since last tag
+        id: commitscount
+        run: echo "value=$(git rev-list `git rev-list --tags --no-walk --max-count=1`..HEAD --count)" >> $GITHUB_OUTPUT
+
+      - name: Get git commit hash
+        id: commit-hash
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: type=sha
+
+      - name: Rename git commit hash
+        id: hash
+        uses: mad9000/actions-find-and-replace-string@4
+        with:
+          source: ${{ steps.commit-hash.outputs.version }}
+          find: "sha-"
+          replace: dev.${{ steps.commitscount.outputs.value }}.
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -33,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.patch.outputs.patch }}-${{ steps.hash.outputs.value }}
           # Set provenance to false due to issue documented here: https://github.com/docker/build-push-action/issues/778
           provenance: false
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -16,12 +16,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Get release version tag
-        run: |
-          echo ::set-output name=version::$(echo "${{ github.ref_name }}" | sed "s/^v//g" )
-          echo ::set-output name=version_minor::$(echo "${{ github.ref_name }}" | sed -e "s/^v//g" -e "s/\.[0-9]\+$//g" )
-          echo ::set-output name=version_major::$(echo "${{ github.ref_name }}" | sed -e "s/^v//g" -e "s/\.[0-9]\+$//g" -e "s/\.[0-9]\+$//g" )
-        id: get_version
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -40,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ steps.get_version.outputs.version }},${{ env.IMAGE_NAME }}:${{ steps.get_version.outputs.version_minor }},${{ env.IMAGE_NAME }}:${{ steps.get_version.outputs.version_major }},${{ env.IMAGE_NAME }}:stable
+          tags: ${{ steps.metadata.outputs.tags }}
           # Set provenance to false due to issue documented here: https://github.com/docker/build-push-action/issues/778
           provenance: false
           platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![](https://github.com/RDFLib/prez/raw/main/prez-logo.png)
 
 # Prez
+
 Prez is a data-configurable Linked Data API framework that delivers _profiles_ of Knowledge Graph data according to the [Content Negotiation by Profile](https://w3c.github.io/dx-connegp/connegp/) standard.
 
 > **Where's the UI?**
@@ -11,22 +12,21 @@ Prez is a data-configurable Linked Data API framework that delivers _profiles_ o
 
 ## Contents
 
-* [Subsystems](#subsystems)
-* [Installation](#installation)
-* [Running](#running)
-* [Data Validation](#data-validation)
-* [Contact](#contact)
-* [Contributing](#contributing)
-* [License](#license)
-
+- [Subsystems](#subsystems)
+- [Installation](#installation)
+- [Running](#running)
+- [Data Validation](#data-validation)
+- [Contact](#contact)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Subsystems
 
 Prez comes with several pre-configures subsystems:
 
-* _VocPrez_ - for vocabularies, based on the [SKOS](https://www.w3.org/TR/skos-reference/) data model
-* _SpacePrez_ - for spatial data, based on [OGC API](https://docs.ogc.org/is/17-069r3/17-069r3.html) specification and the [GeoSPARQL](https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html) data model
-* _CatPrez_ - for [DCAT](https://www.w3.org/TR/vocab-dcat/) data catalogs
+- _VocPrez_ - for vocabularies, based on the [SKOS](https://www.w3.org/TR/skos-reference/) data model
+- _SpacePrez_ - for spatial data, based on [OGC API](https://docs.ogc.org/is/17-069r3/17-069r3.html) specification and the [GeoSPARQL](https://opengeospatial.github.io/ogc-geosparql/geosparql11/spec.html) data model
+- _CatPrez_ - for [DCAT](https://www.w3.org/TR/vocab-dcat/) data catalogs
 
 Prez uses the modern [FastAPI](https://fastapi.tiangolo.com/) Python web framework, so it's fast! It also has few requirements beyond FastAPI so should be pretty easy to install and run in most cases.
 
@@ -35,7 +35,6 @@ It expects "high quality" data to work well: Prez itself won't patch up bad or m
 > **NOTE**: There are a number of data quality assessment tools and processes you can run to ensure that the data you want Prez to access is fit for purpose. See [Data Validation](#data-validation) below.
 
 Prez accesses data stored in an RDF database - a 'triplestore' - and uses the SPARQL Protocol to do so. Any SPARQL Protocol-compliant DB may be used.
-
 
 ## Installation
 
@@ -53,12 +52,11 @@ We also provide a standard `requirements.txt` file for use with the common [PIP]
 
 > Executing `pip install -r requirements.txt` within a Python virtual environment will probably be all you need to do!
 
-
 ## Running
 
 Prez runs as a standard FastAPI application so for all the normal HOW TO running questions, see FastAPI's documentation:
 
-* <https://fastapi.tiangolo.com>
+- <https://fastapi.tiangolo.com>
 
 ### Environment Variables
 
@@ -89,27 +87,39 @@ port: int = 8000
 
 So the `port` variable must be an `int` and its default value is 8000.
 
-### Using Docker
+### Running in a Container
 
-To run Prez within a Docker container, first build the Docker image using the Dockerfile in this repo, or pull from Dockerhub:
+Prez container images are available [here](https://github.com/RDFLib/prez/pkgs/container/prez).
 
-build: `docker build -t prez .`
+#### Image variants
 
-or
+The image name is `ghcr.io/rdflib/prez`.
 
-pull: `docker pull surroundaustralia/prez`
+The `latest` tag points to the latest stable release of Prez. All latest stable releases have a major, major and minor, and major, minor and patch tag pointing to it.
 
-Then run the image:
+For example, for a release with a git tag of 3.2.4, the following tags will be on the container image:
+
+- `3`
+- `3.2`
+- `3.2.4`
+- `latest`
+
+New commits to the `main` branch creates a rolling dev image with the `dev` tag. The dev builds will also include a tag in the form of major.minor.{patch+1}-dev.{commits-since-last-release}.{short-commit-sha}. This conforms to semantic versioning and will be recognised by orchestration systems to perform automatic releases.
+
+For example, if the latest release is 3.2.4 and there has been 7 new commits since the release and the short commit SHA is fc82562, then the container image tag will be:
+
+- `3.2.5-dev.7.fc82562`
+
+To run an image with Docker:
+
 ```
 docker run -p 8000:8000 \
-    -e ENABLED_PREZS=["SpacePrez", "VocPrez"] \
     -e SPACEPREZ_SPARQL_ENDPOINT=http://localhost:3030/spatial \
     -e VOCPREZ_SPARQL_ENDPOINT=http://localhost:3030/other \
-    rdflib/prez
+    rdflib/prez:3
 ```
 
 The above command will run a Docker container with Prez in it on Port 8000 with SpacePrez & VocPrez subsystems enabled and different SPARQL endpoints given for each.
-
 
 ## Data Validation
 
@@ -119,10 +129,10 @@ For Prez to deliver data via its various subsystems, the data needs to conform t
 
 Formal RDF data profiles - standards that constrain other standards - are specified for Space, Voc & CatPrez. See:
 
-* [SpacePrez Profile Specification](https://w3id.org/profile/spaceprez/spec)
-* [VocPrez Profile Specification](https://w3id.org/profile/vocprez/spec)
-* [CatPrez Profile Specification](https://w3id.org/profile/catprez/spec)
-  * _yes yes, we know this one is offline for the moment. To be fixed shortly!_
+- [SpacePrez Profile Specification](https://w3id.org/profile/spaceprez/spec)
+- [VocPrez Profile Specification](https://w3id.org/profile/vocprez/spec)
+- [CatPrez Profile Specification](https://w3id.org/profile/catprez/spec)
+  - _yes yes, we know this one is offline for the moment. To be fixed shortly!_
 
 The specifications of the various profiles _should_ be straightforward to read. Just be aware that they profile - inherit from and further constrain - other profiles so that there are quite a few 'background' data rules that must be met.
 
@@ -132,10 +142,9 @@ All of the profiles listed above provide validators that can be used with RDF da
 
 The profiles' validators are all available from the profiles themselves (navigate to the listings of other profile resources via the specification links above) and they are also loaded into the _RDFTools_ online tool which you can use without downloading or installing anything:
 
-* <http://rdftools.kurrawong.net/validate>
+- <http://rdftools.kurrawong.net/validate>
 
 Look for the _VocPrez Compounded_ and similar validators. The 'compounded' bit means that validator will validate data against all VocPrez and inherited requirements.
-
 
 ## Contact
 


### PR DESCRIPTION
This fixes https://github.com/RDFLib/prez/issues/100 by removing the use of the deprecated `::set-output` GH Actions syntax.

This PR also updates how container image tags are generated.

### Container image releases

This change will continue to add the latest `major`, `major.minor` and `major.minor.patch` tags to the container image on releases.

It will no longer add the `stable` tag and instead, it will add the `latest` tag. The `latest` tag points to the latest stable release, and not the latest rolling dev builds.

For example, for a release with a git tag of `3.2.4`, the following tags will be on the container image:

- `3`
- `3.2`
- `3.2.4`
- `latest`

### Container image dev builds on push to `main` branch

Dev builds will no longer add the `latest` tag and will only contain tags constructed from the commits made on `main` branch. The dev builds will be in the form of `major.minor.{patch+1}-dev.{commits-since-last-release}.{short-commit-sha}`. This conforms to semantic versioning and will be recognised by orchestration systems to perform automatic releases.

For example, if the latest release is `3.2.4` and there has been 7 new commits since the release and the short commit SHA is `fc82562`, then the container image tag will be:

- `3.2.5-dev.7.fc82562`