### PR TITLE
Docker build and wheel dist build fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ venv/
 .git/
 test_*.py
 .github/
+Dockerfile
+*.Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .idea/
 .pytest_cache/
 .env*
+dist/
 !.env-template
 rdf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ WORKDIR /app
 COPY . .
 
 RUN poetry build
-RUN python -m venv --system-site-packages /opt/venv
-RUN pip install --no-cache-dir dist/*.whl
+RUN python3 -m venv --system-site-packages ${VIRTUAL_ENV}
+RUN ${VIRTUAL_ENV}/bin/pip3 install --no-cache-dir dist/*.whl
 
 #
 # Final

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apk update && \
       bash
 
 WORKDIR /app
-COPY . .
+# prez module is already built as a package and installed in $VIRTUAL_ENV as a library
+COPY main.py pyproject.toml ./
 
 ENTRYPOINT uvicorn prez.app:app --host=${HOST:-0.0.0.0} --port=${PORT:-8000} --proxy-headers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,20 @@ name = "prez"
 version = "0.1.0.dev0"
 description = "A python application for displaying linked data on the web"
 authors = ["Jamie Feiss <jamie.feiss@gmail.com>", "Nicholas Car <nick@kurrawong.net>", "David Habgood <dcchabgood@gmail.com>"]
+packages = [
+    { include = "prez" },
+    { include = "pyproject.toml", format = "wheel", to="prez" },
+]
+include = [
+    { path = "./*.md", format = "sdist" },
+    { path = "LICENSE", format = "sdist" },
+    { path = "demo", format = "sdist" },
+    { path = "dev", format = "sdist" },
+    { path = "tests", format = "sdist" },
+    { path = "poetry.lock", format = "sdist" },
+    { path = "./*.whl", format = "sdist" },
+    { path = "*.toml", format = "sdist" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
I found some inconsistencies and bugs while building Prez in a docker container for deployment on Azure cloud.

This is a collection of five small commits related to building the Prez bdist wheel, installing it in the Docker container, and building the Docker container.

[1](https://github.com/RDFLib/prez/commit/f4db5690511d046c44dd1ab79df5b06fda6dd5bc) Use arg/env variable for venv creation instead of hardcoded location. (It used the venv in other calls, just not in the venv creation command). Explicitly call the venv version of pip3 to install the wheel, so it is obvious the built prez module is being installed in the venv site_packages.

[2](https://github.com/RDFLib/prez/commit/70fcb45da9eeb9db0d90157d6c910a5a2bb0a7d7) Don't copy the whole source tree into the final image, it already has the built prez module and all dependencies installed in the venv, it just needs main.py and supporting files.

[3](https://github.com/RDFLib/prez/commit/e314dca341c949a1f0faf363cbf9be691eadf0b0) Never include dist files in the docker env, this also ensures no dist files are included inside the sdist or wheel packages (poetry excludes packaging everything in gitignore).

[4](https://github.com/RDFLib/prez/commit/e026403259d5d5f8324793c8e7c4b3a435bfcc12) Don't put Dockerfile inside its own Docker build context. Its not needed for the container built, and this allows incremental builds to work properly.

[5](https://github.com/RDFLib/prez/commit/5128d684f19bf59690aa542ac056e6c6eda94cd1) Put prez module's pyproject.toml _inside_ the built prez module in the wheel package, this allows the config builder to find it when prez is installed as a system module. Looks like this is what #216 was trying to solve.
Modify the config builder to search inside the prez module for pyproject.toml if there is not one in the project top directory (enables the above functionality).
Also explicitly list all the files to include in a sdist, because should be different than the wheel bdist.