### PR TITLE
fix: get RDF format from response and fall bak to n-triples

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -136,7 +136,7 @@ prez:OGCRecordsProfile
     altr-ext:hasNodeShape [
         a sh:NodeShape ;
         sh:targetClass prof:Profile , dcat:Catalog , dcat:Resource , skos:Concept , geo:Feature , geo:FeatureCollection
-                               , skos:Collection , rdf:Resource , prez:SearchResult , prez:CQLObjectList ;
+                               , skos:Collection , rdf:Resource , prez:SearchResult , prez:CQLFilterResult ;
         altr-ext:hasDefaultProfile prez:OGCListingProfile
     ] , [
         a sh:NodeShape ;

--- a/prez/models/query_params.py
+++ b/prez/models/query_params.py
@@ -127,6 +127,7 @@ class QueryParams:
         mediatype: str = Query(
             default="text/turtle", alias="_mediatype", description="Requested mediatype"
         ),
+        profile: Optional[str] = Query(default=None, alias="_profile", description="Requested profile"),
         page: int = Query(
             default=1, ge=1, description="Page number, must be greater than 0"
         ),
@@ -168,6 +169,7 @@ class QueryParams:
         ),
     ):
         self.q = q
+        self.profile = profile
         self.page = page
         self.limit = limit
         self.bbox = bbox

--- a/prez/reference_data/endpoints/base/endpoint_nodeshapes.ttl
+++ b/prez/reference_data/endpoints/base/endpoint_nodeshapes.ttl
@@ -55,12 +55,12 @@ ex:Narrowers
 
 ex:CQL
     a sh:NodeShape ;
-    sh:targetClass rdfs:Resource ;
+    sh:targetClass prez:CQLFilterResult ;
     ont:hierarchyLevel 1 ;
     .
 
 ex:Search
     a sh:NodeShape ;
-    sh:targetClass rdfs:Resource ;
+    sh:targetClass prez:SearchResult ;
     ont:hierarchyLevel 1 ;
     .

--- a/prez/reference_data/profiles/ogc_features.ttl
+++ b/prez/reference_data/profiles/ogc_features.ttl
@@ -21,8 +21,8 @@ prez:OGCFeaturesProfile a prof:Profile , prez:IndexProfile ;
             altr-ext:hasDefaultProfile prez:OGCFeaturesMinimalProps ;
             sh:targetClass
                 geo:FeatureCollection,
-                prez:CQLObjectList,
-                prez:SearchResult
+                prez:SearchResult ,
+                prez:CQLFilterResult
         ] ;
     altr-ext:hasResourceFormat
         "application/json",
@@ -78,8 +78,8 @@ prez:OGCFeaturesAllProps a
         geo:FeatureCollection,
         rdf:Resource,
         prof:Profile,
-        prez:CQLObjectList,
-        prez:SearchResult ;
+        prez:SearchResult ,
+        prez:CQLFilterResult ;
     altr-ext:hasDefaultResourceFormat "application/geo+json" ;
     altr-ext:hasResourceFormat
         "application/geo+json",

