### PR TITLE
feat: add on-disk data store for pyoxigraph

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -102,10 +102,13 @@ async def lifespan(app: FastAPI):
     log = logging.getLogger("prez")
     log.info("Starting up")
 
-    if app.state.settings.sparql_repo_type == "pyoxigraph":
+    if app.state.settings.sparql_repo_type == "pyoxigraph_memory":
         app.state.pyoxi_store = get_pyoxi_store()
         app.state.repo = PyoxigraphRepo(app.state.pyoxi_store)
         await load_local_data_to_oxigraph(app.state.pyoxi_store)
+    elif app.state.settings.sparql_repo_type == "pyoxigraph_persistent":
+        app.state.pyoxi_store = get_pyoxi_store()
+        app.state.repo = PyoxigraphRepo(app.state.pyoxi_store)
     elif app.state.settings.sparql_repo_type == "oxrdflib":
         app.state.oxrdflib_store = get_oxrdflib_store()
         app.state.repo = OxrdflibRepo(app.state.oxrdflib_store)
@@ -115,7 +118,7 @@ async def lifespan(app: FastAPI):
         await healthcheck_sparql_endpoints()
     else:
         raise ValueError(
-            "SPARQL_REPO_TYPE must be one of 'pyoxigraph', 'oxrdflib' or 'remote'"
+            "SPARQL_REPO_TYPE must be one of 'pyoxigraph_memory', 'pyoxigraph_persistent', 'oxrdflib' or 'remote'"
         )
 
     await prefix_initialisation(app.state.repo)

--- a/prez/config.py
+++ b/prez/config.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from os import environ
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, Literal
@@ -10,6 +11,17 @@ from rdflib.namespace import SKOS
 
 from prez.enums import SearchMethod
 from prez.reference_data.prez_ns import EP, REG, TERN
+
+
+class SparqlRepoType(str, Enum):
+    #: SPARQL endpoint
+    remote: str = "remote"
+    #: Pyoxigraph store with persistent on-disk storage
+    pyoxigraph_persistent: str = "pyoxigraph_persistent"
+    #: Pyoxigraph store in memory with optional loading of RDF from Turtle files
+    pyoxigraph_memory: str = "pyoxigraph_memory"
+    #: oxrdflib store in memory with optional loading of RDF from Turtle files
+    oxrdflib: str = "oxrdflib"
 
 
 class Settings(BaseSettings):
@@ -52,11 +64,7 @@ class Settings(BaseSettings):
         SDO.description,
     ]
     provenance_predicates: list = [DCTERMS.provenance]
-    value_predicates: list = [
-        SOSA.hasSimpleResult,
-        TERN.hasSimpleValue,
-        RDF.value
-    ]
+    value_predicates: list = [SOSA.hasSimpleResult, TERN.hasSimpleValue, RDF.value]
     search_predicates: list = [
         RDFS.label,
         SKOS.prefLabel,
@@ -66,9 +74,9 @@ class Settings(BaseSettings):
         DCTERMS.title,
     ]
     other_predicates: list = [SDO.color, REG.status]
-    sparql_repo_type: str = "remote"
+    sparql_repo_type: SparqlRepoType = SparqlRepoType.remote
     sparql_timeout: int = 30
-    pyoxigraph_data_dir: Optional[str] = None
+    pyoxigraph_data_dir: str = "pyoxigraph_data_dir"
     log_level: str = "INFO"
     log_output: str = "stdout"
     prez_title: Optional[str] = "Prez"
@@ -80,7 +88,6 @@ class Settings(BaseSettings):
     prez_contact: Optional[Dict[str, Union[str, Any]]] = None
     disable_prefix_generation: bool = False
     default_language: str = "en"
-    local_rdf_dir: str = "rdf"
     endpoint_structure: Optional[Tuple[str, ...]] = ("catalogs", "collections", "items")
     system_endpoints: Optional[List[URIRef]] = [
         EP["system/profile-listing"],

--- a/prez/config.py
+++ b/prez/config.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
     other_predicates: list = [SDO.color, REG.status]
     sparql_repo_type: str = "remote"
     sparql_timeout: int = 30
+    pyoxigraph_data_dir: Optional[str] = None
     log_level: str = "INFO"
     log_output: str = "stdout"
     prez_title: Optional[str] = "Prez"

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -57,7 +57,20 @@ async def get_async_http_client():
 
 
 def get_pyoxi_store():
-    return store
+    # Memory store
+    if settings.pyoxigraph_data_dir is None:
+        logger.info("Using in-memory pyoxigraph data store")
+        return store
+
+    # On-disk store
+    oxigraph_data_dir = Path(settings.pyoxigraph_data_dir)
+    if not oxigraph_data_dir.exists():
+        raise FileNotFoundError(
+            f"Pyoxigraph data directory {oxigraph_data_dir} does not exist"
+        )
+
+    logger.info(f"Using pyoxigraph data store {oxigraph_data_dir}")
+    return Store(path=str(oxigraph_data_dir))
 
 
 def get_system_store():

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -56,21 +56,28 @@ async def get_async_http_client():
     )
 
 
-def get_pyoxi_store():
-    # Memory store
-    if settings.pyoxigraph_data_dir is None:
-        logger.info("Using in-memory pyoxigraph data store")
-        return store
+def get_pyoxi_memory_store():
+    logger.info("Using in-memory pyoxigraph data store")
+    return store
 
