### PR TITLE
minimal implmementation of update endpoint

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -25,6 +25,7 @@ from prez.routers.profiles import router as profiles_router
 from prez.routers.search import router as search_router
 from prez.routers.spaceprez import router as spaceprez_router
 from prez.routers.sparql import router as sparql_router
+from prez.routers.update import update_router
 from prez.routers.vocprez import router as vocprez_router
 from prez.services.app_service import healthcheck_sparql_endpoints, count_objects
 from prez.services.app_service import (
@@ -60,6 +61,7 @@ app.include_router(management_router)
 app.include_router(object_router)
 app.include_router(sparql_router)
 app.include_router(search_router)
+app.include_router(update_router)
 app.include_router(profiles_router)
 if settings.catprez_sparql_endpoint:
     app.include_router(catprez_router)

--- a/prez/routers/update.py
+++ b/prez/routers/update.py
@@ -1,0 +1,28 @@
+import logging
+
+from fastapi import APIRouter
+from fastapi import Request
+
+from prez.sparql.methods import sparql_update
+
+logger = logging.getLogger(__name__)
+update_router = APIRouter(tags=["Update"])
+
+
+async def forward_request_to_backend(request: Request, prez):
+    return await sparql_update(request, prez)
+
+
+@update_router.post("/c/update")
+async def your_endpoint(request: Request):
+    return await forward_request_to_backend(request, "CatPrez")
+
+
+@update_router.post("/v/update")
+async def your_endpoint(request: Request):
+    return await forward_request_to_backend(request, "VocPrez")
+
+
+@update_router.post("/s/update")
+async def your_endpoint(request: Request):
+    return await forward_request_to_backend(request, "SpacePrez")

--- a/prez/routers/update.py
+++ b/prez/routers/update.py
@@ -1,28 +1,21 @@
-import logging
-
 from fastapi import APIRouter
 from fastapi import Request
 
 from prez.sparql.methods import sparql_update
 
-logger = logging.getLogger(__name__)
 update_router = APIRouter(tags=["Update"])
 
 
-async def forward_request_to_backend(request: Request, prez):
-    return await sparql_update(request, prez)
-
-
 @update_router.post("/c/update")
-async def your_endpoint(request: Request):
-    return await forward_request_to_backend(request, "CatPrez")
+async def cp_update(request: Request):
+    return await sparql_update(request, "CatPrez")
 
 
 @update_router.post("/v/update")
-async def your_endpoint(request: Request):
-    return await forward_request_to_backend(request, "VocPrez")
+async def vp_update(request: Request):
+    return await sparql_update(request, "VocPrez")
 
 
 @update_router.post("/s/update")
-async def your_endpoint(request: Request):
-    return await forward_request_to_backend(request, "SpacePrez")
+async def sp_update(request: Request):
+    return await sparql_update(request, "SpacePrez")

--- a/prez/sparql/methods.py
+++ b/prez/sparql/methods.py
@@ -184,21 +184,18 @@ async def sparql_construct(query: str, prez: str):
 
 
 @alru_cache(maxsize=128)
-async def sparql_update(query: str, prez: str):
-    """Returns an rdflib Graph from a CONSTRUCT query for a single SPARQL endpoint"""
-    if not query:
-        return False, None
+async def sparql_update(request, prez):
+    headers = {
+        "Authorization": request.headers.get("Authorization"),
+        "Content-Type": request.headers.get("Content-Type"),
+    }
+    data = await request.body()
+
     try:
         response: httpxResponse = await sparql_clients[prez].post(
             settings.sparql_creds[prez]["update"],
-            data=query,
-            auth=(
-                settings.sparql_creds[prez].get("username", ""),
-                settings.sparql_creds[prez].get("password", ""),
-            ),
-            headers={
-                "Content-Type": "application/sparql-update",
-            },
+            data=data,
+            headers=headers,
             timeout=TIMEOUT,
         )
         response.raise_for_status()

--- a/prez/sparql/methods.py
+++ b/prez/sparql/methods.py
@@ -183,7 +183,6 @@ async def sparql_construct(query: str, prez: str):
         }
 
 
-@alru_cache(maxsize=128)
 async def sparql_update(request, prez):
     headers = {
         "Authorization": request.headers.get("Authorization"),


### PR DESCRIPTION
This is a minimal implementation of prez exposing a SPARQL update endpoint.

It takes basic auth credentials supplied to one of the /c/update, /v/update, /s/update endpoints, along with a SPARQL update and passes these through to the corresponding backend SPARQL endpoints.

These changes have been minimally tested locally and against the current IDN Fuseki instance.