### PR TITLE
David/ogc features bugfixes

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -28,7 +28,7 @@ from prez.exceptions.model_exceptions import (
     URINotFoundException,
     NoProfilesException,
     InvalidSPARQLQueryException,
-    PrefixNotFoundException,
+    PrefixNotFoundException, NoEndpointNodeshapeException,
 )
 from prez.repositories import RemoteSparqlRepo, PyoxigraphRepo, OxrdflibRepo
 from prez.routers.custom_endpoints import create_dynamic_router
@@ -54,7 +54,7 @@ from prez.services.exception_catchers import (
     catch_uri_not_found_exception,
     catch_no_profiles_exception,
     catch_invalid_sparql_query,
-    catch_prefix_not_found_exception,
+    catch_prefix_not_found_exception, catch_no_endpoint_nodeshape_exception,
 )
 from prez.services.generate_profiles import create_profiles_graph
 from prez.services.prez_logging import setup_logger
@@ -174,6 +174,7 @@ def assemble_app(
             PrefixNotFoundException: catch_prefix_not_found_exception,
             NoProfilesException: catch_no_profiles_exception,
             InvalidSPARQLQueryException: catch_invalid_sparql_query,
+            NoEndpointNodeshapeException: catch_no_endpoint_nodeshape_exception,
         },
         **kwargs
     )

--- a/prez/app.py
+++ b/prez/app.py
@@ -189,7 +189,7 @@ def assemble_app(
         app.mount("/static", StaticFiles(directory=Path(__file__).parent / "static"), name="static")
     if _settings.enable_ogc_features:
         app.mount(
-            "/catalogs/{catalogId}/collections/{recordsCollectionId}/features",
+            _settings.ogc_features_mount_path,
             features_subapi,
         )
     app.include_router(base_prez_router)

--- a/prez/config.py
+++ b/prez/config.py
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
     ]
     enable_sparql_endpoint: bool = False
     enable_ogc_features: bool = True
+    ogc_features_mount_path: str = "/catalogs/{catalogId}/collections/{recordsCollectionId}/features"
     custom_endpoints: bool = False
     configuration_mode: bool = False
     temporal_predicate: Optional[URIRef] = SDO.temporal

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -24,6 +24,7 @@ from prez.enums import (
     JSONMediaType,
     GeoJSONMediaType,
 )
+from prez.exceptions.model_exceptions import NoEndpointNodeshapeException
 from prez.models.query_params import QueryParams
 from prez.reference_data.prez_ns import ALTREXT, ONT, EP, OGCE, OGCFEAT
 from prez.repositories import PyoxigraphRepo, RemoteSparqlRepo, OxrdflibRepo, Repo
@@ -402,10 +403,7 @@ async def get_endpoint_nodeshapes(
         )
         return ns
     else:
