### PR TITLE
fix: try to use request accept mediatype in fallback profile

### DIFF
--- a/prez/services/connegp_service.py
+++ b/prez/services/connegp_service.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import time
 from enum import Enum
 from textwrap import dedent
 
@@ -212,22 +211,51 @@ class NegotiatedPMTs(BaseModel):
             }
             for result in repo_response[1][0][1]
         ]
+
         if not available:
+            if self.requested_mediatypes is not None and len(self.requested_mediatypes) > 0:
+                fallback_mediatype = self.requested_mediatypes[0][0]
+            else:
+                fallback_mediatype = None
             if self.listing:
+                # known available mediatypes for the 'mem' profile
+                _available_mem_types = [
+                    "application/ld+json" ,
+                    "application/anot+ld+json" ,
+                    "application/rdf+xml" ,
+                    "text/anot+turtle" ,
+                    "text/turtle"
+                ]
+                if fallback_mediatype is None or fallback_mediatype not in _available_mem_types:
+                    _use_mediatype = "text/anot+turtle"
+                else:
+                    _use_mediatype = fallback_mediatype
                 return [
                     {
                         "profile": URIRef("https://w3id.org/profile/mem"),
                         "title": "Members",
-                        "mediatype": "text/anot+turtle",
+                        "mediatype": _use_mediatype,
                         "class": "http://www.w3.org/2000/01/rdf-schema#Resource",
                     }
                 ]
             else:
+                # known available profiles for the 'open-object' profile
+                _available_open_types = [
+                    "application/ld+json" ,
+                    "application/anot+ld+json" ,
+                    "application/rdf+xml" ,
+                    "text/anot+turtle" ,
+                    "text/turtle"
+                ]
+                if fallback_mediatype is None or fallback_mediatype not in _available_open_types:
+                    _use_mediatype = "text/anot+turtle"
+                else:
+                    _use_mediatype = fallback_mediatype
                 return [
                     {
                         "profile": URIRef("https://prez.dev/profile/open-object"),
                         "title": "Open profile",
-                        "mediatype": "text/anot+turtle",
+                        "mediatype": _use_mediatype,
                         "class": "http://www.w3.org/2000/01/rdf-schema#Resource",
                     }
                 ]


### PR DESCRIPTION
When a specific profile isn't requested, and prez cannot find a profile to use for the object class, it falls back to hardcoded profiles  - open-object for Object endpoint, mem (Members) for Listing endpoint.

The problem is this fallback profile uses a single hardcorded mediatype "text/anot+turtle". Even if you have header "Accept: text/turtle" in the request or "?_mediatype=text/turtle" in the QSA, prez will still always use "text/anot+turtle".

https://github.com/RDFLib/prez/blob/cc8c3cac4ab3bc0580e65539f4568c43be28512e/prez/services/connegp_service.py#L217-L224

https://github.com/RDFLib/prez/blob/cc8c3cac4ab3bc0580e65539f4568c43be28512e/prez/services/connegp_service.py#L226-L233

In this PR:
Instead of using hardcoded mediatypes in fallback profiles, try to use the one that is requested if it matches one of the mediatypes allowed on the fallback profile.