### PR TITLE
ci: update GH actions

### DIFF
--- a/.github/workflows/on_pr_to_main.yaml
+++ b/.github/workflows/on_pr_to_main.yaml
@@ -17,10 +17,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       #----------------------------------------------
@@ -38,7 +38,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/on_push_to_feature.yaml
+++ b/.github/workflows/on_push_to_feature.yaml
@@ -15,7 +15,7 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v4
@@ -36,7 +36,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/on_push_to_main.yaml
+++ b/.github/workflows/on_push_to_main.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Required by WyriHaximus/github-action-get-previous-tag
           fetch-depth: 0
@@ -54,34 +54,34 @@ jobs:
 
       - name: Get git commit hash
         id: commit-hash
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: type=sha
 
       - name: Rename git commit hash
         id: hash
-        uses: mad9000/actions-find-and-replace-string@4
+        uses: mad9000/actions-find-and-replace-string@5
         with:
           source: ${{ steps.commit-hash.outputs.version }}
           find: "sha-"
           replace: dev.${{ steps.commitscount.outputs.value }}.
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
           build-args: PREZ_VERSION=${{ steps.patch.outputs.patch }}-${{ steps.hash.outputs.value }}

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           build-args: PREZ_VERSION=${{ steps.version.outputs.VALUE }}


### PR DESCRIPTION
Last PR merged to main passed tests on branch but failed on merge to main (different GH action).

Running the action locally did not replicate the error -  https://nektosact.com/

Attempting to update GH action dependency versions in case this resolves the issue.