### PR TITLE
feat: add shacl filterShape support for conditional triple pattern emission

### DIFF
--- a/prez/services/query_generation/shacl.py
+++ b/prez/services/query_generation/shacl.py
@@ -428,10 +428,6 @@ class PropertyShape(Shape):
 
             bnode_class = next(self.graph.objects(subject=pp, predicate=SH["class"]), None)
 
-            bnode_filter_shape_uri = next(self.graph.objects(subject=pp, predicate=SH.filterShape), None)
-            if bnode_filter_shape_uri:
-                final_filter_shape_tssp_list.extend(self._parse_filter_shape(bnode_filter_shape_uri))
-
             nested_path_node = next(self.graph.objects(subject=pp, predicate=SH.path), None)
             if nested_path_node:
                 path_to_parse = nested_path_node

--- a/prez/services/query_generation/shacl.py
+++ b/prez/services/query_generation/shacl.py
@@ -235,27 +235,45 @@ class PropertyShape(Shape):
             return int(maxc)
 
     def from_graph(self):
+        # Context Guard: Check if this PropertyShape is inside a sh:filterShape.
+        # This checks for both direct and nested sh:property within the filter.
+        parents = list(self.graph.subjects(SH.property, self.uri))
+        for parent in parents:
+            grandparents = list(self.graph.subjects(SH.filterShape, parent))
+            if grandparents:
+                return  # This is a direct child of a filter shape's property.
+            great_grandparents = list(self.graph.subjects(SH.property, parent))
+            for great_grandparent in great_grandparents:
+                if list(self.graph.subjects(SH.filterShape, great_grandparent)):
+                    return # This is a nested child of a filter shape's property.
+
         self.and_property_paths = []
         self.union_property_paths = []
         _single_class = next(self.graph.objects(self.uri, SH["class"]), None)
         if _single_class:
             self.or_klasses = [URIRef(_single_class)]
 
-        # look for sh:or statements and process classes from these NB only sh:or / sh:class is handled at present.
         or_classes = next(self.graph.objects(self.uri, SH["or"]), None)
         if or_classes:
             or_bns = list(Collection(self.graph, or_classes))
             or_triples = list(self.graph.triples_choices((or_bns, SH["class"], None)))
             self.or_klasses = [URIRef(klass) for _, _, klass in or_triples]
 
-        # Get the path alias defined directly on the property shape node, if any
         shape_level_path_alias = next(self.graph.objects(self.uri, SHEXT.pathAlias), None)
+
+        filter_shape_uri = next(self.graph.objects(self.uri, SH.filterShape), None)
+        filter_shape_tssp_list = []
+        if filter_shape_uri:
+            filter_shape_tssp_list = self._parse_filter_shape(filter_shape_uri)
 
         pps = list(self.graph.objects(self.uri, SH.path))
         for pp in pps:
-            # Pass the shape-level alias down
-            self._process_property_path(pp, shape_level_alias=shape_level_path_alias)
-        # get the longest property path first - for endpoints this will be the path any path_nodes apply to
+            self._add_path_to_shape(
+                pp,
+                shape_level_alias=shape_level_path_alias,
+                filter_shape_tssp_list=filter_shape_tssp_list,
+            )
+
         self.and_property_paths = sorted(
             self.and_property_paths, key=lambda x: len(x), reverse=True
         )
@@ -339,7 +357,7 @@ class PropertyShape(Shape):
                     # We return None here to signal that _process_property_path should not call _add_path for the sh:union BNode itself.
                     union_list = list(Collection(self.graph, bn_obj))
                     for item in union_list:
-                        self._process_property_path(item, union=True)  # Force union=True
+                        self._add_path_to_shape(item, union=True)  # Force union=True
                     return None  # Signal that the union BNode itself doesn't represent a single path to add
                 elif bn_pred == SH.alternativePath:
                     alt_list = list(Collection(self.graph, bn_obj))
@@ -361,47 +379,75 @@ class PropertyShape(Shape):
         else:
             raise ValueError(f"Unexpected node type in SHACL path: {type(pp)}")
 
