### PR TITLE
fix: search query default, subquery defines ?focus_node variable twice

### DIFF
--- a/prez/services/query_generation/search_default.py
+++ b/prez/services/query_generation/search_default.py
@@ -90,6 +90,7 @@ class SearchQueryRegex(ConstructQuery):
                     #   SHA256(CONCAT(STR(?focus_node), STR(?predicate), STR(?match), STR(?weight))))) AS ?hashID)
                     select_clause=SelectClause(
                         variables_or_all=[
+                            sr_uri,
                             pred,
                             match,
                             weight,

--- a/prez/services/query_generation/search_default.py
+++ b/prez/services/query_generation/search_default.py
@@ -90,7 +90,6 @@ class SearchQueryRegex(ConstructQuery):
                     #   SHA256(CONCAT(STR(?focus_node), STR(?predicate), STR(?match), STR(?weight))))) AS ?hashID)
                     select_clause=SelectClause(
                         variables_or_all=[
-                            sr_uri,
                             pred,
                             match,
                             weight,

--- a/prez/services/query_generation/umbrella.py
+++ b/prez/services/query_generation/umbrella.py
@@ -228,7 +228,7 @@ def merge_listing_query_grammar_inputs(
     """
     kwargs = {
         "construct_tss_list": [],
-        "inner_select_vars": [Var(value="focus_node")],
+        "inner_select_vars": [],
         "inner_select_tssp_list": [],
         "inner_select_gpnt": [],
         "limit": None,


### PR DESCRIPTION
The query generates `?focus_node` variable twice in the sub select distinct query.

Before the fix:

```sparql
CONSTRUCT {
?focus_node <https://prez.dev/type> <https://prez.dev/FocusNode> .
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1 .
?hashID <https://prez.dev/searchResultWeight> ?weight .
?hashID <https://prez.dev/searchResultPredicate> ?pred .
?hashID <https://prez.dev/searchResultMatch> ?match .
?hashID <https://prez.dev/searchResultURI> ?focus_node .
?hashID <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://prez.dev/SearchResult>
}
WHERE {


{
SELECT DISTINCT ?focus_node ?focus_node ?pred ?match ?weight (URI(CONCAT("urn:hash:", SHA256(CONCAT(STR(?focus_node), STR(?pred), STR(?match), STR(?weight))))) AS ?hashID)
WHERE {


{
SELECT ?focus_node ?pred ?match (SUM(?w) AS ?weight)
WHERE {


        VALUES ?pred{ <http://www.w3.org/2000/01/rdf-schema#label> <http://www.w3.org/2004/02/skos/core#prefLabel> <http://www.w3.org/2004/02/skos/core#altLabel> <http://www.w3.org/2004/02/skos/core#hiddenLabel> <https://schema.org/name> <http://purl.org/dc/terms/title>  }

{
?focus_node ?pred ?match .
BIND(100 AS ?w)
FILTER (LCASE(?match) = "access")
}
UNION
{
?focus_node ?pred ?match .
BIND(20 AS ?w)
FILTER REGEX(?match, "^access", "i")
}
UNION
{
?focus_node ?pred ?match .
BIND(10 AS ?w)
FILTER REGEX(?match, "access", "i")
}
}GROUP BY ?focus_node ?pred ?match

}
}ORDER BY DESC( ?weight )
LIMIT 11 OFFSET 0

}?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1 .
}
```

After the fix:

```sparql
CONSTRUCT {
?focus_node <https://prez.dev/type> <https://prez.dev/FocusNode> .
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1 .
?hashID <https://prez.dev/searchResultWeight> ?weight .
?hashID <https://prez.dev/searchResultPredicate> ?pred .
?hashID <https://prez.dev/searchResultMatch> ?match .
?hashID <https://prez.dev/searchResultURI> ?focus_node .
?hashID <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://prez.dev/SearchResult>
}
WHERE {


{
SELECT DISTINCT ?focus_node ?pred ?match ?weight (URI(CONCAT("urn:hash:", SHA256(CONCAT(STR(?focus_node), STR(?pred), STR(?match), STR(?weight))))) AS ?hashID)
WHERE {


{
SELECT ?focus_node ?pred ?match (SUM(?w) AS ?weight)
WHERE {


        VALUES ?pred{ <http://www.w3.org/2000/01/rdf-schema#label> <http://www.w3.org/2004/02/skos/core#prefLabel> <http://www.w3.org/2004/02/skos/core#altLabel> <http://www.w3.org/2004/02/skos/core#hiddenLabel> <https://schema.org/name> <http://purl.org/dc/terms/title>  }

{
?focus_node ?pred ?match .
BIND(100 AS ?w)
FILTER (LCASE(?match) = "access")
}
UNION
{
?focus_node ?pred ?match .
BIND(20 AS ?w)
FILTER REGEX(?match, "^access", "i")
}
UNION
{
?focus_node ?pred ?match .
BIND(10 AS ?w)
FILTER REGEX(?match, "access", "i")
}
}GROUP BY ?focus_node ?pred ?match

}
}ORDER BY DESC( ?weight )
LIMIT 11 OFFSET 0

}?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1 .
}
```