### PR TITLE
feat: allow multiple template SPARQL queries for an object/item endpo…

### DIFF
--- a/README-Dev.md
+++ b/README-Dev.md
@@ -687,7 +687,7 @@ PREFIX prez: <https://prez.dev/ont/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 INSERT DATA { GRAPH <https://prez/system> {
     [ a prez:TemplateQuery ;
-        rdf:value """<template_query>
+        rdf:value """<template_queries>
 """ ;
         prez:forEndpoint "http://www.opengis.net/ogcapi-features-1/1.0/feature" ;
     ]

--- a/prez/config.py
+++ b/prez/config.py
@@ -88,7 +88,6 @@ class Settings(BaseSettings):
     custom_endpoints: bool = False
     configuration_mode: bool = False
     temporal_predicate: Optional[URIRef] = SDO.temporal
-    endpoint_to_template_query_filename: Optional[Dict[str, str]] = {}
     prez_ui_url: Optional[str] = None
     search_method: SearchMethod = SearchMethod.DEFAULT
     required_header: dict[str, str] | None = None

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -626,24 +626,20 @@ async def get_ogc_features_mediatype(
     return default_mt
 
 
-async def get_template_query(
+async def get_template_queries(
     endpoint_uri_type: tuple[URIRef, URIRef] = Depends(get_endpoint_uri_type),
-):
+) -> list[str] | None:
     endpoint_uri = endpoint_uri_type[0]
-    filename = settings.endpoint_to_template_query_filename.get(str(endpoint_uri))
 
-    # check local files
-    if filename:
-        return (
-            Path(__file__).parent / "reference_data/template_queries" / filename
-        ).read_text()
-
+    template_queries = []
     # check prez_system_graph
     for s in prez_system_graph.subjects(RDF.type, ONT.TemplateQuery):
         endpoint_in_sys_graph = prez_system_graph.value(s, ONT.forEndpoint, None)
         if str(endpoint_uri) == str(endpoint_in_sys_graph):
             template_query = prez_system_graph.value(s, RDF.value, None)
-            return str(template_query)
+            template_queries.append(str(template_query))
+    if template_queries:
+        return template_queries
     return None
 
 

--- a/prez/routers/ogc_features_router.py
+++ b/prez/routers/ogc_features_router.py
@@ -17,7 +17,7 @@ from prez.dependencies import (
     get_ogc_features_path_params,
     get_profile_nodeshape,
     get_system_repo,
-    get_template_query,
+    get_template_queries,
     get_url,
 )
 from prez.exceptions.model_exceptions import (
@@ -190,7 +190,7 @@ async def listings_with_feature_collection(
     openapi_extra=ogc_features_openapi_extras.get("feature"),
 )
 async def objects(
-    template_query: Optional[str] = Depends(get_template_query),
+    template_queries: Optional[str] = Depends(get_template_queries),
     mediatype: str = Depends(get_ogc_features_mediatype),
     url: str = Depends(get_url),
     path_params: dict = Depends(get_ogc_features_path_params),
@@ -199,7 +199,7 @@ async def objects(
 ):
     try:
         content, headers = await ogc_features_object_function(
-            template_query,
+            template_queries,
             mediatype,
             url,
             data_repo,


### PR DESCRIPTION
…int. Remove unused file based template queries - configuration was complicated with having to specify file paths - and not currently used by anyone. Only data repo template queries are now supported.

From dev documentation, to add a template SPARQL query, use the form:

```sparql
PREFIX prez: <https://prez.dev/ont/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
INSERT DATA { GRAPH <https://prez/system> {
    [ a prez:TemplateQuery ;
        rdf:value """<template_queries>""" ;
        prez:forEndpoint "http://www.opengis.net/ogcapi-features-1/1.0/feature" ;
    ]
    }}
```

Prez will now handle multiple literal values for rdf:value and execute all of these queries, returning the graph merge of the result.