### PR TITLE
SPARQL endpoint opt in

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -171,7 +171,8 @@ def assemble_app(
 
     app.include_router(management_router)
     app.include_router(ogc_records_router)
-    app.include_router(sparql_router)
+    if _settings.enable_sparql_endpoint:
+        app.include_router(sparql_router)
     app.include_router(identifier_router)
     app.openapi = partial(
         prez_open_api_metadata,

--- a/prez/config.py
+++ b/prez/config.py
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
         EP["system/profile-listing"],
         EP["system/profile-object"],
     ]
+    enable_sparql_endpoint: bool = False
 
     @field_validator("prez_version")
     @classmethod

--- a/prez/routers/sparql.py
+++ b/prez/routers/sparql.py
@@ -12,6 +12,7 @@ from starlette.responses import StreamingResponse
 from prez.dependencies import get_data_repo, get_system_repo
 from prez.renderers.renderer import return_annotated_rdf
 from prez.repositories import Repo
+from prez.routers.api_extras_examples import responses
 from prez.services.connegp_service import NegotiatedPMTs
 
 PREZ = Namespace("https://prez.dev/")
@@ -35,7 +36,7 @@ async def sparql_post_passthrough(
     )
 
 
-@router.get("/sparql")
+@router.get("/sparql", responses=responses)
 async def sparql_get_passthrough(
     query: str,
     request: Request,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ os.environ["SPARQL_REPO_TYPE"] = "pyoxigraph"
 
 # os.environ["SPARQL_ENDPOINT"] = "http://localhost:3030/dataset"
 # os.environ["SPARQL_REPO_TYPE"] = "remote"
+os.environ["ENABLE_SPARQL_ENDPOINT"] = "1"
 
 from pathlib import Path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ os.environ["SPARQL_REPO_TYPE"] = "pyoxigraph"
 
 # os.environ["SPARQL_ENDPOINT"] = "http://localhost:3030/dataset"
 # os.environ["SPARQL_REPO_TYPE"] = "remote"
-os.environ["ENABLE_SPARQL_ENDPOINT"] = "1"
+os.environ["ENABLE_SPARQL_ENDPOINT"] = "true"
 
 from pathlib import Path
 

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -3,7 +3,7 @@ def test_select(client):
     r = client.get(
         "/sparql?query=SELECT%20*%0AWHERE%20%7B%0A%20%20%3Fs%20%3Fp%20%3Fo%0A%7D%20LIMIT%201"
     )
-    assert (r.status_code, 200)
+    assert r.status_code == 200
 
 
 def test_construct(client):
@@ -11,7 +11,7 @@ def test_construct(client):
     r = client.get(
         "/sparql?query=CONSTRUCT%20%7B%0A%20%20%3Fs%20%3Fp%20%3Fo%0A%7D%20WHERE%20%7B%0A%20%20%3Fs%20%3Fp%20%3Fo%0A%7D%20LIMIT%201"
     )
-    assert (r.status_code, 200)
+    assert r.status_code == 200
 
 
 def test_ask(client):
@@ -19,7 +19,7 @@ def test_ask(client):
     r = client.get(
         "/sparql?query=PREFIX%20ex%3A%20%3Chttp%3A%2F%2Fexample.com%2Fdatasets%2F%3E%0APREFIX%20dcterms%3A%20%3Chttp%3A%2F%2Fpurl.org%2Fdc%2Fterms%2F%3E%0A%0AASK%0AWHERE%20%7B%0A%20%20%3Fsubject%20dcterms%3Atitle%20%3Ftitle%20.%0A%20%20FILTER%20CONTAINS(LCASE(%3Ftitle)%2C%20%22sandgate%22)%0A%7D"
     )
-    assert (r.status_code, 200)
+    assert r.status_code == 200
 
 
 def test_post(client):
@@ -31,7 +31,7 @@ def test_post(client):
             "format": "application/x-www-form-urlencoded",
         },
     )
-    assert (r.status_code, 200)
+    assert r.status_code == 200
 
 
 def test_post_invalid_data(client):


### PR DESCRIPTION
Makes the SPARQL endpoint opt in using the enable_sparql_endpoint variable in settings; defaulted to False.