### PR TITLE
override anotated mediatypes

### DIFF
--- a/prez/renderers/renderer.py
+++ b/prez/renderers/renderer.py
@@ -70,6 +70,7 @@ async def return_from_graph(
     else:
         if "anot+" in mediatype:
             non_anot_mediatype = mediatype.replace("anot+", "")
+            profile_headers['Content-Type'] = non_anot_mediatype
             graph = await return_annotated_rdf(graph, profile, repo)
             content = io.BytesIO(
                 graph.serialize(format=non_anot_mediatype, encoding="utf-8")


### PR DESCRIPTION
Fixes missing filetype extension for annotated mediatype downloads.

see: http://localhost:8000/v/vocab?_profile=prfl:mem&_mediatype=text/anot+turtle