### PR TITLE
ci: add arm64 container build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,4 +90,4 @@ jobs:
           build-args: PREZ_VERSION=${{ needs.release.outputs.new_release_version }}
           tags: ${{ steps.metadata.outputs.tags }}
           provenance: false
-          platforms: linux/amd64 #,linux/arm64
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
tested build on seperate action and it was successful. looks like the
issue with pyoxigraph and arm is resolved.
