### PR TITLE
feat: wildcard inbound properties and performance improvement for blank node selection

### DIFF
--- a/prez/reference_data/profiles/ogc_features.ttl
+++ b/prez/reference_data/profiles/ogc_features.ttl
@@ -54,7 +54,15 @@ prez:OGCFeaturesMinimalProps a
         "text/anot+turtle",
         "text/turtle" ;
     sh:property
-        [ sh:path rdf:type ] ;
+        [ sh:path
+                  (
+                      sh:union (
+                                   rdf:type
+                                   ( [ sh:inversePath rdfs:member ] rdf:type )
+                                   ( [ sh:inversePath rdfs:member ] [ sh:inversePath dcterms:isPartOf ] )
+                               )
+                  )
+        ] ;
 .
 
 prez:OGCFeaturesAllProps a
@@ -83,12 +91,14 @@ prez:OGCFeaturesAllProps a
     sh:property [
         sh:path (
             sh:union (
+                     [ shext:bNodeDepth "2" ]
                      shext:allPredicateValues
                      ( geo:hasGeometry geo:asWKT )
+                     ( [ sh:inversePath rdfs:member ] rdf:type )
+                     ( [ sh:inversePath rdfs:member ] [ sh:inversePath dcterms:isPartOf ] )
                    )
           )
         ] ;
-    shext:bnode-depth 2 ;
 .
 
 

--- a/prez/reference_data/profiles/ogc_features.ttl
+++ b/prez/reference_data/profiles/ogc_features.ttl
@@ -59,7 +59,7 @@ prez:OGCFeaturesMinimalProps a
                       sh:union (
                                    rdf:type
                                    ( [ sh:inversePath rdfs:member ] rdf:type )
-                                   ( [ sh:inversePath rdfs:member ] [ sh:inversePath dcterms:isPartOf ] )
+                                   ( [ sh:inversePath rdfs:member ] dcterms:isPartOf )
                                )
                   )
         ] ;
@@ -95,7 +95,7 @@ prez:OGCFeaturesAllProps a
                      shext:allPredicateValues
                      ( geo:hasGeometry geo:asWKT )
                      ( [ sh:inversePath rdfs:member ] rdf:type )
-                     ( [ sh:inversePath rdfs:member ] [ sh:inversePath dcterms:isPartOf ] )
+                     ( [ sh:inversePath rdfs:member ] dcterms:isPartOf )
                    )
           )
         ] ;

--- a/prez/reference_data/profiles/ogc_records_profile.ttl
+++ b/prez/reference_data/profiles/ogc_records_profile.ttl
@@ -105,13 +105,18 @@ prez:OGCItemProfile
     altr-ext:hasDefaultResourceFormat "text/anot+turtle" ;
     sh:property
         [
-            sh:path shext:allPredicateValues ;
+            sh:path
+                (
+                    sh:union (
+                                 [ shext:bNodeDepth "2" ]
+                                 shext:allPredicateValues
+                             )
+                )
         ],
         [
             sh:maxCount 0 ;
             sh:path dcterms:hasPart , rdfs:member , skos:member ;
         ] ;
-    shext:bnode-depth 2 ;
     altr-ext:constrainsClass
         dcat:Dataset,
         dcat:Catalog,
@@ -166,11 +171,16 @@ prez:OGCSchemesObjectProfile
     altr-ext:constrainsClass skos:ConceptScheme ;
     sh:property
         [
-            sh:path shext:allPredicateValues
+            sh:path
+                (
+                    sh:union (
+                                 [ shext:bNodeDepth "2" ]
+                                 shext:allPredicateValues
+                             )
+                )
         ],
         [
             sh:maxCount 0 ;
             sh:path skos:hasTopConcept ;
         ] ;
-    shext:bnode-depth 2 ;
 .

--- a/prez/reference_data/profiles/prez_default_profiles.ttl
+++ b/prez/reference_data/profiles/prez_default_profiles.ttl
@@ -55,10 +55,16 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "application/rdf+xml" ,
         "text/anot+turtle" ,
         "text/turtle" ;
