### PR TITLE
Remote profiles bugfix and update to Catalog hierarchy

### DIFF
--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -117,11 +117,8 @@ async def load_system_data_to_oxigraph(store: Store):
     """
     Loads all the data from the local data directory into the local SPARQL endpoint
     """
-    # TODO refactor to use the local files directly
-    for f in (Path(__file__).parent / "reference_data/profiles").glob("*.ttl"):
-        prof_bytes = Graph().parse(f).serialize(format="nt", encoding="utf-8")
-        # profiles_bytes = profiles_graph_cache.default_context.serialize(format="nt", encoding="utf-8")
-        store.load(prof_bytes, "application/n-triples")
+    profiles_bytes = profiles_graph_cache.serialize(format="nt", encoding="utf-8")
+    store.load(profiles_bytes, "application/n-triples")
 
     endpoints_bytes = endpoints_graph_cache.serialize(format="nt", encoding="utf-8")
     store.load(endpoints_bytes, "application/n-triples")

--- a/prez/reference_data/endpoints/data_endpoints_default/default_endpoints.ttl
+++ b/prez/reference_data/endpoints/data_endpoints_default/default_endpoints.ttl
@@ -37,19 +37,17 @@ ex:items-listing a ont:DynamicEndpoint,
     rdfs:label "Items Listing" ;
     ont:apiPath "/catalogs/{catalogId}/collections/{recordsCollectionId}/items" ;
     ont:relevantShapes ex:shape-R0-HL3,
-        ex:shape-R0-HL3-1,
-        ex:shape-R0-HL3-2 .
+        ex:shape-R0-HL3-1 .
 
 ex:items-object a ont:DynamicEndpoint,
         ont:ObjectEndpoint ;
     rdfs:label "Items Object" ;
     ont:apiPath "/catalogs/{catalogId}/collections/{recordsCollectionId}/items/{itemId}" ;
     ont:relevantShapes ex:shape-R0-HL3,
-        ex:shape-R0-HL3-1,
-        ex:shape-R0-HL3-2 .
+        ex:shape-R0-HL3-1 .
 
 ex:shape-R0-HL1 a sh:NodeShape ;
-    sh:property [ sh:or ( [ sh:class skos:Collection ] [ sh:class dcat:Dataset ] [ sh:class skos:ConceptScheme ] ) ;
+    sh:property [ sh:or ( [ sh:class skos:Collection ] [ sh:class dcat:Dataset ] [ sh:class dcat:Resource ] [ sh:class skos:ConceptScheme ] ) ;
             sh:path dcterms:hasPart ] ;
     sh:targetClass dcat:Catalog ;
     ont:hierarchyLevel 1 .
@@ -59,7 +57,8 @@ ex:shape-R0-HL2 a sh:NodeShape ;
             sh:path [ sh:inversePath dcterms:hasPart ] ] ;
     sh:targetClass skos:Collection,
         skos:ConceptScheme,
-        dcat:Dataset ;
+        dcat:Dataset ,
+        dcat:Resource ;
     ont:hierarchyLevel 2 .
 
 ex:shape-R0-HL3 a sh:NodeShape ;
@@ -77,12 +76,3 @@ ex:shape-R0-HL3-1 a sh:NodeShape ;
             sh:path ( [ sh:inversePath skos:member ] [ sh:inversePath dcterms:hasPart ] ) ] ;
     sh:targetClass skos:Concept ;
     ont:hierarchyLevel 3 .
-
-ex:shape-R0-HL3-2 a sh:NodeShape ;
-    sh:property [ sh:class dcat:Dataset ;
-            sh:path [ sh:inversePath dcterms:hasPart ] ],
-        [ sh:class dcat:Catalog ;
-            sh:path ( [ sh:inversePath dcterms:hasPart ] [ sh:inversePath dcterms:hasPart ] ) ] ;
-    sh:targetClass dcat:Resource ;
-    ont:hierarchyLevel 3 .
-

--- a/test_data/catprez.ttl
+++ b/test_data/catprez.ttl
@@ -6,34 +6,22 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 ex:CatalogOne a dcat:Catalog ;
     rdfs:label "Catalog One" ;
-    dcterms:hasPart ex:DCATDataset ;
+    dcterms:hasPart ex:DCATResource ;
     ex:property "Catalog property" ;
 .
 
-ex:DCATDataset a dcat:Dataset ;
+ex:DCATResource a dcat:Resource ;
     rdfs:label "DCAT Resource" ;
-    dcterms:hasPart ex:RDFResource ;
     ex:property "DCAT Resource property"
-.
-
-ex:RDFResource a rdf:Resource ;
-    rdfs:label "RDF Resource" ;
-    ex:property "RDF resource property" ;
 .
 
 ex:CatalogTwo a dcat:Catalog ;
     rdfs:label "amazing catalog" ;
-    dcterms:hasPart ex:DCATDatasetTwo ;
+    dcterms:hasPart ex:DCATResourceTwo ;
     ex:property "complete" ;
 .
 
-ex:DCATDatasetTwo a dcat:Dataset ;
+ex:DCATResourceTwo a dcat:Resource ;
     rdfs:label "rightful" ;
-    dcterms:hasPart ex:RDFResourceTwo ;
     ex:property "exposure"
-.
-
-ex:RDFResourceTwo a rdf:Resource ;
-    rdfs:label "salty" ;
-    ex:property "proficient" ;
 .

--- a/tests/test_endpoints_catprez.py
+++ b/tests/test_endpoints_catprez.py
@@ -34,8 +34,8 @@ def test_lower_level_listing_anot(client, a_catprez_catalog_link):
     r = client.get(f"{a_catprez_catalog_link}/collections?_mediatype=text/turtle")
     response_graph = Graph().parse(data=r.text)
     expected_response = (
-        URIRef("https://example.com/DCATDataset"),
+        URIRef("https://example.com/DCATResource"),
         RDF.type,
-        DCAT.Dataset,
+        DCAT.Resource,
     )
     assert next(response_graph.triples(expected_response))

--- a/tests/test_node_selection_shacl.py
+++ b/tests/test_node_selection_shacl.py
@@ -27,13 +27,14 @@ def test_nodeshape_parsing(nodeshape_uri):
         URIRef("http://www.w3.org/2004/02/skos/core#Collection"),
         URIRef("http://www.w3.org/2004/02/skos/core#ConceptScheme"),
         URIRef("http://www.w3.org/ns/dcat#Dataset"),
+        URIRef("http://www.w3.org/ns/dcat#Resource"),
     ]
     assert len(ns.propertyShapesURIs) == 1
 
 
 @pytest.mark.parametrize(
     "nodeshape_uri",
-    ["http://example.org/shape-R0-HL3-2"],
+    ["http://example.org/shape-R0-HL3-1"],
 )
 def test_nodeshape_to_grammar(nodeshape_uri):
     ns = NodeShape(


### PR DESCRIPTION
Updates Catalog hierarchy to dcat:Catalog / dcat:Resource. Retains dcat:Catalog / dcat:Dataset which is the "parent" of geo:FeatureCollections in "spaceprez".
Bugfix for remote profiles not being loaded to the system (pyoxigraph) store.