-    # On-disk store
+
+def get_pyoxi_persistent_store():
     oxigraph_data_dir = Path(settings.pyoxigraph_data_dir)
     if not oxigraph_data_dir.exists():
         raise FileNotFoundError(
             f"Pyoxigraph data directory {oxigraph_data_dir} does not exist"
         )
-
     logger.info(f"Using pyoxigraph data store {oxigraph_data_dir}")
     return Store(path=str(oxigraph_data_dir))
+
+
+def get_pyoxi_store():
+    if settings.sparql_repo_type == "pyoxigraph_memory":
+        return get_pyoxi_memory_store()
+    elif settings.sparql_repo_type == "pyoxigraph_persistent":
+        return get_pyoxi_persistent_store()
+    else:
+        raise ValueError(f"Invalid pyoxigraph repo type: {settings.sparql_repo_type}")
 
 
 def get_system_store():
@@ -97,7 +104,7 @@ async def get_data_repo(
 ) -> Repo:
     if URIRef(request.scope.get("route").name) in settings.system_endpoints:
         return PyoxigraphRepo(pyoxi_system_store)
-    if settings.sparql_repo_type == "pyoxigraph":
+    if settings.sparql_repo_type == "pyoxigraph_memory" or settings.sparql_repo_type == "pyoxigraph_persistent":
         return PyoxigraphRepo(pyoxi_data_store)
     elif settings.sparql_repo_type == "oxrdflib":
         return OxrdflibRepo(oxrdflib_store)
@@ -127,7 +134,7 @@ async def load_local_data_to_oxigraph(store: Store):
     """
     Loads all the data from the local data directory into the local SPARQL endpoint
     """
-    for file in (Path(__file__).parent.parent / settings.local_rdf_dir).glob("*.ttl"):
+    for file in (Path(__file__).parent.parent / settings.pyoxigraph_data_dir).glob("**/*.ttl"):
         try:
             store.load(file.read_bytes(), "text/turtle")
         except SyntaxError as e:

--- a/prez/services/prez_logging.py
+++ b/prez/services/prez_logging.py
@@ -32,7 +32,6 @@ def setup_logger(settings):
         stdout_handler.setLevel(5)
         stdout_handler.setFormatter(formatter)
         handlers.append(stdout_handler)
-    logger.propagate = False
 
     # add ch to logger
     logger.handlers = handlers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from rdflib import Graph, URIRef
 from starlette.routing import Mount
 
 # comment / uncomment for the CQL tests - cannot figure out how to get a different conftest picked up.
-os.environ["SPARQL_REPO_TYPE"] = "pyoxigraph"
+os.environ["SPARQL_REPO_TYPE"] = "pyoxigraph_memory"
 
 # os.environ["SPARQL_ENDPOINT"] = "http://localhost:3030/dataset"
 # os.environ["SPARQL_REPO_TYPE"] = "remote"

--- a/tests/test_pyoxigraph_in_memory_store_storage.py
+++ b/tests/test_pyoxigraph_in_memory_store_storage.py
@@ -1,0 +1,10 @@
+import logging
+
+from prez.dependencies import get_pyoxi_store
+
+
+def test_pyoxigraph_in_memory_store_storage(caplog):
+    caplog.set_level(logging.INFO)
+    get_pyoxi_store()
+
+    assert "Using in-memory pyoxigraph data store" in caplog.text

--- a/tests/test_pyoxigraph_store_disk_storage.py
+++ b/tests/test_pyoxigraph_store_disk_storage.py
@@ -1,0 +1,44 @@
+import tempfile
+import logging
+from pathlib import Path
+
+import pytest
+
+from prez.dependencies import get_pyoxi_store
+from prez.config import settings
+
+
+@pytest.fixture(scope="function")
+def tmp_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        yield tmp_path
+
+    assert not tmp_path.exists()
+
+
+@pytest.fixture(autouse=True)
+def setup_settings(tmp_path: Path):
+    settings.pyoxigraph_data_dir = str(tmp_path)
+
+
+@pytest.fixture(scope="function")
+def non_existent_data_dir():
+    settings.pyoxigraph_data_dir = "non-existent-data-dir-for-testing"
+    return Path(settings.pyoxigraph_data_dir)
+
+
+def test_pyoxigraph_store_disk_storage_non_existent_data_dir(
+    non_existent_data_dir: Path,
+):
+    assert not non_existent_data_dir.exists()
+    with pytest.raises(FileNotFoundError):
+        get_pyoxi_store()
+
+
+def test_pyoxigraph_store_disk_storage_existent_data_dir(tmp_path: Path, caplog):
+    caplog.set_level(logging.INFO)
+    assert tmp_path.exists()
+    get_pyoxi_store()
+
+    assert "Using pyoxigraph data store" in caplog.text

--- a/tests/test_pyoxigraph_store_disk_storage.py
+++ b/tests/test_pyoxigraph_store_disk_storage.py
@@ -20,6 +20,7 @@ def tmp_path():
 @pytest.fixture(autouse=True)
 def setup_settings(tmp_path: Path):
     settings.pyoxigraph_data_dir = str(tmp_path)
+    settings.sparql_repo_type = "pyoxigraph_persistent"
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This PR adds support for using an on-disk store with the pyoxigraph data store backend.

If the environment variable `PYOXIGRAPH_DATA_DIR` is set, the data store will treat the specified location as a valid oxigraph data directory and operate in persistent (on-disk) mode instead of the default in-memory mode.

### Logging behaviour change

Not sure why log propagation was originally disabled. Without log propagation, I couldn't use caplog to capture the logs in tests.

Let me know if this needs to be added back in. We can make it configurable via settings so that we can enable it in tests and disable it in deployments.