### PR TITLE
fix: update sparql grammar to terminate all triples same subject path with fullstop

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -130,14 +130,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
-    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
 ]
 
 [[package]]
@@ -285,79 +285,79 @@ markers = {main = "extra == \"server\" and platform_system == \"Windows\"", dev 
 
 [[package]]
 name = "coverage"
-version = "7.8.2"
+version = "7.9.1"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bd8ec21e1443fd7a447881332f7ce9d35b8fbd2849e761bb290b584535636b0a"},
-    {file = "coverage-7.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c26c2396674816deaeae7ded0e2b42c26537280f8fe313335858ffff35019be"},
-    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1aec326ed237e5880bfe69ad41616d333712c7937bcefc1343145e972938f9b3"},
-    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5e818796f71702d7a13e50c70de2a1924f729228580bcba1607cccf32eea46e6"},
-    {file = "coverage-7.8.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:546e537d9e24efc765c9c891328f30f826e3e4808e31f5d0f87c4ba12bbd1622"},
-    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ab9b09a2349f58e73f8ebc06fac546dd623e23b063e5398343c5270072e3201c"},
-    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fd51355ab8a372d89fb0e6a31719e825cf8df8b6724bee942fb5b92c3f016ba3"},
-    {file = "coverage-7.8.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0774df1e093acb6c9e4d58bce7f86656aeed6c132a16e2337692c12786b32404"},
-    {file = "coverage-7.8.2-cp310-cp310-win32.whl", hash = "sha256:00f2e2f2e37f47e5f54423aeefd6c32a7dbcedc033fcd3928a4f4948e8b96af7"},
-    {file = "coverage-7.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:145b07bea229821d51811bf15eeab346c236d523838eda395ea969d120d13347"},
-    {file = "coverage-7.8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9"},
-    {file = "coverage-7.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879"},
-    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a"},
-    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5"},
-    {file = "coverage-7.8.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11"},
-    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a"},
-    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb"},
-    {file = "coverage-7.8.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54"},
-    {file = "coverage-7.8.2-cp311-cp311-win32.whl", hash = "sha256:641988828bc18a6368fe72355df5f1703e44411adbe49bba5644b941ce6f2e3a"},
-    {file = "coverage-7.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:8ab4a51cb39dc1933ba627e0875046d150e88478dbe22ce145a68393e9652975"},
-    {file = "coverage-7.8.2-cp311-cp311-win_arm64.whl", hash = "sha256:8966a821e2083c74d88cca5b7dcccc0a3a888a596a04c0b9668a891de3a0cc53"},
-    {file = "coverage-7.8.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e2f6fe3654468d061942591aef56686131335b7a8325684eda85dacdf311356c"},
-    {file = "coverage-7.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76090fab50610798cc05241bf83b603477c40ee87acd358b66196ab0ca44ffa1"},
-    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bd0a0a5054be160777a7920b731a0570284db5142abaaf81bcbb282b8d99279"},
-    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da23ce9a3d356d0affe9c7036030b5c8f14556bd970c9b224f9c8205505e3b99"},
-    {file = "coverage-7.8.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9392773cffeb8d7e042a7b15b82a414011e9d2b5fdbbd3f7e6a6b17d5e21b20"},
-    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:876cbfd0b09ce09d81585d266c07a32657beb3eaec896f39484b631555be0fe2"},
-    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3da9b771c98977a13fbc3830f6caa85cae6c9c83911d24cb2d218e9394259c57"},
-    {file = "coverage-7.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a990f6510b3292686713bfef26d0049cd63b9c7bb17e0864f133cbfd2e6167f"},
-    {file = "coverage-7.8.2-cp312-cp312-win32.whl", hash = "sha256:bf8111cddd0f2b54d34e96613e7fbdd59a673f0cf5574b61134ae75b6f5a33b8"},
-    {file = "coverage-7.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:86a323a275e9e44cdf228af9b71c5030861d4d2610886ab920d9945672a81223"},
-    {file = "coverage-7.8.2-cp312-cp312-win_arm64.whl", hash = "sha256:820157de3a589e992689ffcda8639fbabb313b323d26388d02e154164c57b07f"},
-    {file = "coverage-7.8.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca"},
-    {file = "coverage-7.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d"},
-    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85"},
-    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257"},
-    {file = "coverage-7.8.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108"},
-    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0"},
-    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050"},
-    {file = "coverage-7.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48"},
-    {file = "coverage-7.8.2-cp313-cp313-win32.whl", hash = "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7"},
-    {file = "coverage-7.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3"},
-    {file = "coverage-7.8.2-cp313-cp313-win_arm64.whl", hash = "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7"},
-    {file = "coverage-7.8.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008"},
-    {file = "coverage-7.8.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36"},
-    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46"},
-    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be"},
-    {file = "coverage-7.8.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740"},
-    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625"},
-    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b"},
-    {file = "coverage-7.8.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199"},
-    {file = "coverage-7.8.2-cp313-cp313t-win32.whl", hash = "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8"},
-    {file = "coverage-7.8.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d"},
-    {file = "coverage-7.8.2-cp313-cp313t-win_arm64.whl", hash = "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b"},
-    {file = "coverage-7.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:496948261eaac5ac9cf43f5d0a9f6eb7a6d4cb3bedb2c5d294138142f5c18f2a"},
-    {file = "coverage-7.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eacd2de0d30871eff893bab0b67840a96445edcb3c8fd915e6b11ac4b2f3fa6d"},
-    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b039ffddc99ad65d5078ef300e0c7eed08c270dc26570440e3ef18beb816c1ca"},
-    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e49824808d4375ede9dd84e9961a59c47f9113039f1a525e6be170aa4f5c34d"},
-    {file = "coverage-7.8.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b069938961dfad881dc2f8d02b47645cd2f455d3809ba92a8a687bf513839787"},
-    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:de77c3ba8bb686d1c411e78ee1b97e6e0b963fb98b1637658dd9ad2c875cf9d7"},
-    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1676628065a498943bd3f64f099bb573e08cf1bc6088bbe33cf4424e0876f4b3"},
-    {file = "coverage-7.8.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8e1a26e7e50076e35f7afafde570ca2b4d7900a491174ca357d29dece5aacee7"},
-    {file = "coverage-7.8.2-cp39-cp39-win32.whl", hash = "sha256:6782a12bf76fa61ad9350d5a6ef5f3f020b57f5e6305cbc663803f2ebd0f270a"},
-    {file = "coverage-7.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:1efa4166ba75ccefd647f2d78b64f53f14fb82622bc94c5a5cb0a622f50f1c9e"},
-    {file = "coverage-7.8.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837"},
-    {file = "coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32"},
-    {file = "coverage-7.8.2.tar.gz", hash = "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27"},
+    {file = "coverage-7.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc94d7c5e8423920787c33d811c0be67b7be83c705f001f7180c7b186dcf10ca"},
+    {file = "coverage-7.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16aa0830d0c08a2c40c264cef801db8bc4fc0e1892782e45bcacbd5889270509"},
+    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf95981b126f23db63e9dbe4cf65bd71f9a6305696fa5e2262693bc4e2183f5b"},
+    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f05031cf21699785cd47cb7485f67df619e7bcdae38e0fde40d23d3d0210d3c3"},
+    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb4fbcab8764dc072cb651a4bcda4d11fb5658a1d8d68842a862a6610bd8cfa3"},
+    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0f16649a7330ec307942ed27d06ee7e7a38417144620bb3d6e9a18ded8a2d3e5"},
+    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:cea0a27a89e6432705fffc178064503508e3c0184b4f061700e771a09de58187"},
+    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e980b53a959fa53b6f05343afbd1e6f44a23ed6c23c4b4c56c6662bbb40c82ce"},
+    {file = "coverage-7.9.1-cp310-cp310-win32.whl", hash = "sha256:70760b4c5560be6ca70d11f8988ee6542b003f982b32f83d5ac0b72476607b70"},
+    {file = "coverage-7.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a66e8f628b71f78c0e0342003d53b53101ba4e00ea8dabb799d9dba0abbbcebe"},
+    {file = "coverage-7.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:95c765060e65c692da2d2f51a9499c5e9f5cf5453aeaf1420e3fc847cc060582"},
+    {file = "coverage-7.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ba383dc6afd5ec5b7a0d0c23d38895db0e15bcba7fb0fa8901f245267ac30d86"},
+    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37ae0383f13cbdcf1e5e7014489b0d71cc0106458878ccde52e8a12ced4298ed"},
+    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69aa417a030bf11ec46149636314c24c8d60fadb12fc0ee8f10fda0d918c879d"},
+    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4be2a28656afe279b34d4f91c3e26eccf2f85500d4a4ff0b1f8b54bf807338"},
+    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:382e7ddd5289f140259b610e5f5c58f713d025cb2f66d0eb17e68d0a94278875"},
+    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e5532482344186c543c37bfad0ee6069e8ae4fc38d073b8bc836fc8f03c9e250"},
+    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a39d18b3f50cc121d0ce3838d32d58bd1d15dab89c910358ebefc3665712256c"},
+    {file = "coverage-7.9.1-cp311-cp311-win32.whl", hash = "sha256:dd24bd8d77c98557880def750782df77ab2b6885a18483dc8588792247174b32"},
+    {file = "coverage-7.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:6b55ad10a35a21b8015eabddc9ba31eb590f54adc9cd39bcf09ff5349fd52125"},
+    {file = "coverage-7.9.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ad935f0016be24c0e97fc8c40c465f9c4b85cbbe6eac48934c0dc4d2568321e"},
+    {file = "coverage-7.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626"},
+    {file = "coverage-7.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb"},
+    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300"},
+    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8"},
+    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5"},
+    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd"},
+    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898"},
+    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d"},
+    {file = "coverage-7.9.1-cp312-cp312-win32.whl", hash = "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74"},
+    {file = "coverage-7.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e"},
+    {file = "coverage-7.9.1-cp312-cp312-win_arm64.whl", hash = "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342"},
+    {file = "coverage-7.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631"},
+    {file = "coverage-7.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f"},
+    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd"},
+    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86"},
+    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43"},
+    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1"},
+    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751"},
+    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67"},
+    {file = "coverage-7.9.1-cp313-cp313-win32.whl", hash = "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643"},
+    {file = "coverage-7.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a"},
+    {file = "coverage-7.9.1-cp313-cp313-win_arm64.whl", hash = "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d"},
+    {file = "coverage-7.9.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0"},
+    {file = "coverage-7.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d"},
+    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f"},
+    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029"},
+    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece"},
+    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683"},
+    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f"},
+    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10"},
+    {file = "coverage-7.9.1-cp313-cp313t-win32.whl", hash = "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363"},
+    {file = "coverage-7.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7"},
+    {file = "coverage-7.9.1-cp313-cp313t-win_arm64.whl", hash = "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c"},
+    {file = "coverage-7.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f424507f57878e424d9a95dc4ead3fbdd72fd201e404e861e465f28ea469951"},
+    {file = "coverage-7.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:535fde4001b2783ac80865d90e7cc7798b6b126f4cd8a8c54acfe76804e54e58"},
+    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71"},
+    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56f5eb308b17bca3bbff810f55ee26d51926d9f89ba92707ee41d3c061257e55"},
+    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfa447506c1a52271f1b0de3f42ea0fa14676052549095e378d5bff1c505ff7b"},
+    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9ca8e220006966b4a7b68e8984a6aee645a0384b0769e829ba60281fe61ec4f7"},
+    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:49f1d0788ba5b7ba65933f3a18864117c6506619f5ca80326b478f72acf3f385"},
+    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:68cd53aec6f45b8e4724c0950ce86eacb775c6be01ce6e3669fe4f3a21e768ed"},
+    {file = "coverage-7.9.1-cp39-cp39-win32.whl", hash = "sha256:95335095b6c7b1cc14c3f3f17d5452ce677e8490d101698562b2ffcacc304c8d"},
+    {file = "coverage-7.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:e1b5191d1648acc439b24721caab2fd0c86679d8549ed2c84d5a7ec1bedcc244"},
+    {file = "coverage-7.9.1-pp39.pp310.pp311-none-any.whl", hash = "sha256:db0f04118d1db74db6c9e1cb1898532c7dcc220f1d2718f058601f7c3f499514"},
+    {file = "coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c"},
+    {file = "coverage-7.9.1.tar.gz", hash = "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec"},
 ]
 
 [package.extras]
