### PR TITLE
Fix release version formatting

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -16,6 +16,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: latest
+
+      - name: Get release version
+        id: version
+        run: echo "VALUE=$(npx --yes semver ${{ github.event.release.tag_name }})" >> "$GITHUB_OUTPUT"
+
       - name: Docker metadata
         id: metadata
         uses: docker/metadata-action@v4
@@ -43,7 +52,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          build-args: PREZ_VERSION=${{ steps.metadata.outputs.tags }}
+          build-args: PREZ_VERSION=${{ steps.version.outputs.VALUE }}
           tags: ${{ steps.metadata.outputs.tags }}
           # Set provenance to false due to issue documented here: https://github.com/docker/build-push-action/issues/778
           provenance: false


### PR DESCRIPTION
I previously did not realise `docker/metadata-action` provides the full container name plus tag.

This fixes that and correctly sets the Docker build argument `PREZ_VERSION` with the semver version.