### PR TITLE
Add ability to declare prefixes in remote Repos

### DIFF
--- a/tests/data/prefixes/data_using_prefixes.ttl
+++ b/tests/data/prefixes/data_using_prefixes.ttl
@@ -1,0 +1,11 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ex: <https://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+<https://david/bogusCatalogous> a dcat:Catalog ;
+    rdfs:label "A Catalog with prefixed david" ;
+    dcterms:hasPart ex:DCATResource ;
+    ex:property "some property" ;
+.

--- a/tests/data/prefixes/remote_prefixes.ttl
+++ b/tests/data/prefixes/remote_prefixes.ttl
@@ -1,0 +1,9 @@
+PREFIX vann:    <http://purl.org/vocab/vann/>
+PREFIX ldgovau: <https://linked.data.gov.au/datasets/>
+PREFIX gnaf:    <https://linked.data.gov.au/datasets/gnaf/>
+PREFIX addr:    <https://linked.data.gov.au/datasets/gnaf/address/>
+
+
+[ vann:preferredNamespacePrefix "davo" ;
+vann:preferredNamespaceUri <https://david/> ;
+] .

--- a/tests/test_remote_prefixes.py
+++ b/tests/test_remote_prefixes.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from pyoxigraph.pyoxigraph import Store
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDF, DCAT
+
+from prez.app import assemble_app
+from prez.dependencies import get_repo
+from prez.sparql.methods import Repo, PyoxigraphRepo
+
+
+@pytest.fixture(scope="session")
+def test_store() -> Store:
+    # Create a new pyoxigraph Store
+    store = Store()
+
+    for file in Path(__file__).parent.glob("../tests/data/prefixes/*.ttl"):
+        store.load(file.read_bytes(), "text/turtle")
+
+    return store
+
+
+@pytest.fixture(scope="session")
+def test_repo(test_store: Store) -> Repo:
+    # Create a PyoxigraphQuerySender using the test_store
+    return PyoxigraphRepo(test_store)
+
+
+@pytest.fixture(scope="session")
+def client(test_repo: Repo) -> TestClient:
+    # Override the dependency to use the test_repo
+    def override_get_repo():
+        return test_repo
+
+    app = assemble_app()
+
+    app.dependency_overrides[get_repo] = override_get_repo
+
+    with TestClient(app) as c:
+        yield c
+
+    # Remove the override to ensure subsequent tests are unaffected
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.xfail(
+    reason="Dependency overrides not configured correctly. Test passes when manually tested using Fuseki"
+)
+def test_catalog_link(client):
+    # get link for first catalog
+    r = client.get("/c/catalogs")
+    g = Graph().parse(data=r.text)
+    member_uri = g.value(None, RDF.type, DCAT.Catalog)
+    link = str(g.value(member_uri, URIRef(f"https://prez.dev/link", None)))
+    assert link == "/c/catalogs/davo:bogusCatalogous"


### PR DESCRIPTION
Prefixes can be declared in remote repositories using the vann namespace as per the example below. These are loaded first and will take priority over namespaces declared within the `prez/reference_data/prefixes/*.ttl` files.

```
@prefix vann: <http://purl.org/vocab/vann/> .

[ vann:preferredNamespacePrefix "altr-ext" ;
 vann:preferredNamespaceUri <http://www.w3.org/ns/dx/connegp/altr-ext#>
] .
```