-    def _process_property_path(self, pp: Node, union: bool = False, shape_level_alias: Optional[URIRef] = None):
-        """Processes a SHACL path node by parsing it and adding it to the appropriate list."""
-        path_to_parse = pp  # Default to the original node
-        path_alias_value = shape_level_alias  # Start with the alias from the parent shape
+    def _parse_filter_shape(self, filter_shape_uri: Node) -> List[TriplesSameSubjectPath]:
+        """
+        Parses a sh:filterShape structure and returns the corresponding triple patterns.
+        This is a narrow implementation based on the specific use case described in the documentation.
+        """
+        patterns = []
+        # sh:filterShape -> sh:property
+        prop_bnode = next(self.graph.objects(filter_shape_uri, SH.property))
+        # sh:property -> sh:property (sibling)
+        sibling_prop_bnode = next(self.graph.objects(prop_bnode, SH.property))
+        # sibling sh:property -> sh:path
+        sibling_path = next(self.graph.objects(sibling_prop_bnode, SH.path))
+        # sibling sh:property -> sh:hasValue
+        sibling_has_value = list(self.graph.objects(sibling_prop_bnode, SH.hasValue))
+        if sibling_has_value:
+            patterns.append(
+                TriplesSameSubjectPath.from_spo(
+                    self.focus_node, IRI(value=str(sibling_path)), IRI(value=str(sibling_has_value[0]))
+                )
+            )
+        else:  # check for sh:in
+            sibling_in_bn = next(self.graph.objects(sibling_prop_bnode, SH["in"]))
+            # sibling_in_vals = list(Collection(self.graph, sibling_in_bn))
+            if sibling_in_bn:
+                raise NotImplementedError()
+            else:
+                raise ValueError("Expected sh:hasValue or sh:in for the filterShape values.")
+        return patterns
 
-        # Check if pp is a BNode which might contain its own pathAlias, sh:class,
-        # or a nested sh:path.
-        bnode_class = None  # Initialize
+    def _add_path_to_shape(
+        self,
+        pp: Node,
+        union: bool = False,
+        shape_level_alias: Optional[URIRef] = None,
+        filter_shape_tssp_list: Optional[List[TriplesSameSubjectPath]] = None,
+    ):
+        """Processes a SHACL path node by parsing it and adding it to the appropriate list."""
+        path_to_parse = pp
+        path_alias_value = shape_level_alias
+        bnode_class = None
+        final_filter_shape_tssp_list = filter_shape_tssp_list or []
+
         if isinstance(pp, BNode):
-            # Check for an alias specific to this BNode, overriding the shape-level one if found.
             bnode_alias = next(self.graph.objects(subject=pp, predicate=SHEXT.pathAlias), None)
             if bnode_alias:
-                path_alias_value = bnode_alias  # Use BNode-specific alias
+                path_alias_value = bnode_alias
 
-            # Check for sh:class specific to this BNode
             bnode_class = next(self.graph.objects(subject=pp, predicate=SH["class"]), None)
 
-            # Check for nested sh:path (common in sh:union/sh:alternativePath list items)
-            # This logic needs refinement based on structure. If sh:path is *inside* the BNode `pp`,
-            # we parse that inner path but associate the alias found on `pp`.
+            bnode_filter_shape_uri = next(self.graph.objects(subject=pp, predicate=SH.filterShape), None)
+            if bnode_filter_shape_uri:
+                final_filter_shape_tssp_list.extend(self._parse_filter_shape(bnode_filter_shape_uri))
+
             nested_path_node = next(self.graph.objects(subject=pp, predicate=SH.path), None)
             if nested_path_node:
-                # Parse the inner path, but keep the alias determined from pp (or shape_level_alias)
                 path_to_parse = nested_path_node
 
         try:
-            # Parse the determined path node (original pp or nested_path_node)
             path_object = self._parse_property_path(path_to_parse)
-            # Check if path_object is None (e.g., handled by sh:union itself) before adding
             if path_object is not None:
-                # Always assign the determined path_alias if it exists. The setting controls its *use* later.
                 if path_alias_value:
                     path_object.path_alias = path_alias_value
-                # Assign the extracted sh:class if found
                 if bnode_class:
                     path_object.sh_class = bnode_class
-                self._add_path(path_object, union)  # Pass the original 'union' flag
+                if final_filter_shape_tssp_list:
+                    path_object.filter_shape_tssp_list = final_filter_shape_tssp_list
+                self._add_path(path_object, union)
         except ValueError as e:
-            # Log or handle parsing errors appropriately
             log.warning(f"Could not parse property path {path_to_parse} (original node: {pp}). Error: {e}")
-            # Decide if you want to skip this path or raise the error further
 
     def _add_path(self, path: PropertyPath, union: bool):
         """Adds a parsed PropertyPath object to the appropriate list."""
