### PR TITLE
fix: reduce OGC Features link header length for collections

### DIFF
--- a/prez/renderers/renderer.py
+++ b/prez/renderers/renderer.py
@@ -19,13 +19,6 @@ from rdflib import URIRef
 from rdflib.namespace import GEO, RDF
 from sparql_grammar_pydantic import (
     IRI,
-    GraphPatternNotTriples,
-    GroupGraphPattern,
-    GroupGraphPatternSub,
-    OptionalGraphPattern,
-    TriplesBlock,
-    TriplesSameSubject,
-    TriplesSameSubjectPath,
     Var,
 )
 
@@ -40,7 +33,7 @@ from prez.renderers.csv_renderer import render_csv_dropdown
 from prez.renderers.json_renderer import NotFoundError, render_json_dropdown
 from prez.repositories import Repo
 from prez.services.annotations import get_annotation_properties
-from prez.services.connegp_service import RDF_MEDIATYPES
+from prez.services.connegp_service import RDF_MEDIATYPES, MINIMAL_OGC_FEATURES_RDF_FORMATS
 from prez.services.connegp_service import RDF_SERIALIZER_TYPES_MAP
 from prez.services.curie_functions import get_curie_id_for_uri
 from prez.services.query_generation.shacl import NodeShape
@@ -216,7 +209,7 @@ def create_collections_json(
                         rel="items",
                         type=mt,
                     )
-                    for mt in ["application/geo+json", *RDF_MEDIATYPES]
+                    for mt in ["application/geo+json", *MINIMAL_OGC_FEATURES_RDF_FORMATS]
                 ],
             )
         )

--- a/prez/services/connegp_service.py
+++ b/prez/services/connegp_service.py
@@ -14,6 +14,11 @@ from prez.services.curie_functions import get_curie_id_for_uri, get_uri_for_curi
 
 log = logging.getLogger(__name__)
 
+# used to reduce the amount of RDF formats "advertised" for OGC Features API links
+MINIMAL_OGC_FEATURES_RDF_FORMATS = [
+    "text/turtle"
+]
+
 RDF_MEDIATYPES = [
     "text/turtle",
     "application/rdf+xml",

--- a/prez/services/listings.py
+++ b/prez/services/listings.py
@@ -288,7 +288,9 @@ async def ogc_features_listing_function(
                 count,
             )
             all_links = collections.links
-            for coll in collections.collections:
+            # all_links is used to generate link headers - to minimise the size, only use first 10 feature collections.
+            # this is allowed in the spec: https://docs.ogc.org/is/17-069r4/17-069r4.html#_link_headers
+            for coll in collections.collections[:10]:
                 all_links.extend(coll.links)
             link_headers = generate_link_headers(all_links)
             content = io.BytesIO(


### PR DESCRIPTION
reduce header length in OGC Features API listings (at /features/collections/). Issue should not appear at .../items as the links here are not per item. Reduce number of mediatypes shown at /features/collections/ in order to reduce link header size. NB other RDF mediatypes, including annotated ones, can still be requested/returned using the Accept header or _mediatype query parameter as before.