### PR TITLE
fix: range of sh:path should be blank node not RDF Collection

### DIFF
--- a/prez/reference_data/profiles/ogc_features.ttl
+++ b/prez/reference_data/profiles/ogc_features.ttl
@@ -55,13 +55,13 @@ prez:OGCFeaturesMinimalProps a
         "text/turtle" ;
     sh:property
         [ sh:path
-                  (
+                  [
                       sh:union (
                                    rdf:type
                                    ( [ sh:inversePath rdfs:member ] rdf:type )
                                    ( [ sh:inversePath rdfs:member ] dcterms:isPartOf )
                                )
-                  )
+                  ]
         ] ;
 .
 
@@ -89,7 +89,7 @@ prez:OGCFeaturesAllProps a
         "text/anot+turtle",
         "text/turtle" ;
     sh:property [
-        sh:path (
+        sh:path [
             sh:union (
                      [ shext:bNodeDepth "2" ]
                      shext:allPredicateValues
@@ -97,7 +97,7 @@ prez:OGCFeaturesAllProps a
                      ( [ sh:inversePath rdfs:member ] rdf:type )
                      ( [ sh:inversePath rdfs:member ] dcterms:isPartOf )
                    )
-          )
+          ]
         ] ;
 .
 

--- a/prez/reference_data/profiles/ogc_records_profile.ttl
+++ b/prez/reference_data/profiles/ogc_records_profile.ttl
@@ -106,12 +106,12 @@ prez:OGCItemProfile
     sh:property
         [
             sh:path
-                (
+                [
                     sh:union (
                                  [ shext:bNodeDepth "2" ]
                                  shext:allPredicateValues
                              )
-                )
+                ]
         ],
         [
             sh:maxCount 0 ;
@@ -143,7 +143,7 @@ prez:OGCSchemesListProfile
     altr-ext:hasDefaultResourceFormat "text/anot+turtle" ;
     altr-ext:constrainsClass skos:ConceptScheme ;
     sh:property [
-        sh:path (
+        sh:path [
             sh:union (
                   rdf:type
                   dcterms:publisher
@@ -151,7 +151,7 @@ prez:OGCSchemesListProfile
                   ( prov:qualifiedDerivation prov:hadRole )
                   ( prov:qualifiedDerivation prov:entity )
             )
-        )
+        ]
     ] ;
 .
 
@@ -172,12 +172,12 @@ prez:OGCSchemesObjectProfile
     sh:property
         [
             sh:path
-                (
+                [
                     sh:union (
                                  [ shext:bNodeDepth "2" ]
                                  shext:allPredicateValues
                              )
-                )
+                ]
         ],
         [
             sh:maxCount 0 ;

--- a/prez/reference_data/profiles/prez_default_profiles.ttl
+++ b/prez/reference_data/profiles/prez_default_profiles.ttl
@@ -58,12 +58,12 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sh:property
         [
             sh:path
-                (
+                [
                     sh:union (
                                  [ shext:bNodeDepth "2" ]
                                  shext:allPredicateValues
                              )
-                )
+                ]
         ] ;
     .
 
@@ -87,13 +87,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         altr-ext:hasDefaultProfile <https://prez.dev/profile/cqlgeo>
     ] ;
     sh:property [
-        sh:path (
+        sh:path [
             sh:union (
              [ shext:bNodeDepth "2" ]
               shext:allPredicateValues
               ( geo:hasGeometry geo:asWKT )
             )
-          )
+          ]
         ] ;
     .
 
@@ -148,7 +148,7 @@ altr-ext:alt-profile
         rdf:Resource ,
         prof:Profile ;
     sh:property [
-        sh:path (
+        sh:path [
                     sh:union (
                             rdf:type
                             altr-ext:hasResourceFormat
@@ -157,7 +157,7 @@ altr-ext:alt-profile
                             dcterms:title
                             dcterms:identifier
                     )
-                )
+                ]
     ] ;
 .
 
@@ -176,7 +176,7 @@ altr-ext:alt-profile
     altr-ext:constrainsClass
         prof:Profile ;
         sh:property [
-        sh:path (
+        sh:path [
                     sh:union (
                             [ shext:bNodeDepth "25" ]
                             rdf:type
@@ -186,6 +186,6 @@ altr-ext:alt-profile
                             dcterms:title
                             dcterms:identifier
                     )
-                )
+                ]
     ] ;
     .

--- a/prez/services/link_generation.py
+++ b/prez/services/link_generation.py
@@ -35,10 +35,7 @@ async def add_prez_links(
     # get all URIRefs - if Prez can find a class and endpoint for them, an internal link will be generated.
     if uris is None:
         uris = [uri for uri in graph.all_nodes() if isinstance(uri, URIRef)]
-    uri_to_klasses = {}
     t = time.time()
-    # for uri in uris:
-    #     uri_to_klasses[uri] = await get_classes(uri, repo)
     uri_to_klasses = await get_classes(uris, repo)
     log.debug(f"Time taken to get classes: {time.time() - t}")
 

--- a/prez/services/query_generation/shacl.py
+++ b/prez/services/query_generation/shacl.py
@@ -258,8 +258,8 @@ class PropertyShape(Shape):
 
             bn_pred, bn_obj = pred_objects[0]
 
-            if bn_obj == SH.union:
-                self._process_union(pp, union)
+            if bn_pred == SH.union:
+                self._process_union(bn_obj, union)
             elif bn_pred in PRED_TO_PATH_CLASS:
                 path_class = PRED_TO_PATH_CLASS[bn_pred]
                 if path_class == BNodeDepth:
@@ -271,10 +271,7 @@ class PropertyShape(Shape):
 
     def _process_union(self, pp, union: bool):
         union_list = list(Collection(self.graph, pp))
-        if union_list != [SH.union]:
-            union_list_bnode = union_list[1]
-        union_items = list(Collection(self.graph, union_list_bnode))
-        for item in union_items:
+        for item in union_list:
             self._process_property_path(item, True)
 
     def _process_sequence(self, pp, union: bool):
@@ -413,7 +410,6 @@ class PropertyShape(Shape):
             )
 
         if self.minCount == 0:
-            # triples = self.tssp_list.copy()
             self.gpnt_list.append(
                 GraphPatternNotTriples(
                     content=OptionalGraphPattern(

--- a/tests/test_property_selection_shacl.py
+++ b/tests/test_property_selection_shacl.py
@@ -76,14 +76,14 @@ def test_union():
     PREFIX prov: <http://www.w3.org/ns/prov#>
 
     <http://example-profile> sh:property [
-        sh:path (
+        sh:path [
             sh:union (
               dcterms:publisher
               reg:status
               ( prov:qualifiedDerivation prov:hadRole )
               ( prov:qualifiedDerivation prov:entity )
             )
-          )
+          ]
         ]
     .
 
@@ -268,11 +268,11 @@ def test_bnode_depth_union():
     PREFIX shext: <http://example.com/shacl-extension#>
 
     <http://example-profile> sh:property [
-        sh:path (
+        sh:path [
             sh:union (
               [ shext:bNodeDepth "2" ]
             )
-          )
+          ]
         ]
     .
     """)


### PR DESCRIPTION
Shacl path should have a bnode as it's range not an RDF Collection. This is a basic error/typo that has been present for some time and somehow not caused issues until now (potentially due to default RDF ordering in RDFLib). Using an RDF Collection meant that one of either the union of property paths OR the shacl:union property itself were processed, potentially RDFLib typically ordered these internally in such a way that the list and not sh:union was processed. Olis seems to have disrupted this. In any case, use of an RDF Collection is wrong.

The following two changes have been made:
1. Fix the processing of sh:union statements, these were the only thing specified off of RDF Collections from sh:path
2. Fix the relevant profiles to use blank nodes instead of RDF Collections ( "(" -> "[" )