-    sh:property [
-        sh:path shext:allPredicateValues ;
-    ] ;
-    shext:bnode-depth 2 ;
+    sh:property
+        [
+            sh:path
+                (
+                    sh:union (
+                                 [ shext:bNodeDepth "2" ]
+                                 shext:allPredicateValues
+                             )
+                )
+        ] ;
     .
 
 
@@ -80,10 +86,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         sh:targetClass rdfs:Resource ;
         altr-ext:hasDefaultProfile <https://prez.dev/profile/cqlgeo>
     ] ;
-    shext:bnode-depth 2 ;
     sh:property [
         sh:path (
             sh:union (
+             [ shext:bNodeDepth "2" ]
               shext:allPredicateValues
               ( geo:hasGeometry geo:asWKT )
             )
@@ -172,6 +178,7 @@ altr-ext:alt-profile
         sh:property [
         sh:path (
                     sh:union (
+                            [ shext:bNodeDepth "25" ]
                             rdf:type
                             altr-ext:hasResourceFormat
                             altr-ext:hasDefaultResourceFormat
@@ -181,5 +188,4 @@ altr-ext:alt-profile
                     )
                 )
     ] ;
-    shext:bnode-depth 20 ;
     .

--- a/prez/renderers/renderer.py
+++ b/prez/renderers/renderer.py
@@ -193,22 +193,6 @@ async def generate_geojson_extras(
     return link_headers, geojson
 
 
-def _add_inbound_triple_pattern_match(construct_tss_list):
-    triple = (Var(value="inbound_s"), Var(value="inbound_p"), Var(value="focus_node"))
-    construct_tss_list.append(TriplesSameSubject.from_spo(*triple))
-    inbound_tssp_list = [TriplesSameSubjectPath.from_spo(*triple)]
-    opt_inbound_gpnt = GraphPatternNotTriples(
-        content=OptionalGraphPattern(
-            group_graph_pattern=GroupGraphPattern(
-                content=GroupGraphPatternSub(
-                    triples_block=TriplesBlock.from_tssp_list(inbound_tssp_list)
-                )
-            )
-        )
-    )
-    return opt_inbound_gpnt
-
-
 def create_collections_json(
     item_graph, annotations_graph, url, selected_mediatype, query_params, count: str
 ):

--- a/prez/services/query_generation/shacl.py
+++ b/prez/services/query_generation/shacl.py
@@ -683,20 +683,19 @@ class PropertyShape(Shape):
             )
 
             # Add the next triple in the chain (except for the first one which was already added)
-            if depth > 1:
-                all_triples.append(
-                    (
-                        Var(value=f"bn_o_{depth - 1}"),
-                        Var(value=f"bn_p_{depth}"),
-                        Var(value=f"bn_o_{depth}"),
-                    )
+            all_triples.append(
+                (
+                    Var(value=f"bn_o_{depth}"),
+                    Var(value=f"bn_p_{depth + 1}"),
+                    Var(value=f"bn_o_{depth + 1}"),
                 )
+            )
 
         # Create Triples Same Subject Path for WHERE clause
-        tssp_list = [TriplesSameSubjectPath.from_spo(*triple) for triple in all_triples]
+        tssp_list = [TriplesSameSubjectPath.from_spo(*triple) for triple in all_triples[::-1]]
 
         # Create Triples Same Subject for CONSTRUCT TRIPLES clause
-        tss_list = [TriplesSameSubject.from_spo(*triple) for triple in all_triples]
+        tss_list = [TriplesSameSubject.from_spo(*triple) for triple in all_triples[::-1]]
         self.tss_list.extend(tss_list)
 
         # Create the group graph pattern with all triples and filters

--- a/tests/test_property_selection_shacl.py
+++ b/tests/test_property_selection_shacl.py
@@ -27,12 +27,12 @@ def test_simple_path():
         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
     )
     assert (
-        TriplesSameSubjectPath.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=IRI(value=RDF.type),
-            object=Var(value="prof_1_node_1"),
-        )
-        in ps.tssp_list
+            TriplesSameSubjectPath.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=IRI(value=RDF.type),
+                object=Var(value="prof_1_node_1"),
+            )
+            in ps.tssp_list
     )
 
 
