### PR TITLE
Remove properties from ConceptScheme rendering for performance reasons

### DIFF
--- a/prez/reference_data/profiles/ogc_records_profile.ttl
+++ b/prez/reference_data/profiles/ogc_records_profile.ttl
@@ -143,10 +143,10 @@ prez:OGCSchemesObjectProfile
     altr-ext:hasDefaultResourceFormat "text/anot+turtle" ;
     altr-ext:constrainsClass skos:ConceptScheme ;
     sh:property [
-        sh:minCount 0 ;
-        sh:path [sh:inversePath skos:inScheme ]
-        ] , [
         sh:path shext:allPredicateValues
+        ] , [
+        sh:maxCount 0 ;
+        sh:path skos:hasTopConcept ;
         ] ;
     shext:bnode-depth 2 ;
     .


### PR DESCRIPTION
Modify default profile to exclude skos:hasTopConcept to prevent timeouts when loading ConceptSchemes. The top concepts can be obtained using the paginated endpoint `/concept-hierarchy/<cs>/top-concepts`. Remove optional inclusion of concept skos:inScheme conceptScheme links for the same reason.