### PR TITLE
bugfix: Allow for empty Accept headers. Browsers/Curl/httpx do not by…

### DIFF
--- a/prez/services/objects.py
+++ b/prez/services/objects.py
@@ -84,14 +84,14 @@ async def object_function(
         construct_tss_list=profile_nodeshape.tss_list,
     ).to_string()
 
-    if pmts.requested_mediatypes[0][0] == "application/sparql-query":
+    if pmts.requested_mediatypes and (pmts.requested_mediatypes[0][0] == "application/sparql-query"):
         return PlainTextResponse(query, media_type="application/sparql-query")
     query_start_time = time.time()
     item_graph, _ = await data_repo.send_queries([query], [])
     log.debug(f"Query time: {time.time() - query_start_time}")
     if settings.prez_ui_url:
         # If HTML or no specific media type requested
-        if pmts.requested_mediatypes[0][0] in ("text/html", "*/*"):
+        if pmts.requested_mediatypes and (pmts.requested_mediatypes[0][0] in ("text/html", "*/*")):
             item_uri = URIRef(profile_nodeshape.focus_node.value)
             await add_prez_links(item_graph, data_repo, endpoint_structure, [item_uri])
             prez_link = item_graph.value(

--- a/tests/test_endpoints_catprez.py
+++ b/tests/test_endpoints_catprez.py
@@ -30,6 +30,11 @@ def test_catalog_anot(client, a_catprez_catalog_link):
     assert next(response_graph.triples(expected_response))
 
 
+def test_catalog_no_mediatype(client, a_catprez_catalog_link):
+    r = client.get(f"{a_catprez_catalog_link}", headers={"Accept": ""})
+    assert r.status_code == 200
+
+
 def test_lower_level_listing_anot(client, a_catprez_catalog_link):
     r = client.get(f"{a_catprez_catalog_link}/collections?_mediatype=text/turtle")
     response_graph = Graph().parse(data=r.text)


### PR DESCRIPTION
… default supply empty Accept headers, postman/hopscotch etc. do.