@@ -50,20 +50,20 @@ def test_sequence_path():
         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
     )
     assert (
-        TriplesSameSubjectPath.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=IRI(value=PROV.qualifiedDerivation),
-            object=Var(value="prof_1_node_1"),
-        )
-        in ps.tssp_list
+            TriplesSameSubjectPath.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=IRI(value=PROV.qualifiedDerivation),
+                object=Var(value="prof_1_node_1"),
+            )
+            in ps.tssp_list
     )
     assert (
-        TriplesSameSubjectPath.from_spo(
-            subject=Var(value="prof_1_node_1"),
-            predicate=IRI(value=PROV.hadRole),
-            object=Var(value="prof_1_node_2"),
-        )
-        in ps.tssp_list
+            TriplesSameSubjectPath.from_spo(
+                subject=Var(value="prof_1_node_1"),
+                predicate=IRI(value=PROV.hadRole),
+                object=Var(value="prof_1_node_2"),
+            )
+            in ps.tssp_list
     )
 
 
@@ -94,52 +94,52 @@ def test_union():
         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
     )
     assert (
-        TriplesSameSubject.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=IRI(value=PROV.qualifiedDerivation),
-            object=Var(value="prof_1_node_3"),
-        )
-        in ps.tss_list
+            TriplesSameSubject.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=IRI(value=PROV.qualifiedDerivation),
+                object=Var(value="prof_1_node_3"),
+            )
+            in ps.tss_list
     )
     assert (
-        TriplesSameSubject.from_spo(
-            subject=Var(value="prof_1_node_3"),
-            predicate=IRI(value=PROV.hadRole),
-            object=Var(value="prof_1_node_4"),
-        )
-        in ps.tss_list
+            TriplesSameSubject.from_spo(
+                subject=Var(value="prof_1_node_3"),
+                predicate=IRI(value=PROV.hadRole),
+                object=Var(value="prof_1_node_4"),
+            )
+            in ps.tss_list
     )
     assert (
-        TriplesSameSubject.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=IRI(value=PROV.qualifiedDerivation),
-            object=Var(value="prof_1_node_5"),
-        )
-        in ps.tss_list
+            TriplesSameSubject.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=IRI(value=PROV.qualifiedDerivation),
+                object=Var(value="prof_1_node_5"),
+            )
+            in ps.tss_list
     )
     assert (
-        TriplesSameSubject.from_spo(
-            subject=Var(value="prof_1_node_5"),
-            predicate=IRI(value=PROV.entity),
-            object=Var(value="prof_1_node_6"),
-        )
-        in ps.tss_list
+            TriplesSameSubject.from_spo(
+                subject=Var(value="prof_1_node_5"),
+                predicate=IRI(value=PROV.entity),
+                object=Var(value="prof_1_node_6"),
+            )
+            in ps.tss_list
     )
     assert (
-        TriplesSameSubject.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=IRI(value=DCTERMS.publisher),
-            object=Var(value="prof_1_node_1"),
-        )
-        in ps.tss_list
+            TriplesSameSubject.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=IRI(value=DCTERMS.publisher),
+                object=Var(value="prof_1_node_1"),
+            )
+            in ps.tss_list
     )
     assert (
-        TriplesSameSubject.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=IRI(value=REG.status),
-            object=Var(value="prof_1_node_2"),
-        )
-        in ps.tss_list
+            TriplesSameSubject.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=IRI(value=REG.status),
+                object=Var(value="prof_1_node_2"),
+            )
+            in ps.tss_list
     )
 
 
