### PR TITLE
update pydantic syntax for sparql settings

### DIFF
--- a/prez/config.py
+++ b/prez/config.py
@@ -29,9 +29,9 @@ class Settings(BaseSettings):
     prez_version:
     """
 
-    sparql_endpoint: Optional[str]
-    sparql_username: Optional[str]
-    sparql_password: Optional[str]
+    sparql_endpoint: Optional[str] = None
+    sparql_username: Optional[str] = None
+    sparql_password: Optional[str] = None
     sparql_auth: Optional[tuple]
     protocol: str = "http"
     host: str = "localhost"


### PR DESCRIPTION
add '= None' to conform to new pydantic rules.