### PR TITLE
Simplify prez:members declaration; add prez:FocusNode class to focus nodes

### DIFF
--- a/prez/services/link_generation.py
+++ b/prez/services/link_generation.py
@@ -150,9 +150,7 @@ async def add_links_to_graph_and_cache(
             links_ids_graph_cache.quads((uri, PREZ["members"], None, uri))
         )
         if not existing_members_link:
-            members_bn = BNode()
-            quads.append((uri, PREZ["members"], members_bn, uri))
-            quads.append((members_bn, PREZ["link"], Literal(members_link), uri))
+            quads.append((uri, PREZ["members"], Literal(members_link), uri))
     for quad in quads:
         graph.add(quad[:3])
         links_ids_graph_cache.add(quad)

--- a/prez/services/listings.py
+++ b/prez/services/listings.py
@@ -4,7 +4,7 @@ import logging
 from fastapi.responses import PlainTextResponse
 from rdflib import URIRef, Literal
 from rdflib.namespace import RDF
-from sparql_grammar_pydantic import IRI, Var
+from sparql_grammar_pydantic import IRI, Var, TriplesSameSubject
 
 from prez.cache import endpoints_graph_cache
 from prez.reference_data.prez_ns import PREZ, ALTREXT, ONT
@@ -53,6 +53,16 @@ async def listing_function(
         construct_tss_list.extend(subselect_tss_list)
     if profile_nodeshape.tss_list:
         construct_tss_list.extend(profile_nodeshape.tss_list)
+
+    # add focus node declaration if it's an annotated mediatype
+    if "anot+" in pmts.selected["mediatype"]:
+        construct_tss_list.append(
+            TriplesSameSubject.from_spo(
+                subject=profile_nodeshape.focus_node,
+                predicate=IRI(value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                object=IRI(value="https://prez.dev/FocusNode"),
+            )
+        )
 
     queries = []
     main_query = PrezQueryConstructor(

--- a/prez/services/listings.py
+++ b/prez/services/listings.py
@@ -59,7 +59,7 @@ async def listing_function(
         construct_tss_list.append(
             TriplesSameSubject.from_spo(
                 subject=profile_nodeshape.focus_node,
-                predicate=IRI(value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                predicate=IRI(value="https://prez.dev/type"),
                 object=IRI(value="https://prez.dev/FocusNode"),
             )
         )

--- a/prez/services/objects.py
+++ b/prez/services/objects.py
@@ -54,7 +54,7 @@ async def object_function(
         profile_nodeshape.tss_list.append(
             TriplesSameSubject.from_spo(
                 subject=profile_nodeshape.focus_node,
-                predicate=IRI(value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                predicate=IRI(value="https://prez.dev/type"),
                 object=IRI(value="https://prez.dev/FocusNode"),
             )
         )

--- a/prez/services/objects.py
+++ b/prez/services/objects.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from fastapi.responses import PlainTextResponse
+from sparql_grammar_pydantic import TriplesSameSubject, IRI
 
 from prez.models.query_params import QueryParams
 from prez.reference_data.prez_ns import ALTREXT, ONT
@@ -16,11 +17,11 @@ log = logging.getLogger(__name__)
 
 
 async def object_function(
-    data_repo,
-    system_repo,
-    endpoint_structure,
-    pmts,
-    profile_nodeshape,
+        data_repo,
+        system_repo,
+        endpoint_structure,
+        pmts,
+        profile_nodeshape,
 ):
     if pmts.selected["profile"] == ALTREXT["alt-profile"]:
         none_keys = [
@@ -49,7 +50,14 @@ async def object_function(
             original_endpoint_type=ONT["ObjectEndpoint"],
             **none_kwargs,
         )
-
+    if "anot+" in pmts.selected["mediatype"]:
+        profile_nodeshape.tss_list.append(
+            TriplesSameSubject.from_spo(
+                subject=profile_nodeshape.focus_node,
+                predicate=IRI(value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                object=IRI(value="https://prez.dev/FocusNode"),
+            )
+        )
     query = PrezQueryConstructor(
         profile_triples=profile_nodeshape.tssp_list,
         profile_gpnt=profile_nodeshape.gpnt_list,


### PR DESCRIPTION
1. Remove use of blank nodes when specifying prez members
2. Add prez:FocusNode declaration for object and listing results

Previous output:
```
exm:CatalogOne a dcat:Catalog ;
    prez:identifier "exm:CatalogOne" ;
    prez:label "Catalog One" ;
    prez:link "/catalogs/exm:CatalogOne" ;
    prez:members [ 
        prez:link "/catalogs/exm:CatalogOne/collections" .
    ]
```
New output after code changes:
```
exm:CatalogOne a dcat:Catalog ;
    prez:identifier "exm:CatalogOne" ;
    prez:label "Catalog One" ;
    prez:link "/catalogs/exm:CatalogOne" ;
    prez:members "/catalogs/exm:CatalogOne/collections" ;
    prez:type prez:FocusNode .
```