### PR TITLE
build: add PREZ_VERSION environment variable to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG PREZ_VERSION
 ARG PYTHON_VERSION=3.12
 ARG POETRY_VERSION=1.8.1
 ARG VIRTUAL_ENV=/opt/venv
@@ -35,6 +36,8 @@ RUN pip install --no-cache-dir dist/*.whl
 #
 FROM python:${PYTHON_VERSION}-alpine AS final
 
+ARG PREZ_VERSION
+ENV PREZ_VERSION=${PREZ_VERSION}
 ARG VIRTUAL_ENV
 ENV VIRTUAL_ENV=${VIRTUAL_ENV} \
     PATH=${VIRTUAL_ENV}/bin:/root/.local/bin:${PATH}


### PR DESCRIPTION
I was hoping that the prez version is read from `pyproject.toml` but it is not being set when the container image is built via GH Actions for some reason.

This PR sets the `PREZ_VERSION` environment variable in the Dockerfile itself. The prez application will use this as the fallback version if it cannot read from `pyproject.toml`.