### PR TITLE
Bump docker/metadata-action to v4 for on_release.yaml workflow

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |


### PR DESCRIPTION
Removes usage of deprecated set-output.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more info.