### PR TITLE
Add versioning on push to main and release

### DIFF
--- a/.github/workflows/on_push_to_main.yaml
+++ b/.github/workflows/on_push_to_main.yaml
@@ -84,6 +84,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          build-args: PREZ_VERSION=${{ env.IMAGE_NAME }}:${{ steps.patch.outputs.patch }}-${{ steps.hash.outputs.value }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.patch.outputs.patch }}-${{ steps.hash.outputs.value }}
             ${{ env.IMAGE_NAME }}:dev

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -43,6 +43,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          build-args: PREZ_VERSION=${{ steps.metadata.outputs.tags }}
           tags: ${{ steps.metadata.outputs.tags }}
           # Set provenance to false due to issue documented here: https://github.com/docker/build-push-action/issues/778
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG PREZ_VERSION
+
 # Creating a python base with shared environment variables
 FROM python:3.11-slim-buster as builder-base
 ENV PYTHONUNBUFFERED=1 \
@@ -33,6 +35,10 @@ COPY poetry.lock pyproject.toml connegp-0.1.5-py3-none-any.whl ./
 RUN poetry install --only main --no-root --no-ansi
 
 FROM python:3.11-slim-buster
+
+ARG PREZ_VERSION
+ENV PREZ_VERSION=${PREZ_VERSION}
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:$PATH"

--- a/prez/config.py
+++ b/prez/config.py
@@ -1,3 +1,4 @@
+from os import environ
 from pathlib import Path
 from typing import Optional
 
@@ -84,9 +85,14 @@ class Settings(BaseSettings):
 
     @root_validator()
     def get_version(cls, values):
-        values["prez_version"] = toml.load(
-            Path(Path(__file__).parent.parent) / "pyproject.toml"
-        )["tool"]["poetry"]["version"]
+        version = environ.get("PREZ_VERSION")
+        values["prez_version"] = version
+
+        if version is None or version == "":
+            values["prez_version"] = toml.load(
+                Path(Path(__file__).parent.parent) / "pyproject.toml"
+            )["tool"]["poetry"]["version"]
+
         return values
 
     @root_validator()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prez"
-version = "3.0.8"
+version = "0.1.0.dev0"
 description = "A python application for displaying linked data on the web"
 authors = ["Jamie Feiss <jamie.feiss@gmail.com>", "Nicholas Car <nick@kurrawong.net>", "David Habgood <dcchabgood@gmail.com>"]
 


### PR DESCRIPTION
This PR adds the following to Prez:

- rolling dev version for changes to main
- release version

Our current official way of distributing Prez is via container images published here in this repo's GitHub Packages. Anyone who runs a container from there will be able to get the version by going to the route `/` and getting a response like the one below.

```
curl -X 'GET' 'http://localhost:8000'
```

```turtle
@prefix prez: <https://prez.dev/> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<http://localhost:8000> prez:currentTBOXCacheSize 0 ;
    prez:enabledPrezFlavour [ a prez:ProfilesPrez ;
            prez:link "/p" ],
        [ a prez:CatPrez ;
            prez:availableSearchMethod prez:exactMatch,
                prez:jenaFTName ;
            prez:link "/c" ],
        [ a prez:SpacePrez ;
            prez:availableSearchMethod prez:exactMatch,
                prez:jenaFTName ;
            prez:link "/s" ],
        [ a prez:VocPrez ;
            prez:availableSearchMethod prez:exactMatch,
                prez:jenaFTName,
                prez:skosPrefLabel,
                prez:skosWeighted ;
            prez:link "/v" ] ;
    prez:version "3.3.0" .
```

Running a dev image will get a version in the following format `3.2.2-dev.3.cc2b9d2` as described previously in this PR https://github.com/RDFLib/prez/pull/104.

Running a production release will get a version from the release's git tag in the full semver format, e.g. `3.3.0`. See the semver description also in this PR https://github.com/RDFLib/prez/pull/104.

How does Prez read this version? It is set when building the container image in GitHub Actions as a `build-arg`. E.g., `PREZ_VERSION=3.3.0`. Prez's settings object just reads this value from the `PREZ_VERSION` environment variable. When running locally during development, it falls back to reading from the `pyproject.toml` as before, which now has a permanent value of `0.1.0.dev0`.

The idea is, through normal development and maintenance, we don't need to worry about manually bumping the version in Prez. Prez is distributed officially as a container image, therefore, we only need to maintain the version on the container image's tag and the version set within the environment variable. The `pyproject.toml` version can remain fixed since we don't publish it via PyPI anyway.

If we're all happy with this approach, we can do the same thing for Prez UI. The solution is not perfect, but at least if we get this in, we don't have to worry about manually updating the version. We can always modify the process in future updates.