### PR TITLE
fix: redirects to existing resources without a prez:link

### DIFF
--- a/prez/services/objects.py
+++ b/prez/services/objects.py
@@ -100,10 +100,14 @@ async def object_function(
             prez_ui_url = re.sub(r"/+$", "", settings.prez_ui_url)
             if prez_link:
                 return RedirectResponse(prez_ui_url + str(prez_link))
+            elif len(item_graph):
+                return RedirectResponse(prez_ui_url + "/object?uri=" + urllib.parse.quote_plus(item_uri))
             else:
                 return RedirectResponse(
                     prez_ui_url + "/404?uri=" + urllib.parse.quote_plus(item_uri)
                 )
+    if not len(item_graph):
+        raise URINotFoundException(uri=profile_nodeshape.focus_node.value)
     if "anot+" in pmts.selected["mediatype"]:
         item_graph.add((BNode(), PREZ.currentProfile, pmts.selected["profile"]))
         await add_prez_links(item_graph, data_repo, endpoint_structure)

--- a/prez/services/objects.py
+++ b/prez/services/objects.py
@@ -106,8 +106,6 @@ async def object_function(
                 return RedirectResponse(
                     prez_ui_url + "/404?uri=" + urllib.parse.quote_plus(item_uri)
                 )
-    if not len(item_graph):
-        raise URINotFoundException(uri=profile_nodeshape.focus_node.value)
     if "anot+" in pmts.selected["mediatype"]:
         item_graph.add((BNode(), PREZ.currentProfile, pmts.selected["profile"]))
         await add_prez_links(item_graph, data_repo, endpoint_structure)


### PR DESCRIPTION
Redirection to prez-ui should work even without a prez:link to the `/object?uri=...` prez-ui endpoint.

Additionally, return a 404 when the item graph is empty (ie no data found about the resource). This may not be 100% correct, though, because the item may exist but not have any data for a given profile...