### PR TITLE
fix: hierarchy level calculation for ogc features api

### DIFF
--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -436,7 +436,7 @@ async def get_endpoint_nodeshapes(
     }
     # A hierarchy level covers a listing and an item endpoint. Path segment maths is: int({2,3}/2) -> 1; int({4,5}/2) -> 2 etc.
     # For Features API mounted as "features", remove extra level when counting to get correct hierarchy level.
-    hierarchy_level = int(len(url_path.replace("features/collections", "features").split("/")) / 2)
+    hierarchy_level = int(len(url_path.replace("/features/collections", "/features").split("/")) / 2)
     """
     Determines the relevant nodeshape based on the endpoint, hierarchy level, and parent URI
     """


### PR DESCRIPTION
url_path.replace("features/collections", "features") to url_path.replace("/features/collections", "/features") to prevent incorrectly replacing on curies that happen to end with 'features'

lets come back to this later and add some tests