### PR TITLE
fix: don't recreate remotesparql repo and http_async_client on every request

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -112,12 +112,17 @@ async def lifespan(app: FastAPI):
             mount_app = r.app
             if isinstance(mount_app, (Starlette, FastAPI)) and mount_app is not app:
                 mounted_apps.append(mount_app)
-    if app.state.settings.sparql_repo_type == "pyoxigraph":
+    if app.state.settings.sparql_repo_type == "pyoxigraph_memory":
         app.state.pyoxi_store = pyoxi_store = get_pyoxi_store()
         for mounted_app in mounted_apps:
             mounted_app.state.pyoxi_store = pyoxi_store
         app.state.repo = repo = PyoxigraphRepo(pyoxi_store)
         await load_local_data_to_oxigraph(pyoxi_store)
+    elif app.state.settings.sparql_repo_type == "pyoxigraph_persistent":
+        app.state.pyoxi_store = pyoxi_store = get_pyoxi_store()
+        for mounted_app in mounted_apps:
+            mounted_app.state.pyoxi_store = pyoxi_store
+        app.state.repo = repo = PyoxigraphRepo(pyoxi_store)
     elif app.state.settings.sparql_repo_type == "oxrdflib":
         app.state.oxrdflib_store = oxrdflib_store = get_oxrdflib_store()
         for mounted_app in mounted_apps:
@@ -131,7 +136,7 @@ async def lifespan(app: FastAPI):
         await healthcheck_sparql_endpoints()
     else:
         raise ValueError(
-            "SPARQL_REPO_TYPE must be one of 'pyoxigraph', 'oxrdflib' or 'remote'"
+            "SPARQL_REPO_TYPE must be one of 'pyoxigraph_memory', 'pyoxigraph_persistent', 'oxrdflib' or 'remote'"
         )
 
     await prefix_initialisation(repo)

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -108,7 +108,7 @@ async def get_data_repo(
         return data_repo
     except (AttributeError, LookupError):
         pass
-    if settings.sparql_repo_type == "pyoxigraph":
+    if settings.sparql_repo_type == "pyoxigraph_memory" or settings.sparql_repo_type == "pyoxigraph_persistent":
         return PyoxigraphRepo(pyoxi_data_store)
     elif settings.sparql_repo_type == "oxrdflib":
         return OxrdflibRepo(oxrdflib_store)


### PR DESCRIPTION
Fixes #391 
This prevents the creation of a new `http_async_client` for every request.

1) Ensure some of the cached state objects that get set on the main FastAPI app also gets set on the mounted Sub-Apps.
2) Remove "get_async_http_client" dependency from the "get_data_repo" dependency. This stops a new client from being created every request
3) In `get_data_repo()` function, try to use the saved `app.state.repo`, and only fall back to creating the repo if that saved state object is not available