### PR TITLE
ci: migrate from python-semantic-release to semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,11 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,45 +1,35 @@
-name: Continuous Delivery
+name: semantic-release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
-    concurrency: release
-
     permissions:
-      id-token: write
-      contents: write
-
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
-      # Note: we need to checkout the repository at the workflow sha in case during the workflow
-      # the branch was updated. To keep PSR working with the configured release branches,
-      # we force a checkout of the desired release branch but at the workflow sha HEAD.
-      - name: Setup | Checkout Repository at workflow sha
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.sha }}
-
-      - name: Setup | Force correct release branch on workflow sha
-        run: |
-          git checkout -B ${{ github.ref_name }} ${{ github.sha }}
-
-      - name: Action | Semantic Version Release
-        id: release
-        # Adjust tag with desired version if applicable.
-        uses: python-semantic-release/python-semantic-release@v9.11.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_committer_name: "github-actions"
-          git_committer_email: "actions@users.noreply.github.com"
-
-      - name: Publish | Upload to GitHub Release Assets
-        uses: python-semantic-release/publish-action@v9.8.9
-        if: steps.release.outputs.released == 'true'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release.outputs.tag }}
+          node-version: "lts/*"
+      - name: Install dependencies
+        run: npm install -g semantic-release
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,6 @@
+plugins:
+  - '@semantic-release/commit-analyzer':
+    preset:
+      "angular"
+  - '@semantic-release/release-notes-generator'
+  - '@semantic-release/github'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,6 @@ line-length = 88
 [tool.isort]
 profile = "black"
 
-[tool.semantic_release]
-version_toml = ["pyproject.toml:tool.poetry.version"]
-
 [pytest]
 pythonpath = ["prez"]
 testpaths = ["tests"]


### PR DESCRIPTION
Python semantic release was only used to auto update the version
variable in pyproject.toml, but this does not work with branch
protection rules and so is not neccessary anymore. Thus it is better to
use the more common semantic-release action which works with branch
protection rules as it does not need to commit any files as part of the
release.
