### PR TITLE
Only retrieve remote Prez profiles; count query bug; annotation performance

### DIFF
--- a/prez/reference_data/profiles/ogc_features.ttl
+++ b/prez/reference_data/profiles/ogc_features.ttl
@@ -9,7 +9,7 @@
 @prefix shext: <http://example.com/shacl-extension#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-prez:OGCFeaturesProfile a prof:Profile ;
+prez:OGCFeaturesProfile a prof:Profile , prez:IndexProfile ;
     dcterms:description "A system profile for OGC Features conformant API" ;
     dcterms:identifier "ogcfeat"^^xsd:token ;
     dcterms:title "OGC Features Profile" ;

--- a/prez/reference_data/profiles/ogc_records_profile.ttl
+++ b/prez/reference_data/profiles/ogc_records_profile.ttl
@@ -16,7 +16,7 @@ PREFIX shext: <http://example.com/shacl-extension#>
 
 
 prez:OGCRecordsProfile
-    a prof:Profile ;
+    a prof:Profile , prez:IndexProfile ;
     dcterms:identifier "ogc"^^xsd:token ;
     dcterms:description "A system profile for OGC Records conformant API" ;
     dcterms:title "OGC Profile" ;
@@ -57,8 +57,7 @@ prez:OGCRecordsProfile
             sh:targetClass
                 dcat:Catalog,
                 dcat:Resource,
-                skos:Concept
-            ,
+                skos:Concept ,
                 skos:Collection,
                 rdf:Resource ;
             altr-ext:hasDefaultProfile prez:OGCItemProfile

--- a/prez/reference_data/profiles/prez_default_profiles.ttl
+++ b/prez/reference_data/profiles/prez_default_profiles.ttl
@@ -16,7 +16,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 
 <https://prez.dev/profile/prez>
-    a prof:Profile ;
+    a prof:Profile , prez:IndexProfile ;
     dcterms:identifier "prez"^^xsd:token ;
     dcterms:description "A profile for the Prez Linked Data API" ;
     dcterms:title "Prez profile" ;

--- a/prez/services/annotations.py
+++ b/prez/services/annotations.py
@@ -100,7 +100,10 @@ async def process_uncached_terms(
         rdf_queries=[annotations_query], tabular_queries=[]
     )
 
-    all_results = context_results[0] + repo_results[0] + system_results[0]
+    all_results = Graph()
+    all_results += context_results[0]
+    all_results += repo_results[0]
+    all_results += system_results[0]
 
     # Initialize subjects_map with each term having an empty set to start with
     subjects_map = {term: set() for term in terms}

--- a/prez/services/generate_profiles.py
+++ b/prez/services/generate_profiles.py
@@ -18,35 +18,12 @@ async def create_profiles_graph(repo) -> Graph:
         profiles_graph_cache.parse(f)
     log.info("Prez default profiles loaded")
     remote_profiles_query = """
-        PREFIX dcat: <http://www.w3.org/ns/dcat#>
-        PREFIX geo: <http://www.opengis.net/ont/geosparql#>
         PREFIX prof: <http://www.w3.org/ns/dx/prof/>
-        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-
-        CONSTRUCT {?s ?p ?o .
-                    ?o ?p2 ?o2 .
-                    ?o2 ?p3 ?o3 .
-                    ?class ?cp ?co}
-        WHERE {?s a prof:Profile ;
-                      ?p ?o
-          OPTIONAL {?o ?p2 ?o2
-            FILTER(ISBLANK(?o))
-            OPTIONAL {?o2 ?p3 ?o3
-            FILTER(ISBLANK(?o2))}
-          }
-          OPTIONAL {
-            ?class rdfs:subClassOf dcat:Resource ;
-                ?cp ?co .
-          }
-          OPTIONAL {
-            ?class rdfs:subClassOf geo:Feature ;
-                ?cp ?co .
-          }
-          OPTIONAL {
-            ?class rdfs:subClassOf skos:Concept ;
-                ?cp ?co .
-          }
+        PREFIX prez: <https://prez.dev/>
+        
+        DESCRIBE ?prof {
+            VALUES ?prof_class { prez:ListingProfile prez:ObjectProfile prez:IndexProfile }
+            ?prof a ?prof_class
         }
         """
     g, _ = await repo.send_queries([remote_profiles_query], [])

--- a/prez/services/query_generation/count.py
+++ b/prez/services/query_generation/count.py
@@ -48,9 +48,9 @@ class CountQuery(ConstructQuery):
     }
     WHERE {
       {
-        SELECT (COUNT(DISTINCT ?focus_node) AS ?count)
+        SELECT (COUNT(?focus_node) AS ?count)
         WHERE {
-          SELECT ?focus_node
+          SELECT DISTINCT ?focus_node
           WHERE {
             <<< original where clause >>>
           } LIMIT 101
@@ -64,7 +64,10 @@ class CountQuery(ConstructQuery):
         limit = settings.listing_count_limit
         limit_plus_one = limit + 1
         inner_ss = SubSelect(
-            select_clause=SelectClause(variables_or_all=[Var(value="focus_node")]),
+            select_clause=SelectClause(
+                variables_or_all=[Var(value="focus_node")],
+                distinct=True,
+            ),
             where_clause=original_subselect.where_clause,
             solution_modifier=SolutionModifier(
                 limit_offset=LimitOffsetClauses(
@@ -78,7 +81,6 @@ class CountQuery(ConstructQuery):
                 content=BuiltInCall(
                     other_expressions=Aggregate(
                         function_name="COUNT",
-                        distinct=True,
                         expression=Expression.from_primary_expression(
                             PrimaryExpression(content=Var(value="focus_node"))
                         ),


### PR DESCRIPTION
1. Ensure only prez related profiles are loaded from remote stores by updating the profile selection query
2. Type profiles used to declare default profiles as prez:IndexProfiles. This makes 1 easier
3. Fix count query bug. Counts could previously be wrong in some instances - moved DISTINCT to correct place.
4. Improve performance of annotations retrieval. Identified slow code and changed to a faster implementation.