### PR TITLE
fix: don't assume RDF from remote endpoint is n-triples

### DIFF
--- a/prez/repositories/remote_sparql.py
+++ b/prez/repositories/remote_sparql.py
@@ -43,9 +43,10 @@ class RemoteSparqlRepo(Repo):
         Returns: rdflib.Graph: An RDFLib Graph object
         """
         response = await self._send_query(query)
+        format = response.headers.get("content-type", "nt")
         g = Graph()
         await response.aread()
-        return g.parse(data=response.text, format="nt")
+        return g.parse(data=response.text, format=format)
 
     async def tabular_query_to_table(self, query: str, context: URIRef = None):
         """


### PR DESCRIPTION
instead get the content-type from the response and fall back to
n-triples if not given
