### PR TITLE
Remove specification of "sh:path skos:prefLabel" in profile such that…

### DIFF
--- a/prez/reference_data/profiles/vocprez_default_profiles.ttl
+++ b/prez/reference_data/profiles/vocprez_default_profiles.ttl
@@ -87,7 +87,6 @@ prez:VocPrezProfile
         "text/turtle" ;
     altr-ext:hasNodeShape [
         a sh:NodeShape ;
-        sh:path skos:prefLabel ;
         sh:targetClass skos:ConceptScheme ;
         altr-ext:focusToChild skos:hasTopConcept ;
     ] ;
@@ -98,13 +97,11 @@ prez:VocPrezProfile
     ] ;
     altr-ext:hasNodeShape [
         a sh:NodeShape ;
-        sh:path skos:prefLabel ;
         sh:targetClass skos:ConceptScheme ;
         altr-ext:childToFocus skos:inScheme ;
     ] ;
     altr-ext:hasNodeShape [
         a sh:NodeShape ;
-        sh:path skos:prefLabel ;
         sh:targetClass skos:ConceptScheme ;
         altr-ext:relativeProperties skos:broader , skos:narrower ;
     ] ;


### PR DESCRIPTION
… all properties for a ConceptScheme are returned when looking at a ConceptScheme

Please test locally.

Specifying sh:path implies a closed profile i.e. any properties not specified under sh:path are excluded. This PR removes the specification of skos:prefLabel, reverting the profile to be open, so if the property skos:prefLabel is present, it will still be returned.