### PR TITLE
fix: add missing api docs for /object endpoint. change from uri to iri

### DIFF
--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -354,8 +354,10 @@ async def get_focus_node(
     ep_uri = endpoint_uri_type[0]
     ep_type = endpoint_uri_type[1]
     if ep_uri == EP["system/object"]:
-        uri = request.query_params.get("uri")
-        return IRI(value=uri)
+        iri = request.query_params.get("iri") or request.query_params.get("uri")
+        if not iri:
+            raise HTTPException(status_code=400, detail="Missing required query parameter: 'iri' or 'uri' ('uri' is marked for deprecation)")
+        return IRI(value=iri)
     elif ep_type == ONT.ObjectEndpoint:
         object_curie = url_path.split("/")[-1]
         focus_node_uri = await get_uri_for_curie_id(object_curie)
@@ -554,8 +556,11 @@ async def get_profile_nodeshape(
     if profile == ALTREXT["alt-profile"]:
         focus_node = Var(value="focus_node")
     elif endpoint_uri_type[0] == EP["system/object"]:
-        uri = request.query_params.get("uri")
-        focus_node = IRI(value=uri)
+        # Allow 'uri' for backwards compatibility
+        identifier_value = request.query_params.get("iri") or request.query_params.get("uri")
+        if not identifier_value:
+            raise HTTPException(status_code=400, detail="Missing required query parameter: 'iri' or 'uri' ('uri' is marked for deprecation)")
+        focus_node = IRI(value=identifier_value)
     elif endpoint_uri_type[1] == ONT.ObjectEndpoint:
         object_curie = url_path.split("/")[-1]
         focus_node_uri = await get_uri_for_curie_id(object_curie)

--- a/prez/routers/base_router.py
+++ b/prez/routers/base_router.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
 from sparql_grammar_pydantic import ConstructQuery
 
 from prez.dependencies import (
@@ -161,10 +163,19 @@ async def objects(
     query_params: ObjectQueryParams = Depends(),
     pmts: NegotiatedPMTs = Depends(get_negotiated_pmts),
     endpoint_structure: tuple[str, ...] = Depends(get_endpoint_structure),
-    profile_nodeshape: NodeShape = Depends(get_profile_nodeshape),
+    profile_nodeshape: NodeShape = Depends(get_profile_nodeshape),  # iri for object endpoint is used here
     data_repo: Repo = Depends(get_data_repo),
     system_repo: Repo = Depends(get_system_repo),
     url: str = Depends(get_url),
+    iri: str = Query(None, description="The IRI of the object to retrieve.", include_in_schema=True,
+                     example="https://example.com/demo-vocabs/image-test/apron-image"),
+    uri: str = Query(None, description="The URI of the object to retrieve. Use 'iri' instead. This will be "
+                                       "deprecated in a future version. Functionally the same as the 'iri' query "
+                                       "parameter.", include_in_schema=True, deprecated=True),
+    mediatype: str = Query(
+            default="text/anot+turtle", alias="_mediatype", description="Requested mediatype"
+        ),
+    profile: Optional[str] = Query(default=None, alias="_profile", description="Requested profile"),
 ):
     return await object_function(
         query_params=query_params,


### PR DESCRIPTION
adds correct api documentation for the `/object` endpoint.

NB docs point users to use `iri` however `uri` is still supported so this is not a breaking change.

![image](https://github.com/user-attachments/assets/775a3fca-865d-460c-a0c7-394dab1f198d)

