### PR TITLE
Add a POST endpoint for the /sparql passthru feature.

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -20,7 +20,7 @@ from prez.dependencies import (
 from prez.models.model_exceptions import (
     ClassNotFoundException,
     URINotFoundException,
-    NoProfilesException,
+    NoProfilesException, InvalidSPARQLQueryException,
 )
 from prez.routers.catprez import router as catprez_router
 from prez.routers.cql import router as cql_router
@@ -47,6 +47,7 @@ from prez.services.exception_catchers import (
     catch_class_not_found_exception,
     catch_uri_not_found_exception,
     catch_no_profiles_exception,
+    catch_invalid_sparql_query,
 )
 from prez.services.generate_profiles import create_profiles_graph
 from prez.services.prez_logging import setup_logger
@@ -167,6 +168,7 @@ def assemble_app(
             ClassNotFoundException: catch_class_not_found_exception,
             URINotFoundException: catch_uri_not_found_exception,
             NoProfilesException: catch_no_profiles_exception,
+            InvalidSPARQLQueryException: catch_invalid_sparql_query
         },
         **kwargs
     )

--- a/prez/models/model_exceptions.py
+++ b/prez/models/model_exceptions.py
@@ -35,3 +35,13 @@ class NoProfilesException(Exception):
             f"for which a profile was searched was/were: {', '.join(klass for klass in classes)}"
         )
         super().__init__(self.message)
+
+
+class InvalidSPARQLQueryException(Exception):
+    """
+    Raised when a SPARQL query is invalid.
+    """
+
+    def __init__(self, error: str):
+        self.message = f"Invalid SPARQL query: {error}"
+        super().__init__(self.message)

--- a/prez/routers/sparql.py
+++ b/prez/routers/sparql.py
@@ -65,19 +65,40 @@ async def sparql_endpoint_handler(query: str, request: Request, repo: Repo, meth
             media_type=non_anot_mediatype,
             headers=prof_and_mt_info.profile_headers,
         )
+
+    query_result: 'httpx.Response' = await repo.sparql(query, request.headers.raw, method=method)
+    if isinstance(query_result, dict):
+        return JSONResponse(content=query_result)
+    elif isinstance(query_result, Graph):
+        return Response(
+            content=query_result.serialize(format="text/turtle"),
+            status_code=200
+        )
+
+    dispositions = query_result.headers.get_list("Content-Disposition")
+    for disposition in dispositions:
+        if disposition.lower().startswith("attachment"):
+            is_attachment = True
+            break
     else:
-        query_result = await repo.sparql(query, request.headers.raw, method=method)
-        if isinstance(query_result, dict):
-            return JSONResponse(content=query_result)
-        elif isinstance(query_result, Graph):
-            return Response(
-                content=query_result.serialize(format="text/turtle"),
-                status_code=200
-            )
-        else:
-            return StreamingResponse(
-                query_result.aiter_raw(),
-                status_code=query_result.status_code,
-                headers=dict(query_result.headers),
-                background=BackgroundTask(query_result.aclose),
-            )
+        is_attachment = False
+    if is_attachment:
+        # remove transfer-encoding chunked, disposition=attachment, and content-length
+        headers = dict()
+        for k, v in query_result.headers.items():
+            if k.lower() not in ("transfer-encoding", "content-disposition", "content-length"):
+                headers[k] = v
+        content = await query_result.aread()
+        await query_result.aclose()
+        return Response(
+            content=content,
+            status_code=query_result.status_code,
+            headers=headers,
+        )
+    else:
+        return StreamingResponse(
+            query_result.aiter_raw(),
+            status_code=query_result.status_code,
+            headers=dict(query_result.headers),
+            background=BackgroundTask(query_result.aclose),
+        )

--- a/prez/routers/sparql.py
+++ b/prez/routers/sparql.py
@@ -24,7 +24,7 @@ async def sparql_post_passthrough(
     # To maintain compatibility with the other SPARQL endpoints,
     # /sparql POST endpoint is not a JSON API, it uses
     # values encoded with x-www-form-urlencoded
-    query: Annotated[str, Form()],
+    query: Annotated[str, Form()],  # Pydantic validation prevents update queries (the Form would need to be "update")
     request: Request,
     repo: Repo = Depends(get_repo),
 ):
@@ -65,7 +65,6 @@ async def sparql_endpoint_handler(query: str, request: Request, repo: Repo, meth
             media_type=non_anot_mediatype,
             headers=prof_and_mt_info.profile_headers,
         )
-
     query_result: 'httpx.Response' = await repo.sparql(query, request.headers.raw, method=method)
     if isinstance(query_result, dict):
         return JSONResponse(content=query_result)

--- a/prez/services/exception_catchers.py
+++ b/prez/services/exception_catchers.py
@@ -5,7 +5,7 @@ from starlette.requests import Request
 from prez.models.model_exceptions import (
     ClassNotFoundException,
     URINotFoundException,
-    NoProfilesException,
+    NoProfilesException, InvalidSPARQLQueryException,
 )
 
 
@@ -48,6 +48,16 @@ async def catch_no_profiles_exception(request: Request, exc: NoProfilesException
         status_code=404,
         content={
             "error": "Not Found",
+            "detail": exc.message,
+        },
+    )
+
+
+async def catch_invalid_sparql_query(request: Request, exc: InvalidSPARQLQueryException):
+    return JSONResponse(
+        status_code=400,
+        content={
+            "error": "Bad Request",
             "detail": exc.message,
         },
     )

