### PR TITLE
David/prez identifier homepage mediatypes

### DIFF
--- a/prez/services/connegp_service.py
+++ b/prez/services/connegp_service.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from enum import Enum
 from textwrap import dedent
 
 from pydantic import BaseModel
@@ -34,6 +35,26 @@ RDF_SERIALIZER_TYPES_MAP = {
     "text/n-triples": "nt",
     "text/plain": "nt",  # text/plain is the old/deprecated mimetype for n-triples
 }
+
+class MediaType(str, Enum):
+    turtle = "text/turtle"
+    n3 = "text/n3"
+    nt = "application/n-triples"
+    json_ld = "application/ld+json"
+    xml = "application/rdf+xml"
+    anot_turtle = "text/anot+turtle"
+    anot_n3 = "text/anot+n3"
+    anot_nt = "application/anot+n-triples"
+    anot_json_ld = "application/anot+ld+json"
+    anot_xml = "application/anot+rdf+xml"
+    # Some common but incorrect mimetypes
+    application_rdf = "application/rdf"
+    application_rdf_xml = "application/rdf xml"
+    application_json = "application/json"
+    application_ld_json = "application/ld json"
+    text_ttl = "text/ttl"
+    text_ntriples = "text/ntriples"
+    text_plain = "text/plain"
 
 
 class TokenError(Exception):

--- a/prez/services/link_generation.py
+++ b/prez/services/link_generation.py
@@ -2,7 +2,7 @@ import logging
 import time
 from string import Template
 