@@ -211,12 +211,12 @@ def test_excluded_props():
         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
     )
     assert (
-        TriplesSameSubjectPath.from_spo(
-            subject=Var(value="focus_node"),
-            predicate=Var(value="preds"),
-            object=Var(value="excluded_pred_vals"),
-        )
-        in ps.tssp_list
+            TriplesSameSubjectPath.from_spo(
+                subject=Var(value="focus_node"),
+                predicate=Var(value="preds"),
+                object=Var(value="excluded_pred_vals"),
+            )
+            in ps.tssp_list
     )
     assert isinstance(ps.gpnt_list[0].content, Filter)
 
@@ -225,16 +225,16 @@ def test_excluded_props():
     ["cardinality_type", "expected_result"],
     [
         (
-            "sh:zeroOrMorePath",
-            "?focus_node <http://purl.org/dc/terms/publisher>* ?prof_1_node_1",
+                "sh:zeroOrMorePath",
+                "?focus_node <http://purl.org/dc/terms/publisher>* ?prof_1_node_1",
         ),
         (
-            "sh:oneOrMorePath",
-            "?focus_node <http://purl.org/dc/terms/publisher>+ ?prof_1_node_1",
+                "sh:oneOrMorePath",
+                "?focus_node <http://purl.org/dc/terms/publisher>+ ?prof_1_node_1",
         ),
         (
-            "sh:zeroOrOnePath",
-            "?focus_node <http://purl.org/dc/terms/publisher>? ?prof_1_node_1",
+                "sh:zeroOrOnePath",
+                "?focus_node <http://purl.org/dc/terms/publisher>? ?prof_1_node_1",
         ),
     ],
 )
@@ -256,3 +256,101 @@ def test_cardinality_props(cardinality_type, expected_result):
         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
     )
     assert ps.tssp_list[0].to_string() == expected_result
+
+
+def test_bnode_depth_union():
+    g = Graph().parse(
+        data="""
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX reg: <http://purl.org/linked-data/registry#>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX shext: <http://example.com/shacl-extension#>
+
+    <http://example-profile> sh:property [
+        sh:path (
+            sh:union (
+              [ shext:bNodeDepth "2" ]
+              dcterms:publisher
+            )
+          )
+        ]
+    .
+    """)
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    expected_output = "".join("""
+    {
+        ?focus_node <http://purl.org/dc/terms/publisher> ?prof_1_node_1
+    }
+    UNION
+    {
+        ?focus_node ?bn_p_1 ?bn_o_1
+        FILTER isBLANK(?bn_o_1)
+    }
+    UNION
+    {
+        ?bn_o_1 ?bn_p_2 ?bn_o_2 .
+        ?focus_node ?bn_p_1 ?bn_o_1
+        FILTER isBLANK(?bn_o_1)
+        FILTER isBLANK(?bn_o_2)
+    }""".split())
+    actual_output = "".join(ps.gpnt_list[0].to_string().split())
+    assert actual_output == expected_output
+
+
+def test_bnode_depth_direct():
+    g = Graph().parse(
+        data="""
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX reg: <http://purl.org/linked-data/registry#>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX shext: <http://example.com/shacl-extension#>
+
+    <http://example-profile> sh:property [
+        sh:path [ shext:bNodeDepth "2" ]
+        ]
+    .
+    """)
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    expected_output = "".join("""
+    {
+        ?focus_node ?bn_p_1 ?bn_o_1
+        FILTER isBLANK(?bn_o_1)
+    }
+    UNION
+    {
+        ?bn_o_1 ?bn_p_2 ?bn_o_2 .
+        ?focus_node ?bn_p_1 ?bn_o_1
+        FILTER isBLANK(?bn_o_1)
+        FILTER isBLANK(?bn_o_2)
+    }""".split())
+    actual_output = "".join(ps.gpnt_list[0].to_string().split())
+    assert actual_output == expected_output
+
+
+def test_bnode_depth_profile_depth():
+    g = Graph().parse(
+        data="""
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX reg: <http://purl.org/linked-data/registry#>
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX shext: <http://example.com/shacl-extension#>
+
+    <http://example-profile> sh:property [
+        sh:path [ shext:bNodeDepth "25" ]
+        ]
+    .
+    """)
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    # output is extremely long, just attempt to generate the property shape; syntax is tested in two prior tests.

