### PR TITLE
Fix vocpub profile to display all properties for concepts

### DIFF
--- a/prez/reference_data/profiles/vocprez_default_profiles.ttl
+++ b/prez/reference_data/profiles/vocprez_default_profiles.ttl
@@ -9,6 +9,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX shext: <http://example.com/shacl-extension#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -103,7 +104,7 @@ prez:VocPrezProfile
     altr-ext:hasNodeShape [
         a sh:NodeShape ;
         sh:targetClass skos:ConceptScheme ;
-        altr-ext:relativeProperties skos:broader , skos:narrower ;
+        altr-ext:relativeProperties shext:allPredicateValues ;
     ] ;
     altr-ext:hasNodeShape [
         a sh:NodeShape ;

--- a/prez/sparql/objects_listings.py
+++ b/prez/sparql/objects_listings.py
@@ -237,7 +237,7 @@ def generate_relative_properties(
                 if relative_properties == [URIRef('http://example.com/shacl-extension#allPredicateValues')]:
                     rel_string += f"""VALUES ?rel_{k}_props {{ UNDEF }} }}\n"""
                 else:
-                    rel_string += f"""VALUES ?rel_{k}_props {{ {" ".join('<' + str(pred.n3()) + '>' for pred in relative_properties)} }} }}\n"""
+                    rel_string += f"""VALUES ?rel_{k}_props {{ {" ".join('<' + pred + '>' for pred in relative_properties)} }} }}\n"""
     return rel_string
 
 

--- a/prez/sparql/objects_listings.py
+++ b/prez/sparql/objects_listings.py
@@ -234,7 +234,10 @@ def generate_relative_properties(
                 rel_string += """OPTIONAL { """
             rel_string += f"""?{other_kvs[k]} ?rel_{k}_props ?rel_{k}_val .\n"""
             if construct_select == "select":
-                rel_string += f"""VALUES ?rel_{k}_props {{ {" ".join('<' + str(pred) + '>' for pred in relative_properties)} }} }}\n"""
+                if relative_properties == [URIRef('http://example.com/shacl-extension#allPredicateValues')]:
+                    rel_string += f"""VALUES ?rel_{k}_props {{ UNDEF }} }}\n"""
+                else:
+                    rel_string += f"""VALUES ?rel_{k}_props {{ {" ".join('<' + str(pred.n3()) + '>' for pred in relative_properties)} }} }}\n"""
     return rel_string
 
 
@@ -272,7 +275,10 @@ def generate_include_predicates(include_predicates):
     VALUES ?p { <http://example1.com> <http://example2.com> }
     """
     if include_predicates:
-        return f"""VALUES ?p{{\n{chr(10).join([f"<{p}>" for p in include_predicates])}\n}}"""
+        if include_predicates == [URIRef('http://example.com/shacl-extension#allPredicateValues')]:
+            return ""
+        else:
+            return f"""VALUES ?p{{\n{chr(10).join([f"<{p}>" for p in include_predicates])}\n}}"""
     return ""
 
 


### PR DESCRIPTION
Fix vocpub profile to display all properties for concepts by adding a "shext:allPredicateValues" special predicate.

V4 will implement similar functionality.