### PR TITLE
extend default search predicates

### DIFF
--- a/prez/config.py
+++ b/prez/config.py
@@ -54,6 +54,8 @@ class Settings(BaseSettings):
     search_predicates: list = [
         RDFS.label,
         SKOS.prefLabel,
+        SKOS.altLabel,
+        SKOS.hiddenLabel,
         SDO.name,
         DCTERMS.title,
     ]


### PR DESCRIPTION
extended to include alt and hidden labels as per the recommendation in
#282
