### PR TITLE
fix: retrieve remote profiles only once

### DIFF
--- a/prez/cache.py
+++ b/prez/cache.py
@@ -2,7 +2,7 @@ from aiocache import caches
 from pyoxigraph.pyoxigraph import Store
 from rdflib import ConjunctiveGraph, Dataset, Graph
 
-profiles_graph_cache = Dataset()
+profiles_graph_cache = Graph()
 profiles_graph_cache.bind("prez", "https://prez.dev/")
 
 endpoints_graph_cache = ConjunctiveGraph()

--- a/prez/services/generate_profiles.py
+++ b/prez/services/generate_profiles.py
@@ -22,8 +22,10 @@ async def create_profiles_graph(repo) -> Graph:
         PREFIX prez: <https://prez.dev/>
 
         DESCRIBE ?prof {
+            SELECT DISTINCT ?prof {
             VALUES ?prof_class { prez:ListingProfile prez:ObjectProfile prez:IndexProfile }
             ?prof a ?prof_class
+            }
         }
         """
     g, _ = await repo.send_queries([remote_profiles_query], [])


### PR DESCRIPTION
Where remote profiles are defined with two classes (e.g. a ListingProfile that is also an ObjectProfile), the existing profile retrieval DESCRIBE incorrectly retrieved triples for the profile twice. a SELECT DISTINCT has been included in the WHERE clause to prevent this.

Self approving as this is a one line change.