--- a/tests/test_property_selection_shacl.py
+++ b/tests/test_property_selection_shacl.py
@@ -271,7 +271,6 @@ def test_bnode_depth_union():
         sh:path (
             sh:union (
               [ shext:bNodeDepth "2" ]
-              dcterms:publisher
             )
           )
         ]
@@ -283,17 +282,15 @@ def test_bnode_depth_union():
     )
     expected_output = "".join("""
     {
-        ?focus_node <http://purl.org/dc/terms/publisher> ?prof_1_node_1
-    }
-    UNION
-    {
-        ?focus_node ?bn_p_1 ?bn_o_1
+        ?focus_node ?bn_p_1 ?bn_o_1 .
+        ?bn_o_1 ?bn_p_2 ?bn_o_2
         FILTER isBLANK(?bn_o_1)
     }
     UNION
     {
+        ?focus_node ?bn_p_1 ?bn_o_1 .
         ?bn_o_1 ?bn_p_2 ?bn_o_2 .
-        ?focus_node ?bn_p_1 ?bn_o_1
+        ?bn_o_2 ?bn_p_3 ?bn_o_3
         FILTER isBLANK(?bn_o_1)
         FILTER isBLANK(?bn_o_2)
     }""".split())
@@ -321,13 +318,15 @@ def test_bnode_depth_direct():
     )
     expected_output = "".join("""
     {
-        ?focus_node ?bn_p_1 ?bn_o_1
+        ?focus_node ?bn_p_1 ?bn_o_1 .
+        ?bn_o_1 ?bn_p_2 ?bn_o_2
         FILTER isBLANK(?bn_o_1)
     }
     UNION
     {
+        ?focus_node ?bn_p_1 ?bn_o_1 .
         ?bn_o_1 ?bn_p_2 ?bn_o_2 .
-        ?focus_node ?bn_p_1 ?bn_o_1
+        ?bn_o_2 ?bn_p_3 ?bn_o_3
         FILTER isBLANK(?bn_o_1)
         FILTER isBLANK(?bn_o_2)
     }""".split())


### PR DESCRIPTION
a few performance and functionality updates:
- Within the OGC Features API, for features listing, remove use of second query that retrieved CBD of the parent Feature Collection. This includes removal of the manually included inbound triple patterns. Both inbound patterns and the properties of the parent feature collection can be specified in profiles using sh:inversePath, including via [ sh:inversePath shext:allPredicateValues ] to get all inbound triples to a focus node ( ?inbound_s ?inbound_p ?focus_node ). Sequence paths can be used for specific properties of the parent Feature Collection.
- Modify blank node constructs to be a series of UNION clauses of the form:
```sparql
    {
        ?focus_node ?bn_p_1 ?bn_o_1 .
        ?bn_o_1 ?bn_p_1 ?bn_o_2
        FILTER isBLANK(?bn_o_1)
    }
    UNION
    {
        ?focus_node ?bn_p_1 ?bn_o_1 .
        ?bn_o_1 ?bn_p_1 ?bn_o_2 .
        ?bn_o_2 ?bn_p_2 ?bn_o_3
        FILTER isBLANK(?bn_o_1)
        FILTER isBLANK(?bn_o_2)
    }
```
This has been tested in both GraphDB and Fuseki and is performant in both.

- Blank node depth is now specified as a property path extension, of the form:
```turtle
sh:property [
    sh:path (
        sh:union (
                 [ shext:bNodeDepth "2" ]
                 shext:allPredicateValues
                 ( geo:hasGeometry geo:asWKT )
```
or
```turtle
sh:property [
        sh:path [ shext:bNodeDepth "2" ]
        ]
```
This is a more natural fit for the way they are created/included in the generated queries.