### PR TITLE
Link Genreation bugfix

### DIFF
--- a/prez/services/model_methods.py
+++ b/prez/services/model_methods.py
@@ -17,16 +17,14 @@ async def get_classes(
     _, r = await repo.send_queries([], [(uri, q)])
     tabular_result = r[0]  # should only be one result - only one query sent
     if endpoint != URIRef("https://prez.dev/endpoint/object"):
-        endpoint_classes = endpoints_graph_cache.objects(
+        endpoint_classes = list(endpoints_graph_cache.objects(
             subject=endpoint, predicate=URIRef("https://prez.dev/ont/deliversClasses")
-        )
+        ))
         object_classes_delivered_by_endpoint = []
         for c in tabular_result[1]:
             if URIRef(c["class"]["value"]) in endpoint_classes:
-                object_classes_delivered_by_endpoint.append(c["class"]["value"])
+                object_classes_delivered_by_endpoint.append(URIRef(c["class"]["value"]))
         classes = frozenset(object_classes_delivered_by_endpoint)
     else:
         classes = frozenset([c["class"]["value"] for c in tabular_result[1]])
-    # add profiles classes
-    # profiles_classes = profiles_graph_cache.query(q)
     return classes


### PR DESCRIPTION
Bugfix to ensure links are created where an object has >1 class. Wrap call to graph.objects() with list() to create an iterable and prevent generator being consumed on first iteration of for loop.