### PR TITLE
allow port and host to be configurable when running Prez from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,4 @@ COPY pyproject.toml .
 # copy the venv folder from builder image
 COPY --from=builder-base /app/.venv ./.venv
 
-ENTRYPOINT ["uvicorn", "prez.app:app", "--host=0.0.0.0", "--port=8000", "--proxy-headers"]
+ENTRYPOINT uvicorn prez.app:app --host=${HOST:-0.0.0.0} --port=${PORT:-8000} --proxy-headers


### PR DESCRIPTION
Parameterised Uvicorn host and port settings in the Dockerfile ENTRYPOINT, providing default values to enhance configurability in deployment scenarios