-        raise ValueError(
-            f"No relevant nodeshape found for the given endpoint {ep_uri}, hierarchy level "
-            f"{hierarchy_level}, and parent URI"
-        )
+        raise NoEndpointNodeshapeException(ep_uri, hierarchy_level)
 
 
 async def get_negotiated_pmts(

--- a/prez/exceptions/model_exceptions.py
+++ b/prez/exceptions/model_exceptions.py
@@ -57,3 +57,17 @@ class InvalidSPARQLQueryException(Exception):
     def __init__(self, error: str):
         self.message = f"Invalid SPARQL query: {error}"
         super().__init__(self.message)
+
+
+class NoEndpointNodeshapeException(Exception):
+    """
+    Raised when no endpoint nodeshape can be identified for the given classes/relations.
+    """
+
+    def __init__(self, ep_uri: str, hierarchy_level: int):
+        self.message = (
+            f"No relevant nodeshape found for the given endpoint {ep_uri}, hierarchy level "
+            f"{hierarchy_level}, and parent URI"
+        )
+        super().__init__(self.message)
+

--- a/prez/reference_data/endpoints/features/features_metadata.ttl
+++ b/prez/reference_data/endpoints/features/features_metadata.ttl
@@ -27,10 +27,10 @@ ogcfeat:feature
 
 ogcfeat:queryables-global
     a ont:ListingEndpoint ;
-    ont:relevantShapes ex:FeatureCollections ;
+    ont:relevantShapes ex:QueryablesGlobal ;
 .
 
 ogcfeat:queryables-local
     a ont:ListingEndpoint ;
-    ont:relevantShapes ex:Feature ;
+    ont:relevantShapes ex:QueryablesLocal ;
 .

--- a/prez/reference_data/endpoints/features/features_nodeshapes.ttl
+++ b/prez/reference_data/endpoints/features/features_nodeshapes.ttl
@@ -15,7 +15,7 @@ ex:FeatureCollections
     sh:property [ sh:path  void:inDataset ;
                 sh:class dcat:Dataset ; ] ;
     sh:targetClass geo:FeatureCollection ;
-    ont:hierarchyLevel 3 .
+    ont:hierarchyLevel 1 .
 
 ex:Feature
     a                  sh:NodeShape ;
@@ -24,14 +24,20 @@ ex:Feature
     sh:property        [ sh:class dcat:Dataset ;
                         sh:path ( [ sh:inversePath rdfs:member ] void:inDataset ) ] ;
     sh:targetClass     geo:Feature ;
-    ont:hierarchyLevel 4 .
+    ont:hierarchyLevel 2 .
 
 ex:Object
     a                  sh:NodeShape ;
-    ont:hierarchyLevel 3 .
+    ont:hierarchyLevel 1 .
 
-ex:Queryables
+ex:QueryablesGlobal
     a sh:NodeShape ;
     sh:targetClass prez:Queryable ;
-    ont:hierarchyLevel 3 , 5
+    ont:hierarchyLevel 1 ;
+.
+
+ex:QueryablesLocal
+    a sh:NodeShape ;
+    sh:targetClass prez:Queryable ;
+    ont:hierarchyLevel 2 ;
 .

--- a/prez/routers/ogc_features_router.py
+++ b/prez/routers/ogc_features_router.py
@@ -25,7 +25,7 @@ from prez.exceptions.model_exceptions import (
     URINotFoundException,
     InvalidSPARQLQueryException,
     PrefixNotFoundException,
-    NoProfilesException,
+    NoProfilesException, NoEndpointNodeshapeException,
 )
 from prez.models.ogc_features import generate_landing_page_links, OGCFeaturesLandingPage
 from prez.models.query_params import QueryParams
@@ -41,7 +41,7 @@ from prez.services.exception_catchers import (
     catch_uri_not_found_exception,
     catch_invalid_sparql_query,
     catch_prefix_not_found_exception,
-    catch_no_profiles_exception,
+    catch_no_profiles_exception, catch_no_endpoint_nodeshape_exception,
 )
 from prez.services.listings import ogc_features_listing_function, generate_link_headers
 from prez.services.objects import ogc_features_object_function
@@ -61,6 +61,7 @@ features_subapi = FastAPI(
         URINotFoundException: catch_uri_not_found_exception,
         PrefixNotFoundException: catch_prefix_not_found_exception,
         InvalidSPARQLQueryException: catch_invalid_sparql_query,
+        NoEndpointNodeshapeException: catch_no_endpoint_nodeshape_exception,
     },
 )
 features_subapi.include_router(conformance_router)

--- a/prez/services/exception_catchers.py
+++ b/prez/services/exception_catchers.py
@@ -7,7 +7,7 @@ from prez.exceptions.model_exceptions import (
     URINotFoundException,
     NoProfilesException,
     InvalidSPARQLQueryException,
-    PrefixNotFoundException,
+    PrefixNotFoundException, NoEndpointNodeshapeException,
 )
 
 
@@ -69,6 +69,18 @@ async def catch_no_profiles_exception(request: Request, exc: NoProfilesException
 
 async def catch_invalid_sparql_query(
     request: Request, exc: InvalidSPARQLQueryException
+):
+    return JSONResponse(
+        status_code=400,
+        content={
+            "error": "Bad Request",
+            "detail": exc.message,
+        },
+    )
+
+
+async def catch_no_endpoint_nodeshape_exception(
+    request: Request, exc: NoEndpointNodeshapeException
 ):
     return JSONResponse(
         status_code=400,

--- a/prez/services/query_generation/cql.py
+++ b/prez/services/query_generation/cql.py
@@ -217,6 +217,8 @@ class CQLParser:
         if not val:  # then should be an IRI
             val = args[1].get("@id")
             value = IRI(value=val)
+        elif val.startswith("http"):  # hack
+            value = IRI(value=val)
         elif isinstance(val, str):  # literal string
             value = RDFLiteral(value=val)
         elif isinstance(val, (int, float)):  # literal numeric


### PR DESCRIPTION
CQL property value filtering assumes URI if starts with http/https.

Add dynamic mount path for OGC Features API; including dynamically modifying hierarchy level of OGC Features endpoints based on where it is mounted.

The latter is required for the MERIT API in BDR such that it can be mounted at e.g. /features