### PR TITLE
fix: change Prez's profiles graph to a Graph rather than a Dataset as…

### DIFF
--- a/prez/cache.py
+++ b/prez/cache.py
@@ -2,7 +2,7 @@ from aiocache import caches
 from pyoxigraph.pyoxigraph import Store
 from rdflib import ConjunctiveGraph, Dataset, Graph
 
-profiles_graph_cache = Dataset()
+profiles_graph_cache = Graph()
 profiles_graph_cache.bind("prez", "https://prez.dev/")
 
 endpoints_graph_cache = ConjunctiveGraph()


### PR DESCRIPTION
… there are differences in querying triples parsed from files vs remote profiles. This is either a bug or inconsistent behaviour in RDFLib not worth investigating as Graph is sufficient.