### PR TITLE
feat: add "subscription-key" as query parameter, to support Azure and…

### DIFF
--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -599,6 +599,7 @@ async def check_unknown_params(request: Request):
         "filter",
         "order_by",
         "order_by_direction",
+        "subscription-key",
     }
     unknown_params = set(request.query_params.keys()) - known_params
     if unknown_params:

--- a/prez/models/query_params.py
+++ b/prez/models/query_params.py
@@ -160,6 +160,11 @@ class QueryParams:
             default=None,
             description="Optional: Order direction, must be 'ASC' or 'DESC'",
         ),
+        subscription_key: str = Query(
+            default=None,
+            description="An optional API Subscription key",
+            alias="subscription-key",
+        ),
     ):
         self.q = q
         self.page = page
@@ -172,6 +177,7 @@ class QueryParams:
         self.order_by_direction = order_by_direction
         self.filter = filter
         self.mediatype = mediatype
+        self.subscription_key = subscription_key
         self.validate_filter()
 
     def validate_filter(self):


### PR DESCRIPTION
… other APIs that wish to use API keys.