### PR TITLE
Raise a early error when a RemoteSparqlRepo is configured, but SPARQL_ENDPOINT is none.

### DIFF
--- a/prez/repositories/remote_sparql.py
+++ b/prez/repositories/remote_sparql.py
@@ -15,6 +15,12 @@ log = logging.getLogger(__name__)
 class RemoteSparqlRepo(Repo):
     def __init__(self, async_client: httpx.AsyncClient):
         self.async_client = async_client
+        if not settings.sparql_endpoint:
+            raise ValueError(
+                "When using a remote SPARQL endpoint, "
+                "the SPARQL_ENDPOINT setting must be set using either "
+                "the environment variable or the config file."
+            )
 
     async def _send_query(self, query: str, mediatype="text/turtle"):
         """Sends a SPARQL query asynchronously.


### PR DESCRIPTION
Raise a ValueError on startup when a RemoteSparqlRepo is configured, but SPARQL_ENDPOINT is not provided in the settings file or the env var.

Fixes #260
