### PR TITLE
feat: add gzip middleware enabled by default for >1000 bytes

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from typing import Any, Dict, Optional, Union
 
 from fastapi import FastAPI
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.utils import get_openapi
 from rdflib import Graph
 from starlette.middleware.cors import CORSMiddleware
@@ -218,6 +219,8 @@ def assemble_app(
         _app=app,
     )
 
+    if not _settings.gzip_min_size == -1:
+        app.add_middleware(GZipMiddleware, minimum_size=_settings.gzip_min_size)
     app.middleware("http")(add_cors_headers)
 
     app.add_middleware(

--- a/prez/config.py
+++ b/prez/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, Literal
 
 import toml
-from pydantic import field_validator
+from pydantic import field_validator, Field
 from pydantic_settings import BaseSettings
 from rdflib import DCTERMS, RDFS, SDO, URIRef, RDF, SOSA
 from rdflib.namespace import SKOS
@@ -110,6 +110,10 @@ class Settings(BaseSettings):
     use_path_aliases: bool = False
     spatial_query_format: Literal["geosparql", "qlever", "graphdb"] = "geosparql"
     search_uses_listing_count_limit: bool = False
+    gzip_min_size: int = Field(
+        default=1000,
+        description="Minimum size in bytes for gzip compression. Use -1 to disable compression altogether."
+    )
 
     @field_validator("prez_version")
     @classmethod


### PR DESCRIPTION
Adds the default GZipMiddleware available in FastAPI.
Opt out feature.
Min size before compression is used is set with new config setting: `gzip_min_size`. Default value is 1000 bytes for no particular reason; 500 or 1000 values are common.
To disable compression altogether set `gzip_min_size=-1` i.e. the behaviour prior to this PR.

Didn't see much performance difference in local testing i.e. API and browser on same machine - I imagine it will help in non local settings particularly with larger responses. Would be good to get some rough numbers to back this up.