### PR TITLE
Separate multiple sequence predicates into its own SPARQL OPTIONAL clause for the listing construct query

### DIFF
--- a/prez/sparql/objects_listings.py
+++ b/prez/sparql/objects_listings.py
@@ -145,7 +145,6 @@ def generate_listing_construct(
         # if this is a top level class, include it's general class here so we can create
         # links to instances of the top level class,
     }
-    print(query)
     return query, predicates_for_link_addition
 
 

--- a/prez/sparql/objects_listings.py
+++ b/prez/sparql/objects_listings.py
@@ -79,11 +79,17 @@ def generate_listing_construct(
     # based on them being an instance of a class), else use the URI of the "parent" off of which members will be listed.
     # TODO collapse this to an inline expression below; include change in both object and listing queries
     sequence_construct = ""
+    sequence_construct_where = ""
     if sequence_predicates:
         for i, sequence_predicate in enumerate(sequence_predicates):
-            sequence_construct += generate_sequence_construct(
+            seq_partial_str = "OPTIONAL {\n"
+            generate_sequence_construct_result: str = generate_sequence_construct(
                 uri_or_tl_item, [sequence_predicate], i
             )
+            seq_partial_str += generate_sequence_construct_result
+            seq_partial_str += "\n}\n"
+            sequence_construct_where += seq_partial_str
+            sequence_construct += generate_sequence_construct_result
     query = dedent(
         f"""
         PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -108,9 +114,7 @@ def generate_listing_construct(
             {f'{uri_or_tl_item} a <{focus_item.general_class}> .{chr(10)}' if focus_item.top_level_listing else ""}\
             {f'OPTIONAL {{ {uri_or_tl_item} ?p ?o .' if include_predicates else ""}\
             {f'{generate_include_predicates(include_predicates)} }}' if include_predicates else ""} \
-            OPTIONAL {{
-                {sequence_construct}\
-            }}
+            {sequence_construct_where}\
             {generate_outbound_predicates(uri_or_tl_item, outbound_children, outbound_parents)} \
             {generate_inbound_predicates(uri_or_tl_item, inbound_children, inbound_parents)} {chr(10)} \
             {generate_relative_properties("select", relative_properties, inbound_children, inbound_parents,
@@ -141,6 +145,7 @@ def generate_listing_construct(
         # if this is a top level class, include it's general class here so we can create
         # links to instances of the top level class,
     }
+    print(query)
     return query, predicates_for_link_addition
 
 

--- a/prez/sparql/objects_listings.py
+++ b/prez/sparql/objects_listings.py
@@ -78,18 +78,7 @@ def generate_listing_construct(
     # item to a variable if it's a top level listing (this will utilise "class based" listing, where objects are listed
     # based on them being an instance of a class), else use the URI of the "parent" off of which members will be listed.
     # TODO collapse this to an inline expression below; include change in both object and listing queries
-    sequence_construct = ""
-    sequence_construct_where = ""
-    if sequence_predicates:
-        for i, sequence_predicate in enumerate(sequence_predicates):
-            seq_partial_str = "OPTIONAL {\n"
-            generate_sequence_construct_result: str = generate_sequence_construct(
-                uri_or_tl_item, [sequence_predicate], i
-            )
-            seq_partial_str += generate_sequence_construct_result
-            seq_partial_str += "\n}\n"
-            sequence_construct_where += seq_partial_str
-            sequence_construct += generate_sequence_construct_result
+    sequence_construct, sequence_construct_where = generate_sequence_construct(sequence_predicates, uri_or_tl_item)
     query = dedent(
         f"""
         PREFIX dcterms: <http://purl.org/dc/terms/>
@@ -276,7 +265,7 @@ def generate_inverse_predicates(inverse_predicates):
     return ""
 
 
-def generate_sequence_construct(object_uri, sequence_predicates, path_n=0):
+def _generate_sequence_construct(object_uri, sequence_predicates, path_n=0):
     """
     Generates part of a SPARQL CONSTRUCT query for property paths, given a list of lists of property paths.
     """
@@ -291,6 +280,23 @@ def generate_sequence_construct(object_uri, sequence_predicates, path_n=0):
             all_sequence_construct += construct_and_where
         return all_sequence_construct
     return ""
+
+
+def generate_sequence_construct(sequence_predicates: list[list[URIRef]], uri_or_tl_item: str) -> tuple[str, str]:
+    sequence_construct = ""
+    sequence_construct_where = ""
+    if sequence_predicates:
+        for i, sequence_predicate in enumerate(sequence_predicates):
+            seq_partial_str = "OPTIONAL {\n"
+            generate_sequence_construct_result: str = _generate_sequence_construct(
+                uri_or_tl_item, [sequence_predicate], i
+            )
+            seq_partial_str += generate_sequence_construct_result
+            seq_partial_str += "\n}\n"
+            sequence_construct_where += seq_partial_str
+            sequence_construct += generate_sequence_construct_result
+
+    return sequence_construct, sequence_construct_where
 
 
 def generate_bnode_construct(depth):

--- a/tests/sparql/test_object_listings.py
+++ b/tests/sparql/test_object_listings.py
@@ -1,0 +1,26 @@
+from rdflib.namespace import PROV
+
+from prez.sparql.objects_listings import generate_sequence_construct
+
+
+def test_generate_sequence_construct() -> None:
+    sequence_construct, sequence_construct_where = generate_sequence_construct([[PROV.qualifiedDerivation, PROV.hadRole], [PROV.qualifiedDerivation, PROV.entity]], "?top_level_item")
+
+    expected_sequence_construct = """\t?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_0 .
+\t?seq_o1_0 <http://www.w3.org/ns/prov#hadRole> ?seq_o2_0 .\t?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_1 .
+\t?seq_o1_1 <http://www.w3.org/ns/prov#entity> ?seq_o2_1 ."""
+
+    assert sequence_construct == expected_sequence_construct
+
+    expected_sequence_construct_where = """\
+OPTIONAL {
+\t?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_0 .
+\t?seq_o1_0 <http://www.w3.org/ns/prov#hadRole> ?seq_o2_0 .
+}
+OPTIONAL {
+\t?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_1 .
+\t?seq_o1_1 <http://www.w3.org/ns/prov#entity> ?seq_o2_1 .
+}
+"""
+
+    assert sequence_construct_where == expected_sequence_construct_where


### PR DESCRIPTION
This fixes https://github.com/RDFLib/prez/issues/106.

Previous query with all the sequence predicates in a single OPTIONAL clause.

```sparql
PREFIX dcterms: <http://purl.org/dc/terms/>
PREFIX prez: <https://prez.dev/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

CONSTRUCT {
  ?top_level_item a <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
  ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_0 .
  ?seq_o1_0 <http://www.w3.org/ns/prov#hadRole> ?seq_o2_0 .       
  ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_1 .
  ?seq_o1_1 <http://www.w3.org/ns/prov#entity> ?seq_o2_1 .
  ?top_level_item ?p ?o .        
}
WHERE {
  ?top_level_item a <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
  OPTIONAL { 
    ?top_level_item ?p ?o .            
    VALUES ?p{
      <http://purl.org/dc/terms/publisher>
      <http://purl.org/linked-data/registry#status>
    } 
  }             
  OPTIONAL {
    ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_0 .
    ?seq_o1_0 <http://www.w3.org/ns/prov#hadRole> ?seq_o2_0 .       
    ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_1 .
    ?seq_o1_1 <http://www.w3.org/ns/prov#entity> ?seq_o2_1 .            
  }

  {
    SELECT ?top_level_item
    WHERE {
      ?top_level_item a <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
    }
    LIMIT 20
    OFFSET 0
  }
}
```

New query with each predicate `prov:hadRole` and `prov:entity` in its own OPTIONAL clause.

```sparql
PREFIX dcterms: <http://purl.org/dc/terms/>
PREFIX prez: <https://prez.dev/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

CONSTRUCT {
  ?top_level_item a <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
  ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_0 .
  ?seq_o1_0 <http://www.w3.org/ns/prov#hadRole> ?seq_o2_0 .       
  ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_1 .
  ?seq_o1_1 <http://www.w3.org/ns/prov#entity> ?seq_o2_1 .
  ?top_level_item ?p ?o .        
}
WHERE {
  ?top_level_item a <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
  OPTIONAL { 
    ?top_level_item ?p ?o .            
    VALUES ?p{
      <http://purl.org/dc/terms/publisher>
      <http://purl.org/linked-data/registry#status>
    } }             
  OPTIONAL {
    ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_0 .
    ?seq_o1_0 <http://www.w3.org/ns/prov#hadRole> ?seq_o2_0 .
  }
  OPTIONAL {
    ?top_level_item <http://www.w3.org/ns/prov#qualifiedDerivation> ?seq_o1_1 .
    ?seq_o1_1 <http://www.w3.org/ns/prov#entity> ?seq_o2_1 .
  }

  {
    SELECT ?top_level_item
    WHERE {
      ?top_level_item a <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
    }
    LIMIT 20
    OFFSET 80
  }
}
```