@@ -476,7 +522,7 @@ class PropertyShape(Shape):
         pp_i = 0
         # Process AND paths
         if self.and_property_paths:
-            and_paths_data, pp_i = self.process_property_paths(
+            and_paths_data, pp_i = self._generate_sparql_for_paths(
                 self.and_property_paths, path_or_prop, pp_i
             )
             for item in and_paths_data:
@@ -484,7 +530,7 @@ class PropertyShape(Shape):
 
         # Process UNION paths
         if self.union_property_paths:
-            union_paths_data, pp_i = self.process_property_paths(
+            union_paths_data, pp_i = self._generate_sparql_for_paths(
                 self.union_property_paths, path_or_prop, pp_i
             )
             # Store the processed data (including TSSP lists and facet binds) for union paths
@@ -565,7 +611,7 @@ class PropertyShape(Shape):
             )
             self.gpnt_list.append(gpnt)
 
-    def process_property_paths(self, property_paths, path_or_prop, start_pp_i) -> Tuple[List[Dict[str, Any]], int]:
+    def _generate_sparql_for_paths(self, property_paths, path_or_prop, start_pp_i) -> Tuple[List[Dict[str, Any]], int]:
         """Processes property paths, generating TSSP lists and facet binds."""
         processed_paths_data = []
         pp_i = start_pp_i
@@ -600,6 +646,9 @@ class PropertyShape(Shape):
             current_facet_binds = []
             if obj_node:  # Only create binds if we have a valid object node
                 current_facet_binds = self._create_facet_binds(property_path, obj_node)
+
+            if property_path.filter_shape_tssp_list:
+                current_tssp.extend(property_path.filter_shape_tssp_list)
 
             if isinstance(property_path, Path):
                 if property_path.value == SHEXT.allPredicateValues:
@@ -1256,6 +1305,7 @@ class PropertyPath(BaseModel):
     uri: Optional[URIRef] = None
     path_alias: Optional[URIRef] = None
     sh_class: Optional[URIRef] = None
+    filter_shape_tssp_list: Optional[List[TriplesSameSubjectPath]] = []
 
     def __len__(self):
         return 1  # Default length for all PropertyPath subclasses

--- a/tests/test_filter_shape.py
+++ b/tests/test_filter_shape.py
@@ -1,8 +1,11 @@
-from rdflib import Graph, URIRef, RDF, Namespace
+from rdflib import Graph, URIRef, RDF, Namespace, Literal, XSD
 from sparql_grammar_pydantic import (
     IRI,
     TriplesSameSubjectPath,
     Var,
+    BooleanLiteral,
+    NumericLiteral,
+    RDFLiteral,
 )
 
 from prez.services.query_generation.shacl import PropertyShape
@@ -82,71 +85,239 @@ def test_filter_shape_sosa_style_property_chain():
         assert expected.to_string() in tssp_strings
 
 
-# def test_filter_shape_sosa_style_property_chain_in():
-#     """
-#     Tests a property shape with a filter shape that uses a property chain.
-#     The filter condition is on a sibling property of the focus node.
-#     The SHACL pattern with an inverse path in the filter is based on documentation. This test assumes
-#     the implementation correctly interprets this pattern to apply the filter to the focus node.
-#     """
-#     g = Graph()
-#     g.bind("sh", SH)
-#     g.bind("sosa", SOSA)
-#     g.bind("rdf", RDF)
-#     g.bind("ex", EX)
-#     g.parse(
-#         data="""
-#     @prefix sh: <http://www.w3.org/ns/shacl#> .
-#     @prefix sosa: <http://www.w3.org/ns/sosa/> .
-#     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-#     @prefix ex: <http://example.com/> .
-#
-#     <http://example-profile> sh:property [
-#         sh:path ( sosa:hasResult rdf:value ) ;
-#         sh:filterShape [
-#             sh:property [
-#                 # The path here is the inverse of the main path.
-#                 # This is a pattern to indicate the filter applies to a sibling property of the main path's subject.
-#                 sh:path ( [ sh:inversePath rdf:value ] [ sh:inversePath sosa:hasResult ] ) ;
-#                 sh:property [
-#                     sh:path sosa:observedProperty ;
-#                     sh:in ( ex:SomeObservableProperty ex:SomeOtherObservableProperty ) ;
-#                 ]
-#             ]
-#         ]
-#     ].
-#     """,
-#         format="turtle",
-#     )
-#     path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
-#
-#     ps = PropertyShape(
-#         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
-#     )
-#
-#     # Expected triples in the WHERE clause.
-#     # The implementation should flatten the filter shape's logic so that it applies to the focus node.
-#
-#     # 1. The filter condition from the nested property shape
-#     filter_triple_1 = TriplesSameSubjectPath.from_spo(
-#         subject=Var(value="focus_node"),
-#         predicate=IRI(value=SOSA.observedProperty),
-#         object=IRI(value=EX.SomeObservableProperty),
-#     )
-#
-#     # 2. The main property path
-#     path_triple_1 = TriplesSameSubjectPath.from_spo(
-#         subject=Var(value="focus_node"),
-#         predicate=IRI(value=SOSA.hasResult),
-#         object=Var(value="prof_1_node_1"),
-#     )
-#     path_triple_2 = TriplesSameSubjectPath.from_spo(
-#         subject=Var(value="prof_1_node_1"),
-#         predicate=IRI(value=RDF.value),
-#         object=Var(value="prof_1_node_2"),
-#     )
-#
-#     # The order is not guaranteed, so check for presence
-#     tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
-#     for expected in [filter_triple_1, path_triple_1, path_triple_2]:
-#         assert expected.to_string() in tssp_strings
+def test_filter_shape_has_value_uri():
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("sosa", SOSA)
+    g.bind("rdf", RDF)
+    g.bind("ex", EX)
+    g.parse(
+        data="""
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix sosa: <http://www.w3.org/ns/sosa/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix ex: <http://example.com/> .
+
+    <http://example-profile> sh:property [
+        sh:path sosa:hasResult;
+        sh:filterShape [
+            sh:property [
+                sh:path ( [ sh:inversePath sosa:hasResult ] ) ;
+                sh:property [
+                    sh:path sosa:observedProperty ;
+                    sh:hasValue ex:SomeObservableProperty
+                ]
+            ]
+        ]
+    ].
+    """,
+        format="turtle",
+    )
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    filter_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.observedProperty),
+        object=IRI(value=EX.SomeObservableProperty),
+    )
+    path_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.hasResult),
+        object=Var(value="prof_1_node_1"),
+    )
+    tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+    assert filter_triple.to_string() in tssp_strings
+    assert path_triple.to_string() in tssp_strings
+
+
+def test_filter_shape_has_value_boolean():
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("sosa", SOSA)
+    g.bind("rdf", RDF)
+    g.bind("ex", EX)
+    g.parse(
+        data="""
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix sosa: <http://www.w3.org/ns/sosa/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix ex: <http://example.com/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://example-profile> sh:property [
+        sh:path sosa:hasResult;
+        sh:filterShape [
+            sh:property [
+                sh:path ( [ sh:inversePath sosa:hasResult ] ) ;
+                sh:property [
+                    sh:path ex:someBooleanProperty ;
+                    sh:hasValue "true"^^xsd:boolean
+                ]
+            ]
+        ]
+    ].
+    """,
+        format="turtle",
+    )
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    filter_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=EX.someBooleanProperty),
+        object=BooleanLiteral(value=True),
+    )
+    path_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.hasResult),
+        object=Var(value="prof_1_node_1"),
+    )
+    tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+    assert filter_triple.to_string() in tssp_strings
+    assert path_triple.to_string() in tssp_strings
+
+
+def test_filter_shape_has_value_integer():
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("sosa", SOSA)
+    g.bind("rdf", RDF)
+    g.bind("ex", EX)
+    g.parse(
+        data="""
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix sosa: <http://www.w3.org/ns/sosa/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix ex: <http://example.com/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://example-profile> sh:property [
+        sh:path sosa:hasResult;
+        sh:filterShape [
+            sh:property [
+                sh:path ( [ sh:inversePath sosa:hasResult ] ) ;
+                sh:property [
+                    sh:path ex:someIntegerProperty ;
+                    sh:hasValue "42"^^xsd:integer
+                ]
+            ]
+        ]
+    ].
+    """,
+        format="turtle",
+    )
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    filter_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=EX.someIntegerProperty),
+        object=NumericLiteral(value=42),
+    )
+    path_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.hasResult),
+        object=Var(value="prof_1_node_1"),
+    )
+    tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+    assert filter_triple.to_string() in tssp_strings
+    assert path_triple.to_string() in tssp_strings
+
+
+def test_filter_shape_has_value_decimal():
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("sosa", SOSA)
+    g.bind("rdf", RDF)
+    g.bind("ex", EX)
+    g.parse(
+        data="""
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix sosa: <http://www.w3.org/ns/sosa/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix ex: <http://example.com/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+    <http://example-profile> sh:property [
+        sh:path sosa:hasResult;
+        sh:filterShape [
+            sh:property [
+                sh:path ( [ sh:inversePath sosa:hasResult ] ) ;
+                sh:property [
+                    sh:path ex:someDecimalProperty ;
+                    sh:hasValue "3.14"^^xsd:decimal
+                ]
+            ]
+        ]
+    ].
+    """,
+        format="turtle",
+    )
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    filter_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=EX.someDecimalProperty),
+        object=NumericLiteral(value=3.14),
+    )
+    path_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.hasResult),
+        object=Var(value="prof_1_node_1"),
+    )
+    tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+    assert filter_triple.to_string() in tssp_strings
+    assert path_triple.to_string() in tssp_strings
+
+
+def test_filter_shape_has_value_string():
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("sosa", SOSA)
+    g.bind("rdf", RDF)
+    g.bind("ex", EX)
+    g.parse(
+        data="""
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix sosa: <http://www.w3.org/ns/sosa/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix ex: <http://example.com/> .
+
+    <http://example-profile> sh:property [
+        sh:path sosa:hasResult;
+        sh:filterShape [
+            sh:property [
+                sh:path ( [ sh:inversePath sosa:hasResult ] ) ;
+                sh:property [
+                    sh:path ex:someStringProperty ;
+                    sh:hasValue "hello"
+                ]
+            ]
+        ]
+    ].
+    """,
+        format="turtle",
+    )
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+    filter_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=EX.someStringProperty),
+        object=RDFLiteral(value="hello"),
+    )
+    path_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.hasResult),
+        object=Var(value="prof_1_node_1"),
+    )
+    tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+    assert filter_triple.to_string() in tssp_strings
+    assert path_triple.to_string() in tssp_strings

