### PR TITLE
fix: for missing ?focus_node var on inner subselect for CQL-genreated SUBSELECT query

### DIFF
--- a/prez/services/query_generation/cql.py
+++ b/prez/services/query_generation/cql.py
@@ -92,7 +92,8 @@ class CQLParser:
             queryable_props=None,
     ):
         self.inner_select_gpntotb_list: list[GraphPatternNotTriples] = []
-        self.inner_select_vars: list[Var] = []
+        # Always include at least ?focus_node SELECT var
+        self.inner_select_vars: list[Var] = [Var(value="focus_node")]
         self.cql: dict = cql
         self.cql_json = cql_json
         self.var_counter = 0

--- a/tests/test_cql.py
+++ b/tests/test_cql.py
@@ -469,3 +469,25 @@ UNION
     ]
     assert len(parser.inner_select_gpntotb_list) == len(expected_inner_select_gpntotb_list_str)
     assert parser.inner_select_gpntotb_list[0].to_string().replace(" ", "").replace("\n", "") == expected_inner_select_gpntotb_list_str[0].replace(" ", "").replace("\n", "")
+
+
+def test_focus_node_in_subquery():
+    """
+    Tests that ?focus_node is always included in the inner select variables,
+    even for a simple query.
+    """
+    from prez.services.query_generation.cql import CQLParser
+    from sparql_grammar_pydantic import Var
+
+    cql_json_data = {
+        "op": "=",
+        "args": [
+            {"property": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},
+            "http://www.w3.org/ns/sosa/Sample",
+        ],
+    }
+
+    parser = CQLParser(cql_json=cql_json_data)
+    parser.parse()
+
+    assert Var(value="focus_node") in parser.inner_select_vars

--- a/tests/test_query_construction.py
+++ b/tests/test_query_construction.py
@@ -334,3 +334,32 @@ def test_count_query():
         solution_modifier=SolutionModifier(),
     )
     print(query)
+
+
+def test_umbrella_cql_query():
+    """
+    Tests that a CQL query handled by the umbrella PrezQueryConstructor
+    correctly includes ?focus_node in its subquery.
+    """
+    from prez.services.query_generation.cql import CQLParser
+    from prez.services.query_generation.umbrella import (
+        merge_listing_query_grammar_inputs,
+    )
+    from prez.models.query_params import ListingQueryParams
+
+    cql_json_data = {
+        "op": "=",
+        "args": [
+            {"property": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},
+            "http://www.w3.org/ns/sosa/Sample",
+        ],
+    }
+    parser = CQLParser(cql_json=cql_json_data)
+    parser.parse()
+    qp = ListingQueryParams(limit=1, page=1, offset=1, _filter=None, bbox = [], datetime=None, order_by=None)
+    kwargs = merge_listing_query_grammar_inputs(
+        cql_parser=parser, query_params=qp
+    )
+    query = PrezQueryConstructor(**kwargs)
+    query_string = query.to_string()
+    assert "SELECT DISTINCT ?focus_node" in query_string


### PR DESCRIPTION
Fixes #402 

This adds `?focus_node` as a static always-present Variable for the inner SUBSELECT on the CQL query generation.

This is required because #387 removed the addtion of "?focus_node" from the umbrella query.

As @recalcitrantsupplant mentioned in #387, its better to have the Search and CQL query generation include `?focus_node" themselves rather than add it in the umbrella, so the subquery is complete in and of itself, for testing purposes.

Evidently there was no testing for this, because the CQL query breakage flew under the radar.