@@ -1286,14 +1286,14 @@ test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
 
 [[package]]
 name = "pydantic"
-version = "2.11.5"
+version = "2.11.7"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7"},
-    {file = "pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a"},
+    {file = "pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b"},
+    {file = "pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db"},
 ]
 
 [package.dependencies]
@@ -2153,14 +2153,14 @@ files = [
 
 [[package]]
 name = "sparql-grammar-pydantic"
-version = "0.1.9"
+version = "0.1.10"
 description = "Pydantic models for the SPARQL Grammar."
 optional = false
 python-versions = "<4.0,>=3.11"
 groups = ["main"]
 files = [
-    {file = "sparql_grammar_pydantic-0.1.9-py3-none-any.whl", hash = "sha256:3e35df1e5775955ec62406ebd00345ba858ff61d83f4f5b663a619d0df0ab7f1"},
-    {file = "sparql_grammar_pydantic-0.1.9.tar.gz", hash = "sha256:d93b1133933c14256b1a9e3c83eca9cab46409eeb6338dbca5564cd690298f11"},
+    {file = "sparql_grammar_pydantic-0.1.10-py3-none-any.whl", hash = "sha256:d7d2d01f317370a8346f5f77c11e69eafcefb97f7fa9884277f217a506b1cf22"},
+    {file = "sparql_grammar_pydantic-0.1.10.tar.gz", hash = "sha256:0296cd24a17ff68fcb3805f44a05eb12581a309aa6866fca936d2da6fa20dbc9"},
 ]
 
 [package.dependencies]
@@ -2341,4 +2341,4 @@ server = ["uvicorn"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "4d872ad744119efeffe8ef45b73fd173b7cad4ca632c0208bbe542658404dace"
+content-hash = "79f094844a9da1e3dd1ef6f651dacebcb0d474829223aff31d2904c6d035cf21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pydantic = "^2.10.6"
 pydantic-settings = "^2.5.0"
 pyld = "^2.0.4"
 aiocache = "^0.12.2"
-sparql-grammar-pydantic = "^0.1.9"
+sparql-grammar-pydantic = "^0.1.10"
 rdf2geojson = {git = "https://github.com/Kurrawong/rdf2geojson.git", rev = "v0.7.2"}
 python-multipart = "^0.0.20"
 pyoxigraph = "^0.4.4"

--- a/test_data/cql/expected_generated_queries/additional_temporal_disjoint_instant.rq
+++ b/test_data/cql/expected_generated_queries/additional_temporal_disjoint_instant.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:updated_at> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:updated_at> ?dt_1_instant
+?focus_node <ex:updated_at> ?dt_1_instant .
 FILTER (?dt_1_instant > "2012-08-10T05:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> || ?dt_1_instant < "2012-08-10T05:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/additional_temporal_during_intervals.rq
+++ b/test_data/cql/expected_generated_queries/additional_temporal_during_intervals.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start > "2017-06-10T07:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end < "2017-06-11T10:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/clause7_12.rq
+++ b/test_data/cql/expected_generated_queries/clause7_12.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:event_time> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:event_time> ?dt_1_instant
+?focus_node <ex:event_time> ?dt_1_instant .
 FILTER (! (?dt_1_instant > "1969-07-24T16:50:35+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> || ?dt_1_instant < "1969-07-16T05:32:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>))
 }

--- a/test_data/cql/expected_generated_queries/clause7_13.rq
+++ b/test_data/cql/expected_generated_queries/clause7_13.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:liftOff> ?dt_1_end .
-?focus_node <ex:touchdown> ?dt_1_start
-
+?focus_node <ex:touchdown> ?dt_1_start .
 FILTER (?dt_1_start > "1969-07-16T13:32:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end < "1969-07-24T16:50:35+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example20.rq
+++ b/test_data/cql/expected_generated_queries/example20.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:built> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:built> ?dt_1_instant
+?focus_node <ex:built> ?dt_1_instant .
 FILTER (?dt_1_instant < "2015-01-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example21.rq
+++ b/test_data/cql/expected_generated_queries/example21.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:built> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:built> ?dt_1_instant
+?focus_node <ex:built> ?dt_1_instant .
 FILTER (?dt_1_instant > "2012-06-05T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example22.rq
+++ b/test_data/cql/expected_generated_queries/example22.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start > "2017-06-10T07:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end < "2017-06-11T10:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example27.rq
+++ b/test_data/cql/expected_generated_queries/example27.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:built> ?datetime
 }
 WHERE {
-?focus_node <ex:built> ?datetime
+?focus_node <ex:built> ?datetime .
 FILTER (?datetime > "2012-06-05T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example53.rq
+++ b/test_data/cql/expected_generated_queries/example53.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:updated_at> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:updated_at> ?dt_1_instant
+?focus_node <ex:updated_at> ?dt_1_instant .
 FILTER (?dt_1_instant > "2010-02-10T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example54.rq
+++ b/test_data/cql/expected_generated_queries/example54.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:updated_at> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:updated_at> ?dt_1_instant
+?focus_node <ex:updated_at> ?dt_1_instant .
 FILTER (?dt_1_instant < "2012-08-10T05:30:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example55.rq
+++ b/test_data/cql/expected_generated_queries/example55.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_2_end .
-?focus_node <ex:starts_at> ?dt_2_start
-
+?focus_node <ex:starts_at> ?dt_2_start .
 FILTER ("2000-01-01T00:00:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> < ?dt_2_start && "2005-01-10T01:01:01.393216+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> > ?dt_2_end)
 }

--- a/test_data/cql/expected_generated_queries/example56.rq
+++ b/test_data/cql/expected_generated_queries/example56.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_2_end .
-?focus_node <ex:starts_at> ?dt_2_start
-
+?focus_node <ex:starts_at> ?dt_2_start .
 FILTER ("2005-01-10T01:01:01.393216+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> < ?dt_2_start)
 }

--- a/test_data/cql/expected_generated_queries/example57.rq
+++ b/test_data/cql/expected_generated_queries/example57.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start > "2005-01-10T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end < "2010-02-10T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example58.rq
+++ b/test_data/cql/expected_generated_queries/example58.rq
@@ -2,6 +2,6 @@ CONSTRUCT {
 ?focus_node <ex:updated_at> ?dt_1_instant
 }
 WHERE {
-?focus_node <ex:updated_at> ?dt_1_instant
+?focus_node <ex:updated_at> ?dt_1_instant .
 FILTER (?dt_1_instant = "1851-04-29T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example59.rq
+++ b/test_data/cql/expected_generated_queries/example59.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start < "1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end = "2010-02-10T05:29:20.073225+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example60.rq
+++ b/test_data/cql/expected_generated_queries/example60.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start > "1991-10-07T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end = "2010-02-10T05:29:20.073225+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example61.rq
+++ b/test_data/cql/expected_generated_queries/example61.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (! (?dt_1_end < "1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> || ?dt_1_start > "2010-02-10T05:29:20.073225+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>))
 }

--- a/test_data/cql/expected_generated_queries/example62.rq
+++ b/test_data/cql/expected_generated_queries/example62.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_2_end .
-?focus_node <ex:starts_at> ?dt_2_start
-
+?focus_node <ex:starts_at> ?dt_2_start .
 FILTER ("2010-02-10T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> = ?dt_2_start)
 }

--- a/test_data/cql/expected_generated_queries/example63.rq
+++ b/test_data/cql/expected_generated_queries/example63.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_2_end .
-?focus_node <ex:starts_at> ?dt_2_start
-
+?focus_node <ex:starts_at> ?dt_2_start .
 FILTER ("2010-02-10T05:29:20.073225+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> = ?dt_2_end)
 }

--- a/test_data/cql/expected_generated_queries/example64.rq
+++ b/test_data/cql/expected_generated_queries/example64.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_2_end .
-?focus_node <ex:starts_at> ?dt_2_start
-
+?focus_node <ex:starts_at> ?dt_2_start .
 FILTER ("1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> > ?dt_2_start && "1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> < ?dt_2_end && "2010-02-10T05:29:20.073225+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> > ?dt_2_end)
 }

--- a/test_data/cql/expected_generated_queries/example65.rq
+++ b/test_data/cql/expected_generated_queries/example65.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start < "1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end > "1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> && ?dt_1_end < "1992-10-09T08:08:08.393473+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/test_data/cql/expected_generated_queries/example66.rq
+++ b/test_data/cql/expected_generated_queries/example66.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_2_end .
-?focus_node <ex:starts_at> ?dt_2_start
-
+?focus_node <ex:starts_at> ?dt_2_start .
 FILTER ("1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> = ?dt_2_start && "2010-02-10T05:29:20.073225+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> > ?dt_2_end)
 }

--- a/test_data/cql/expected_generated_queries/example67.rq
+++ b/test_data/cql/expected_generated_queries/example67.rq
@@ -4,7 +4,6 @@ CONSTRUCT {
 }
 WHERE {
 ?focus_node <ex:ends_at> ?dt_1_end .
-?focus_node <ex:starts_at> ?dt_1_start
-
+?focus_node <ex:starts_at> ?dt_1_start .
 FILTER (?dt_1_start = "1991-10-07T08:21:06.393262+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
 }

--- a/tests/test_cql.py
+++ b/tests/test_cql.py
@@ -122,11 +122,11 @@ def test_cql_or_operator_fix():
     expected_inner_select_gpntotb_list_str = [
         """
 {
-?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sosa/Sample>
+?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sosa/Sample> .
 }
 UNION
 {
-?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://linked.data.gov.au/def/borehole/Bore>
+?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://linked.data.gov.au/def/borehole/Bore> .
 }"""
     ]
     assert len(parser.inner_select_gpntotb_list) == len(expected_inner_select_gpntotb_list_str)
@@ -193,7 +193,7 @@ def test_cql_nested_and_operator():
         """?focus_node <http://purl.org/dc/terms/creator> <http://example.org/organizations#GeologicalSurvey> .
 ?focus_node <http://purl.org/dc/terms/format> <http://example.org/formats#PDF> .
 ?focus_node <http://purl.org/dc/terms/subject> <http://example.org/subjects#Geology> .
-?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#Report>"""
+?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/vocab#Report> ."""
     ]
     assert len(parser.inner_select_gpntotb_list) == len(expected_inner_select_gpntotb_list_str)
     assert parser.inner_select_gpntotb_list[0].to_string().replace(" ", "").replace("\n", "") == expected_inner_select_gpntotb_list_str[0].replace(" ", "").replace("\n", "")
@@ -260,15 +260,15 @@ def test_cql_and_of_A_or_BC():
     where_content = parser.query_object.where_clause.group_graph_pattern.content
 
     expected_inner_select_gpntotb_list_str = [
-        """?focus_node <http://example.org/propA> <http://example.org/valA>""",
+        """?focus_node <http://example.org/propA> <http://example.org/valA> .""",
         """
 {
 {
-?focus_node <http://example.org/propB> <http://example.org/valB>
+?focus_node <http://example.org/propB> <http://example.org/valB> .
 }
 UNION
 {
-?focus_node <http://example.org/propC> <http://example.org/valC>
+?focus_node <http://example.org/propC> <http://example.org/valC> .
 }
 }"""
     ]
@@ -302,12 +302,12 @@ def test_cql_or_of_A_and_BC():
         """
 
 {
-?focus_node <http://example.org/propA> <http://example.org/valA>
+?focus_node <http://example.org/propA> <http://example.org/valA> .
 }
 UNION
 {
 ?focus_node <http://example.org/propC> <http://example.org/valC> .
-?focus_node <http://example.org/propB> <http://example.org/valB>
+?focus_node <http://example.org/propB> <http://example.org/valB> .
 
 }"""
     ]
@@ -339,7 +339,7 @@ def test_cql_and_of_and_AB_C():
     expected_inner_select_gpntotb_list_str = [
         """?focus_node <http://example.org/propC> <http://example.org/valC> .
 ?focus_node <http://example.org/propB> <http://example.org/valB> .
-?focus_node <http://example.org/propA> <http://example.org/valA>"""
+?focus_node <http://example.org/propA> <http://example.org/valA> ."""
     ]
     assert len(parser.inner_select_gpntotb_list) == len(expected_inner_select_gpntotb_list_str)
     assert parser.inner_select_gpntotb_list[0].to_string().replace(" ", "").replace("\n", "") == expected_inner_select_gpntotb_list_str[0].replace(" ", "").replace("\n", "")
@@ -370,16 +370,16 @@ def test_cql_or_of_or_AB_C():
         """
 {
 {
-?focus_node <http://example.org/propA> <http://example.org/valA>
+?focus_node <http://example.org/propA> <http://example.org/valA> .
 }
 UNION
 {
-?focus_node <http://example.org/propB> <http://example.org/valB>
+?focus_node <http://example.org/propB> <http://example.org/valB> .
 }
 }
 UNION
 {
-?focus_node <http://example.org/propC> <http://example.org/valC>
+?focus_node <http://example.org/propC> <http://example.org/valC> .
 }
 """
     ]
@@ -411,21 +411,21 @@ def test_cql_and_of_or_AB_or_CD():
         """
 {
 {
-?focus_node <http://example.org/propA> <http://example.org/valA>
+?focus_node <http://example.org/propA> <http://example.org/valA> .
 }
 UNION
 {
-?focus_node <http://example.org/propB> <http://example.org/valB>
+?focus_node <http://example.org/propB> <http://example.org/valB> .
 }
 }""",
         """
 {
 {
-?focus_node <http://example.org/propC> <http://example.org/valC>
+?focus_node <http://example.org/propC> <http://example.org/valC> .
 }
 UNION
 {
-?focus_node <http://example.org/propD> <http://example.org/valD>
+?focus_node <http://example.org/propD> <http://example.org/valD> .
 }
 }"""
     ]
@@ -458,12 +458,12 @@ def test_cql_or_of_and_AB_and_CD():
         """
 {
 ?focus_node <http://example.org/propB> <http://example.org/valB> .
-?focus_node <http://example.org/propA> <http://example.org/valA>
+?focus_node <http://example.org/propA> <http://example.org/valA> .
 }
 UNION
 {
 ?focus_node <http://example.org/propD> <http://example.org/valD> .
-?focus_node <http://example.org/propC> <http://example.org/valC>
+?focus_node <http://example.org/propC> <http://example.org/valC> .
 }
 """
     ]

--- a/tests/test_property_selection_shacl.py
+++ b/tests/test_property_selection_shacl.py
@@ -286,14 +286,14 @@ def test_bnode_depth_union():
     expected_output = "".join("""
     {
         ?focus_node ?bn_p_1 ?bn_o_1 .
-        ?bn_o_1 ?bn_p_2 ?bn_o_2
+        ?bn_o_1 ?bn_p_2 ?bn_o_2 .
         FILTER isBLANK(?bn_o_1)
     }
     UNION
     {
         ?focus_node ?bn_p_1 ?bn_o_1 .
         ?bn_o_1 ?bn_p_2 ?bn_o_2 .
-        ?bn_o_2 ?bn_p_3 ?bn_o_3
+        ?bn_o_2 ?bn_p_3 ?bn_o_3 .
         FILTER isBLANK(?bn_o_1)
         FILTER isBLANK(?bn_o_2)
     }""".split())
@@ -322,14 +322,14 @@ def test_bnode_depth_direct():
     expected_output = "".join("""
     {
         ?focus_node ?bn_p_1 ?bn_o_1 .
-        ?bn_o_1 ?bn_p_2 ?bn_o_2
+        ?bn_o_1 ?bn_p_2 ?bn_o_2 .
         FILTER isBLANK(?bn_o_1)
     }
     UNION
     {
         ?focus_node ?bn_p_1 ?bn_o_1 .
         ?bn_o_1 ?bn_p_2 ?bn_o_2 .
-        ?bn_o_2 ?bn_p_3 ?bn_o_3
+        ?bn_o_2 ?bn_p_3 ?bn_o_3 .
         FILTER isBLANK(?bn_o_1)
         FILTER isBLANK(?bn_o_2)
     }""".split())
@@ -466,27 +466,26 @@ def test_union_nested_bnode():
 
     # Pattern 1: dcterms:publisher
     expected_pattern_1 = """{
-?focus_node <http://purl.org/dc/terms/publisher> ?prof_1_node_1
+?focus_node <http://purl.org/dc/terms/publisher> ?prof_1_node_1 .
 }"""
     assert union_pattern.group_graph_patterns[0].to_string().strip() == expected_pattern_1.strip()
 
     # Pattern 2: reg:status
     expected_pattern_2 = """{
-?focus_node <http://purl.org/linked-data/registry#status> ?prof_1_node_2
+?focus_node <http://purl.org/linked-data/registry#status> ?prof_1_node_2 .
 }"""
     assert union_pattern.group_graph_patterns[1].to_string().strip() == expected_pattern_2.strip()
 
     # Pattern 3: ( prov:qualifiedDerivation prov:hadRole )
     expected_pattern_3 = """{
 ?prof_1_node_3 <http://www.w3.org/ns/prov#hadRole> ?prof_1_node_4 .
-?focus_node <http://www.w3.org/ns/prov#qualifiedDerivation> ?prof_1_node_3
-
+?focus_node <http://www.w3.org/ns/prov#qualifiedDerivation> ?prof_1_node_3 .
 }"""
     assert union_pattern.group_graph_patterns[2].to_string().strip() == expected_pattern_3.strip()
 
     # Pattern 4: inverse(dcterms:creator)
     expected_pattern_4 = """{
-?prof_1_node_5 <http://purl.org/dc/terms/creator> ?focus_node
+?prof_1_node_5 <http://purl.org/dc/terms/creator> ?focus_node .
 }"""
     assert union_pattern.group_graph_patterns[3].to_string().strip() == expected_pattern_4.strip()
 
@@ -593,16 +592,16 @@ def test_sh_class_in_bnode_path(mock_settings):
     {
     ?prof_1_node_2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/DerivationRole> .
     ?prof_1_node_1 <http://www.w3.org/ns/prov#hadRole> ?prof_1_node_2 .
-    ?focus_node <http://www.w3.org/ns/prov#qualifiedDerivation> ?prof_1_node_1
+    ?focus_node <http://www.w3.org/ns/prov#qualifiedDerivation> ?prof_1_node_1 .
     }
     UNION
     {
     ?prof_1_node_3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.com/LabelType> .
-    ?focus_node <http://www.w3.org/2004/02/skos/core#prefLabel> ?prof_1_node_3
+    ?focus_node <http://www.w3.org/2004/02/skos/core#prefLabel> ?prof_1_node_3 .
     }
     UNION
     {
-    ?focus_node <http://purl.org/dc/terms/title> ?prof_1_node_4
+    ?focus_node <http://purl.org/dc/terms/title> ?prof_1_node_4 .
     }
     """
 

--- a/tests/test_shacl_sequence_alternative_paths.py
+++ b/tests/test_shacl_sequence_alternative_paths.py
@@ -150,11 +150,11 @@ def test_sequence_with_alternative_containing_complex_elements(focus_node_var, g
 
 
 {
-?prof_1_node_2 <http://example.com/ns#invAlt> ?prof_1_node_1
+?prof_1_node_2 <http://example.com/ns#invAlt> ?prof_1_node_1 .
 }
 UNION
 {
-?prof_1_node_1 <http://example.com/ns#cardAlt>* ?prof_1_node_2
+?prof_1_node_1 <http://example.com/ns#cardAlt>* ?prof_1_node_2 .
 }
 }"""
     assert actual_gpnt_string == expected_gpnt_string


### PR DESCRIPTION
Update sparql grammar pydantic. TriplesBlock will now always produce a full stop "." per triple (including cases where it isn't required). This is to cover cases where multiple TriplesBlocks with a single triple are used together and previously did not terminate their single triples with a "."
