### PR TITLE
Fix broken profiles

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -14,6 +14,8 @@ from prez.dependencies import (
     get_pyoxi_store,
     load_local_data_to_oxigraph,
     get_oxrdflib_store,
+    get_system_store,
+    load_profile_data_to_oxigraph,
 )
 from prez.models.model_exceptions import (
     ClassNotFoundException,
@@ -144,6 +146,9 @@ async def app_startup():
     await count_objects(app.state.repo)
     await populate_api_info()
     await add_common_context_ontologies_to_tbox_cache()
+
+    app.state.pyoxi_system_store = get_system_store()
+    await load_profile_data_to_oxigraph(app.state.pyoxi_system_store)
 
 
 @app.on_event("shutdown")

--- a/prez/cache.py
+++ b/prez/cache.py
@@ -24,4 +24,6 @@ search_methods = {}
 
 store = Store()
 
+system_store = Store()
+
 oxrdflib_store = Graph(store="Oxigraph")

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -4,7 +4,7 @@ import httpx
 from fastapi import Depends
 from pyoxigraph import Store
 
-from prez.cache import store, oxrdflib_store
+from prez.cache import store, oxrdflib_store, system_store, profiles_graph_cache
 from prez.config import settings
 from prez.sparql.methods import PyoxigraphRepo, RemoteSparqlRepo, OxrdflibRepo
 
@@ -20,6 +20,10 @@ async def get_async_http_client():
 
 def get_pyoxi_store():
     return store
+
+
+def get_system_store():
+    return system_store
 
 
 def get_oxrdflib_store():
@@ -38,9 +42,29 @@ async def get_repo(
         return RemoteSparqlRepo(http_async_client)
 
 
+async def get_system_repo(
+    pyoxi_store: Store = Depends(get_system_store),
+):
+    """
+    A pyoxigraph Store with Prez system data including:
+    - Profiles
+    # TODO add and test other system data (endpoints etc.)
+    """
+    return PyoxigraphRepo(pyoxi_store)
+
+
 async def load_local_data_to_oxigraph(store: Store):
     """
     Loads all the data from the local data directory into the local SPARQL endpoint
     """
     for file in (Path(__file__).parent.parent / "rdf").glob("*.ttl"):
         store.load(file.read_bytes(), "text/turtle")
+
+
+async def load_profile_data_to_oxigraph(store: Store):
+    """
+    Loads all the data from the local data directory into the local SPARQL endpoint
+    """
+    # TODO refactor to use the local files directly
+    graph_bytes = profiles_graph_cache.serialize(format="nt", encoding="utf-8")
+    store.load(graph_bytes, "application/n-triples")

--- a/prez/routers/profiles.py
+++ b/prez/routers/profiles.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Request, Depends
 
-from prez.dependencies import get_repo
+from prez.dependencies import get_repo, get_system_repo
 from prez.services.objects import object_function
 from prez.services.listings import listing_function
 
@@ -31,7 +31,7 @@ async def profiles(
     request: Request,
     page: int = 1,
     per_page: int = 20,
-    repo=Depends(get_repo),
+    repo=Depends(get_system_repo),
 ):
     return await listing_function(
         request=request, page=page, per_page=per_page, repo=repo
@@ -43,5 +43,5 @@ async def profiles(
     summary="Profile",
     name="https://prez.dev/endpoint/profile",
 )
-async def profile(request: Request, profile_curie: str, repo=Depends(get_repo)):
+async def profile(request: Request, profile_curie: str, repo=Depends(get_system_repo)):
     return await object_function(request, object_curie=profile_curie, repo=repo)

--- a/prez/services/model_methods.py
+++ b/prez/services/model_methods.py
@@ -17,9 +17,12 @@ async def get_classes(
     _, r = await repo.send_queries([], [(uri, q)])
     tabular_result = r[0]  # should only be one result - only one query sent
     if endpoint != URIRef("https://prez.dev/endpoint/object"):
-        endpoint_classes = list(endpoints_graph_cache.objects(
-            subject=endpoint, predicate=URIRef("https://prez.dev/ont/deliversClasses")
-        ))
+        endpoint_classes = list(
+            endpoints_graph_cache.objects(
+                subject=endpoint,
+                predicate=URIRef("https://prez.dev/ont/deliversClasses"),
+            )
+        )
         object_classes_delivered_by_endpoint = []
         for c in tabular_result[1]:
             if URIRef(c["class"]["value"]) in endpoint_classes:

--- a/tests/test_endpoints_profiles.py
+++ b/tests/test_endpoints_profiles.py
@@ -48,3 +48,31 @@ def test_profile(client):
     r = client.get("/profiles")
     g = Graph().parse(data=r.text)
     assert (URIRef("https://prez.dev/profile/prez"), RDF.type, PROF.Profile) in g
+
+
+def test_cp_profile(client):
+    # check the example remote profile is loaded
+    r = client.get("/profiles/prez:CatPrezProfile")
+    g = Graph().parse(data=r.text)
+    assert (URIRef("https://prez.dev/CatPrezProfile"), RDF.type, PROF.Profile) in g
+
+
+def test_sp_profile(client):
+    # check the example remote profile is loaded
+    r = client.get("/profiles/prez:SpacePrezProfile")
+    g = Graph().parse(data=r.text)
+    assert (URIRef("https://prez.dev/SpacePrezProfile"), RDF.type, PROF.Profile) in g
+
+
+def test_vp_profile(client):
+    # check the example remote profile is loaded
+    r = client.get("/profiles/prez:VocPrezProfile")
+    g = Graph().parse(data=r.text)
+    assert (URIRef("https://prez.dev/VocPrezProfile"), RDF.type, PROF.Profile) in g
+
+
+def test_pp_profile(client):
+    # check the example remote profile is loaded
+    r = client.get("/profiles/prez:profiles")
+    g = Graph().parse(data=r.text)
+    assert (URIRef("https://prez.dev/profiles"), RDF.type, PROF.Profile) in g


### PR DESCRIPTION
Fixes profiles by creating a system store with Pyoxigraph for system data. At this point only profiles are added to this system graph. When a profiles related endpoint is called, this internal system repo is used. The RDFLib graph cache is still used elsewhere. Ultimately the Pyoxigraph store for system data can replace the various RDFLib caches.

Fixes #184 