### PR TITLE
fix: pyoxigraph persistent store lock contention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+pyoxigraph_data_dir/
+
 venv/
 __pycache__/
 .venv/

--- a/prez/cache.py
+++ b/prez/cache.py
@@ -21,6 +21,8 @@ links_ids_graph_cache.bind("prez", "https://prez.dev/")
 
 store = Store()
 
+persistent_store = None
+
 system_store = Store()
 
 annotations_store = Store()

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -76,12 +76,9 @@ def get_pyoxi_persistent_store():
 
 
 def get_pyoxi_store():
-    if settings.sparql_repo_type == "pyoxigraph_memory":
-        return get_pyoxi_memory_store()
-    elif settings.sparql_repo_type == "pyoxigraph_persistent":
+    if settings.sparql_repo_type == "pyoxigraph_persistent":
         return get_pyoxi_persistent_store()
-    else:
-        raise ValueError(f"Invalid pyoxigraph repo type: {settings.sparql_repo_type}")
+    return get_pyoxi_memory_store()
 
 
 def get_system_store():

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -17,6 +17,7 @@ from prez.cache import (
     queryable_props,
     store,
     system_store,
+    persistent_store,
 )
 from prez.config import settings
 from prez.enums import (
@@ -62,13 +63,16 @@ def get_pyoxi_memory_store():
 
 
 def get_pyoxi_persistent_store():
-    oxigraph_data_dir = Path(settings.pyoxigraph_data_dir)
-    if not oxigraph_data_dir.exists():
-        raise FileNotFoundError(
-            f"Pyoxigraph data directory {oxigraph_data_dir} does not exist"
-        )
-    logger.info(f"Using pyoxigraph data store {oxigraph_data_dir}")
-    return Store(path=str(oxigraph_data_dir))
+    global persistent_store
+    if persistent_store is None:
+        oxigraph_data_dir = Path(settings.pyoxigraph_data_dir)
+        if not oxigraph_data_dir.exists():
+            raise FileNotFoundError(
+                f"Pyoxigraph data directory {oxigraph_data_dir} does not exist"
+            )
+        logger.info(f"Using pyoxigraph data store {oxigraph_data_dir}")
+        persistent_store = Store(path=str(oxigraph_data_dir))
+    return persistent_store
 
 
 def get_pyoxi_store():


### PR DESCRIPTION
Each request was creating a new pyoxigraph `Store` and trying to access the same directory. This PR ensures only one store is created and reused across requests.