--- a/tests/test_filter_shape.py
+++ b/tests/test_filter_shape.py
@@ -1,0 +1,152 @@
+from rdflib import Graph, URIRef, RDF, Namespace
+from sparql_grammar_pydantic import (
+    IRI,
+    TriplesSameSubjectPath,
+    Var,
+)
+
+from prez.services.query_generation.shacl import PropertyShape
+
+SOSA = Namespace("http://www.w3.org/ns/sosa/")
+EX = Namespace("http://example.com/")
+SH = Namespace("http://www.w3.org/ns/shacl#")
+
+
+def test_filter_shape_sosa_style_property_chain():
+    """
+    Tests a property shape with a filter shape that uses a property chain.
+    The filter condition is on a sibling property of the focus node.
+    The SHACL pattern with an inverse path in the filter is based on documentation. This test assumes
+    the implementation correctly interprets this pattern to apply the filter to the focus node.
+    """
+    g = Graph()
+    g.bind("sh", SH)
+    g.bind("sosa", SOSA)
+    g.bind("rdf", RDF)
+    g.bind("ex", EX)
+    g.parse(
+        data="""
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix sosa: <http://www.w3.org/ns/sosa/> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix ex: <http://example.com/> .
+
+    <http://example-profile> sh:property [
+        sh:path ( sosa:hasResult rdf:value ) ;
+        sh:filterShape [
+            sh:property [
+                # The path here is the inverse of the main path.
+                # This is a pattern to indicate the filter applies to a sibling property of the main path's subject.
+                sh:path ( [ sh:inversePath rdf:value ] [ sh:inversePath sosa:hasResult ] ) ;
+                sh:property [
+                    sh:path sosa:observedProperty ;
+                    sh:hasValue ex:SomeObservableProperty
+                ]
+            ]
+        ]
+    ].
+    """,
+        format="turtle",
+    )
+    path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+
+    ps = PropertyShape(
+        uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+    )
+
+    # Expected triples in the WHERE clause.
+    # The implementation should flatten the filter shape's logic so that it applies to the focus node.
+
+    # 1. The filter condition from the nested property shape
+    filter_triple = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.observedProperty),
+        object=IRI(value=EX.SomeObservableProperty),
+    )
+
+    # 2. The main property path
+    path_triple_1 = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="focus_node"),
+        predicate=IRI(value=SOSA.hasResult),
+        object=Var(value="prof_1_node_1"),
+    )
+    path_triple_2 = TriplesSameSubjectPath.from_spo(
+        subject=Var(value="prof_1_node_1"),
+        predicate=IRI(value=RDF.value),
+        object=Var(value="prof_1_node_2"),
+    )
+
+    # The order is not guaranteed, so check for presence
+    tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+    for expected in [filter_triple, path_triple_1, path_triple_2]:
+        assert expected.to_string() in tssp_strings
+
+
+# def test_filter_shape_sosa_style_property_chain_in():
+#     """
+#     Tests a property shape with a filter shape that uses a property chain.
+#     The filter condition is on a sibling property of the focus node.
+#     The SHACL pattern with an inverse path in the filter is based on documentation. This test assumes
+#     the implementation correctly interprets this pattern to apply the filter to the focus node.
+#     """
+#     g = Graph()
+#     g.bind("sh", SH)
+#     g.bind("sosa", SOSA)
+#     g.bind("rdf", RDF)
+#     g.bind("ex", EX)
+#     g.parse(
+#         data="""
+#     @prefix sh: <http://www.w3.org/ns/shacl#> .
+#     @prefix sosa: <http://www.w3.org/ns/sosa/> .
+#     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+#     @prefix ex: <http://example.com/> .
+#
+#     <http://example-profile> sh:property [
+#         sh:path ( sosa:hasResult rdf:value ) ;
+#         sh:filterShape [
+#             sh:property [
+#                 # The path here is the inverse of the main path.
+#                 # This is a pattern to indicate the filter applies to a sibling property of the main path's subject.
+#                 sh:path ( [ sh:inversePath rdf:value ] [ sh:inversePath sosa:hasResult ] ) ;
+#                 sh:property [
+#                     sh:path sosa:observedProperty ;
+#                     sh:in ( ex:SomeObservableProperty ex:SomeOtherObservableProperty ) ;
+#                 ]
+#             ]
+#         ]
+#     ].
+#     """,
+#         format="turtle",
+#     )
+#     path_bn = g.value(subject=URIRef("http://example-profile"), predicate=SH.property)
+#
+#     ps = PropertyShape(
+#         uri=path_bn, graph=g, kind="profile", focus_node=Var(value="focus_node")
+#     )
+#
+#     # Expected triples in the WHERE clause.
+#     # The implementation should flatten the filter shape's logic so that it applies to the focus node.
+#
+#     # 1. The filter condition from the nested property shape
+#     filter_triple_1 = TriplesSameSubjectPath.from_spo(
+#         subject=Var(value="focus_node"),
+#         predicate=IRI(value=SOSA.observedProperty),
+#         object=IRI(value=EX.SomeObservableProperty),
+#     )
+#
+#     # 2. The main property path
+#     path_triple_1 = TriplesSameSubjectPath.from_spo(
+#         subject=Var(value="focus_node"),
+#         predicate=IRI(value=SOSA.hasResult),
+#         object=Var(value="prof_1_node_1"),
+#     )
+#     path_triple_2 = TriplesSameSubjectPath.from_spo(
+#         subject=Var(value="prof_1_node_1"),
+#         predicate=IRI(value=RDF.value),
+#         object=Var(value="prof_1_node_2"),
+#     )
+#
+#     # The order is not guaranteed, so check for presence
+#     tssp_strings = {tssp.to_string() for tssp in ps.tssp_list}
+#     for expected in [filter_triple_1, path_triple_1, path_triple_2]:
+#         assert expected.to_string() in tssp_strings


### PR DESCRIPTION
Implements support for SHACL sh:filterShape to enable conditional triple pattern emission based on sibling property constraints. This allows profiles to emit triples only when the subject node satisfies specific filter conditions using standard SHACL vocabulary.
The implementation adds _parse_filter_shape() method to extract filter conditions and enhances path processing to handle filter shapes. Filter conditions are automatically flattened and applied directly to the focus node, with context guards preventing infinite recursion during processing.
Example Usage:
```turtle
sh:property [
  sh:path ( sosa:hasResult rdf:value ) ;
  sh:filterShape [
    sh:property [
      sh:path ( [ sh:inversePath rdf:value ] [ sh:inversePath sosa:hasResult ] ) ;
      sh:property [
        sh:path sosa:observedProperty ;
        sh:hasValue ex:Temperature
      ]
    ]
  ]
] .
```
Generated SPARQL:
```sparql
?focus_node sosa:observedProperty ex:Temperature .
?focus_node sosa:hasResult ?prof_1_node_1 .
?prof_1_node_1 rdf:value ?prof_1_node_2 .
```
Currently supports sh:hasValue constraints with sh:in support planned. 