-from rdflib import Graph, Literal, URIRef, DCTERMS, BNode
+from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import SH, RDF
 from sparql_grammar_pydantic import (
     IRI,
@@ -145,7 +145,7 @@ async def add_links_to_graph_and_cache(
     quads.append((uri, PREZ["link"], Literal(object_link), uri))
     for uri_in_link_string, curie_in_link_string in identifiers.items():
         quads.append(
-            (uri_in_link_string, DCTERMS.identifier, Literal(curie_in_link_string, datatype=PREZ.identifier), uri)
+            (uri_in_link_string, PREZ.identifier, Literal(curie_in_link_string), uri)
         )
     if (
             members_link

--- a/prez/services/link_generation.py
+++ b/prez/services/link_generation.py
@@ -2,7 +2,7 @@ import logging
 import time
 from string import Template
 
-from rdflib import Graph, Literal, URIRef
+from rdflib import Graph, Literal, URIRef, BNode
 from rdflib.namespace import SH, RDF
 from sparql_grammar_pydantic import (
     IRI,

--- a/prez/services/link_generation.py
+++ b/prez/services/link_generation.py
@@ -150,9 +150,7 @@ async def add_links_to_graph_and_cache(
             links_ids_graph_cache.quads((uri, PREZ["members"], None, uri))
         )
         if not existing_members_link:
-            members_bn = BNode()
-            quads.append((uri, PREZ["members"], members_bn, uri))
-            quads.append((members_bn, PREZ["link"], Literal(members_link), uri))
+            quads.append((uri, PREZ["members"], Literal(members_link), uri))
     for quad in quads:
         graph.add(quad[:3])
         links_ids_graph_cache.add(quad)

--- a/prez/services/link_generation.py
+++ b/prez/services/link_generation.py
@@ -46,11 +46,11 @@ async def add_prez_links(graph: Graph, repo: Repo, endpoint_structure):
 
 
 async def _link_generation(
-    uri: URIRef,
-    repo: Repo,
-    klasses,
-    graph: Graph,
-    endpoint_structure: str = settings.endpoint_structure,
+        uri: URIRef,
+        repo: Repo,
+        klasses,
+        graph: Graph,
+        endpoint_structure: str = settings.endpoint_structure,
 ):
     """
     Generates links for the given URI if it is not already cached.
@@ -75,6 +75,8 @@ async def _link_generation(
             not in [
                 URIRef("http://example.org/ns#CQL"),
                 URIRef("http://example.org/ns#Search"),
+                URIRef("http://example.org/ns#TopConcepts"),
+                URIRef("http://example.org/ns#Narrowers"),
             ]
         ]
         # run queries for available nodeshapes to get link components
@@ -91,19 +93,20 @@ async def _link_generation(
                             curie_for_uri,
                             members_link,
                             object_link,
+                            identifiers
                         ) = await create_link_strings(
                             ns.hierarchy_level, solution, uri, endpoint_structure
                         )
                         # add links and identifiers to graph and cache
                         await add_links_to_graph_and_cache(
-                            curie_for_uri, graph, members_link, object_link, uri
+                            curie_for_uri, graph, members_link, object_link, uri, identifiers
                         )
             else:
-                curie_for_uri, members_link, object_link = await create_link_strings(
+                curie_for_uri, members_link, object_link, identifiers = await create_link_strings(
                     ns.hierarchy_level, {}, uri, endpoint_structure
                 )
                 await add_links_to_graph_and_cache(
-                    curie_for_uri, graph, members_link, object_link, uri
+                    curie_for_uri, graph, members_link, object_link, uri, identifiers
                 )
 
 
@@ -133,19 +136,21 @@ async def get_nodeshapes_constraining_class(klasses, uri):
 
 
 async def add_links_to_graph_and_cache(
-    curie_for_uri, graph, members_link, object_link, uri
+        curie_for_uri, graph, members_link, object_link, uri, identifiers: dict
 ):
     """
     Adds links and identifiers to the given graph and cache.
     """
     quads = []
     quads.append((uri, PREZ["link"], Literal(object_link), uri))
-    quads.append(
-        (uri, DCTERMS.identifier, Literal(curie_for_uri, datatype=PREZ.identifier), uri)
-    )
+    for uri_in_link_string, curie_in_link_string in identifiers.items():
+        quads.append(
+            (uri_in_link_string, DCTERMS.identifier, Literal(curie_in_link_string, datatype=PREZ.identifier), uri)
+        )
     if (
-        members_link
-    ):  # TODO need to confirm the link value doesn't match the existing link value, as multiple endpoints can deliver the same class/have different links for the same URI
+            members_link
+    ):  # TODO need to confirm the link value doesn't match the existing link value, as multiple endpoints can deliver
+        # the same class/have different links for the same URI
         existing_members_link = list(
             links_ids_graph_cache.quads((uri, PREZ["members"], None, uri))
         )
@@ -160,6 +165,8 @@ async def create_link_strings(hierarchy_level, solution, uri, endpoint_structure
     """
     Creates link strings based on the hierarchy level and solution provided.
     """
+    identifiers = {URIRef(v["value"]): get_curie_id_for_uri(v["value"]) for k, v in solution.items()} | {
+        uri: get_curie_id_for_uri(uri)}
     components = list(endpoint_structure[: int(hierarchy_level)])
     variables = reversed(
         ["focus_node"] + [f"path_node_{i}" for i in range(1, len(components))]
@@ -168,14 +175,14 @@ async def create_link_strings(hierarchy_level, solution, uri, endpoint_structure
         "".join([f"/{comp}/${pattern}" for comp, pattern in zip(components, variables)])
     )
     curie_for_uri = get_curie_id_for_uri(uri)
-    sol_values = {k: get_curie_id_for_uri(v["value"]) for k, v in solution.items()}
+    sol_values = {k: identifiers[URIRef(v["value"])] for k, v in solution.items()}
     object_link = item_link_template.substitute(
         sol_values | {"focus_node": curie_for_uri}
     )
     members_link = None
     if len(components) < len(list(endpoint_structure)):
         members_link = object_link + "/" + endpoint_structure[len(components)]
-    return curie_for_uri, members_link, object_link
+    return curie_for_uri, members_link, object_link, identifiers
 
 
 async def get_link_components(ns, repo):

--- a/prez/services/listings.py
+++ b/prez/services/listings.py
@@ -4,7 +4,7 @@ import logging
 from fastapi.responses import PlainTextResponse
 from rdflib import URIRef, Literal
 from rdflib.namespace import RDF
-from sparql_grammar_pydantic import IRI, Var
+from sparql_grammar_pydantic import IRI, Var, TriplesSameSubject
 
 from prez.cache import endpoints_graph_cache
 from prez.reference_data.prez_ns import PREZ, ALTREXT, ONT
@@ -53,6 +53,16 @@ async def listing_function(
         construct_tss_list.extend(subselect_tss_list)
     if profile_nodeshape.tss_list:
         construct_tss_list.extend(profile_nodeshape.tss_list)
+
+    # add focus node declaration if it's an annotated mediatype
+    if "anot+" in pmts.selected["mediatype"]:
+        construct_tss_list.append(
+            TriplesSameSubject.from_spo(
+                subject=profile_nodeshape.focus_node,
+                predicate=IRI(value="https://prez.dev/type"),
+                object=IRI(value="https://prez.dev/FocusNode"),
+            )
+        )
 
     queries = []
     main_query = PrezQueryConstructor(

--- a/prez/services/objects.py
+++ b/prez/services/objects.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from fastapi.responses import PlainTextResponse
+from sparql_grammar_pydantic import TriplesSameSubject, IRI
 
 from prez.models.query_params import QueryParams
 from prez.reference_data.prez_ns import ALTREXT, ONT
@@ -16,11 +17,11 @@ log = logging.getLogger(__name__)
 
 
 async def object_function(
-    data_repo,
-    system_repo,
-    endpoint_structure,
-    pmts,
-    profile_nodeshape,
+        data_repo,
+        system_repo,
+        endpoint_structure,
+        pmts,
+        profile_nodeshape,
 ):
     if pmts.selected["profile"] == ALTREXT["alt-profile"]:
         none_keys = [
@@ -49,7 +50,14 @@ async def object_function(
             original_endpoint_type=ONT["ObjectEndpoint"],
             **none_kwargs,
         )
-
+    if "anot+" in pmts.selected["mediatype"]:
+        profile_nodeshape.tss_list.append(
+            TriplesSameSubject.from_spo(
+                subject=profile_nodeshape.focus_node,
+                predicate=IRI(value="https://prez.dev/type"),
+                object=IRI(value="https://prez.dev/FocusNode"),
+            )
+        )
     query = PrezQueryConstructor(
         profile_triples=profile_nodeshape.tssp_list,
         profile_gpnt=profile_nodeshape.gpnt_list,


### PR DESCRIPTION
1. Process mediatype requests on homepage route ("/"). The homepage rendering does not use the same object/listing pattern/renderer that the rest of Prez does and was previously hardcoded to only return text/turtle.
2. For prez identifiers, used in links, change from:
` (uri, DCTERMS.identifier, Literal(curie_for_uri, datatype=PREZ.identifier))`
to:
`(uri, PREZ.identifier, Literal(curie_for_uri))`
This simplifies frontend processing.