--- a/prez/reference_data/profiles/ogc_records_profile.ttl
+++ b/prez/reference_data/profiles/ogc_records_profile.ttl
@@ -33,14 +33,13 @@ prez:OGCRecordsProfile
         [
             a sh:NodeShape ;
             sh:targetClass
-                dcat:Catalog,
-                dcat:Resource,
-                skos:Concept
-            ,
-                skos:Collection,
-                rdf:Resource,
-                prez:SearchResult,
-                prez:CQLObjectList ;
+                dcat:Catalog ,
+                dcat:Resource ,
+                skos:Concept ,
+                skos:Collection ,
+                rdf:Resource ,
+                prez:SearchResult ,
+                prez:CQLFilterResult ;
             altr-ext:hasDefaultProfile prez:OGCListingProfile
         ],
         [
@@ -78,13 +77,13 @@ prez:OGCListingProfile
         "text/turtle" ;
     altr-ext:hasDefaultResourceFormat "text/anot+turtle" ;
     altr-ext:constrainsClass
-        dcat:Catalog,
-        skos:Collection,
-        skos:Concept,
-        dcat:Resource,
-        prof:Profile,
-        prez:SearchResult,
-        prez:CQLObjectList,
+        dcat:Catalog ,
+        skos:Collection ,
+        skos:Concept ,
+        dcat:Resource ,
+        prof:Profile ,
+        prez:SearchResult ,
+        prez:CQLFilterResult ,
         rdf:Resource ;
     sh:property [ sh:path rdf:type ]
 .

--- a/prez/reference_data/profiles/prez_default_profiles.ttl
+++ b/prez/reference_data/profiles/prez_default_profiles.ttl
@@ -48,7 +48,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:identifier "openobj"^^xsd:token ;
     dcterms:description "An open profile for objects which will return all direct properties for a resource." ;
     dcterms:title "Open profile" ;
-    altr-ext:constrainsClass prez:SPARQLQuery , prof:Profile , prez:SearchResult , prez:Object ;
+    altr-ext:constrainsClass prez:SPARQLQuery , prof:Profile , prez:SearchResult , prez:Object , prez:CQLFilterResult ;
     altr-ext:hasDefaultResourceFormat "text/anot+turtle" ;
     altr-ext:hasResourceFormat "application/ld+json" ,
         "application/anot+ld+json" ,
@@ -83,7 +83,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "text/turtle" ;
     altr-ext:hasNodeShape [
         a sh:NodeShape ;
-        sh:targetClass rdfs:Resource ;
+        sh:targetClass prez:CQLFilterResult ;
         altr-ext:hasDefaultProfile <https://prez.dev/profile/cqlgeo>
     ] ;
     sh:property [
@@ -108,7 +108,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                              dcat:Catalog ,
                              skos:ConceptScheme ,
                              skos:Collection ,
-                             prez:CQLObjectList ,
+                             prez:CQLFilterResult ,
                              prez:QueryablesList ,
                              prof:Profile ;
     altr-ext:hasDefaultResourceFormat "text/anot+turtle" ;

--- a/prez/repositories/remote_sparql.py
+++ b/prez/repositories/remote_sparql.py
@@ -44,8 +44,9 @@ class RemoteSparqlRepo(Repo):
         """
         response = await self._send_query(query)
         g = Graph()
+        format = response.headers.get("content-type", "nt")
         await response.aread()
-        return g.parse(data=response.text, format="nt")
+        return g.parse(data=response.text, format=format)
 
     async def tabular_query_to_table(self, query: str, context: URIRef = None):
         """

--- a/prez/services/connegp_service.py
+++ b/prez/services/connegp_service.py
@@ -286,7 +286,7 @@ class NegotiatedPMTs(BaseModel):
               ?mid rdfs:subClassOf* ?base_class .
               VALUES ?base_class {{ {" ".join(klass.n3() for klass in query_klasses)}
                prof:Profile prez:SPARQLQuery
-              prez:SearchResult prez:CQLObjectList prez:Object rdfs:Resource }}
+              prez:SearchResult prez:CQLFilterResult prez:Object rdfs:Resource }}
               ?profile altr-ext:constrainsClass ?class ;
                        altr-ext:hasResourceFormat ?format ;
                        dcterms:title ?title .\

--- a/prez/services/query_generation/umbrella.py
+++ b/prez/services/query_generation/umbrella.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Tuple, Union
 
+from rdflib import URIRef
 from sparql_grammar_pydantic import (
     ConstructQuery,
     ConstructTemplate,
@@ -241,8 +242,12 @@ def merge_listing_query_grammar_inputs(
         kwargs["inner_select_gpnt"].extend(cql_parser.inner_select_gpnt_list)
 
     if endpoint_nodeshape:
-        kwargs["inner_select_tssp_list"].extend(endpoint_nodeshape.tssp_list)
-        kwargs["inner_select_gpnt"].extend(endpoint_nodeshape.gpnt_list)
+        # endpoint nodeshape will constrain the focus nodes selected - undesirable for plain search/CQL. However, if
+        # search/CQL is used on a generic listing endpoint, then we do want both the endpoint nodeshape (which
+        # constrains the focus nodes) + the search/CQL query.
+        if endpoint_nodeshape.uri not in [URIRef('http://example.org/ns#Search'), URIRef('http://example.org/ns#CQL')]:
+            kwargs["inner_select_tssp_list"].extend(endpoint_nodeshape.tssp_list)
+            kwargs["inner_select_gpnt"].extend(endpoint_nodeshape.gpnt_list)
 
     if bbox:
         gpnt, tssp_list = generate_bbox_filter(bbox, filter_crs)


### PR DESCRIPTION
- **fix: don't assume 'nt' mediatype from remote sparql endpoint**
- **fix: add a check to the umbrella query builder that if a search or CQL query is received ONLY on the /search or /cql endpoints, then the class information for the types of objects is excluded from the generated SPARQL query. search and CQL queries received on other listing endpoints will still apply the class filter relevant to that endpoint.**