--- a/prez/sparql/methods.py
+++ b/prez/sparql/methods.py
@@ -96,18 +96,24 @@ class RemoteSparqlRepo(Repo):
     ):
         """Sends a starlette Request object (containing a SPARQL query in the URL parameters) to a proxied SPARQL
         endpoint."""
-        # TODO: This only supports SPARQL GET requests because the query is sent as a query parameter.
+        # Uses GET if the proxied query was received as a query param using GET
+        # Uses POST if the proxied query was received as a form-encoded body using POST
 
-        query_escaped_as_bytes = f"query={quote_plus(query)}".encode("utf-8")
-
-        # TODO: Global app settings should be passed in as a function argument.
-        url = httpx.URL(url=settings.sparql_endpoint, query=query_escaped_as_bytes)
         headers = []
         for header in raw_headers:
-            if header[0] != b"host":
+            if header[0] not in (b"host", b"content-length"):
                 headers.append(header)
+
+        if method == "GET":
+            query_escaped_as_bytes = f"query={quote_plus(query)}".encode("utf-8")
+            url = httpx.URL(url=settings.sparql_endpoint, query=query_escaped_as_bytes)
+            data = None
+        else:
+            url = httpx.URL(url=settings.sparql_endpoint)
+            data = {"query": query}
+
         headers.append((b"host", str(url.host).encode("utf-8")))
-        rp_req = self.async_client.build_request(method, url, headers=headers)
+        rp_req = self.async_client.build_request(method, url, headers=headers, data=data)
         return await self.async_client.send(rp_req, stream=True)
 
 

--- a/prez/sparql/methods.py
+++ b/prez/sparql/methods.py
@@ -101,19 +101,19 @@ class RemoteSparqlRepo(Repo):
 
         headers = []
         for header in raw_headers:
-            if header[0] not in (b"host", b"content-length"):
+            if header[0] not in (b"host", b"content-length", b"content-type"):
                 headers.append(header)
-
+        query_escaped_as_bytes = f"query={quote_plus(query)}".encode("utf-8")
         if method == "GET":
-            query_escaped_as_bytes = f"query={quote_plus(query)}".encode("utf-8")
             url = httpx.URL(url=settings.sparql_endpoint, query=query_escaped_as_bytes)
-            data = None
+            content = None
         else:
+            headers.append((b"content-type", b"application/x-www-form-urlencoded"))
             url = httpx.URL(url=settings.sparql_endpoint)
-            data = {"query": query}
+            content = query_escaped_as_bytes
 
         headers.append((b"host", str(url.host).encode("utf-8")))
-        rp_req = self.async_client.build_request(method, url, headers=headers, data=data)
+        rp_req = self.async_client.build_request(method, url, headers=headers, content=content)
         return await self.async_client.send(rp_req, stream=True)
 
 

--- a/prez/sparql/methods.py
+++ b/prez/sparql/methods.py
@@ -11,6 +11,7 @@ from fastapi.concurrency import run_in_threadpool
 from rdflib import Namespace, Graph, URIRef, Literal, BNode
 
 from prez.config import settings
+from prez.models.model_exceptions import InvalidSPARQLQueryException
 
 PREZ = Namespace("https://prez.dev/")
 
@@ -163,7 +164,10 @@ class PyoxigraphRepo(Repo):
 
     def _sparql(self, query: str) -> dict | Graph | bool:
         """Submit a sparql query to the pyoxigraph store and return the formatted results."""
-        results = self.pyoxi_store.query(query)
+        try:
+            results = self.pyoxi_store.query(query)
+        except SyntaxError as e:
+            raise InvalidSPARQLQueryException(e.msg)
         if isinstance(results, pyoxigraph.QuerySolutions):  # a SELECT query result
             results_dict = self._handle_query_solution_results(results)
             return results_dict

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -65,3 +65,41 @@ def test_ask(client):
         "/sparql?query=PREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.com%2Fdatasets%2F%3E%0APREFIX%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0A%0AASK%0AWHERE%20%7B%0A%20%20%3Fsubject%20dcterms%3Atitle%20%3Ftitle%20.%0A%20%20FILTER%20CONTAINS(LCASE(%3Ftitle)%2C%20%22sandgate%22)%0A%7D"
     )
     assert (r.status_code, 200)
+
+
+def test_post(client):
+    """check that a valid post query returns a 200 response."""
+    r = client.post(
+        "/sparql",
+        data={
+            "query": "SELECT * WHERE { ?s ?p ?o } LIMIT 1",
+            "format": "application/x-www-form-urlencoded",
+        },
+    )
+    assert (r.status_code, 200)
+
+
+def test_post_invalid_data(client):
+    """check that a post query with invalid data returns a 400 response."""
+    r = client.post(
+        "/sparql",
+        data={
+            "query": "INVALID QUERY",
+            "format": "application/x-www-form-urlencoded",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_insert_as_query(client):
+    """
+    Also tested manually with Fuseki
+    """
+    r = client.post(
+        "/sparql",
+        data={
+            "query": "INSERT {<:s> <:p> <:o>}",
+            "format": "application/x-www-form-urlencoded",
+        },
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
When Prez is behind Azure APIM, all URL query args are limited 2048 characters long.
sparql queries should not really be sent with GET requests anyway.
Add a POST endpoint for the /sparql passthru feature.
This causes the proxied query to the graph db to be called as a POST too