### PR TITLE
feat: wrap cql datetime and bounding box expressions in filter exists

### DIFF
--- a/prez/models/query_params.py
+++ b/prez/models/query_params.py
@@ -41,7 +41,7 @@ def reformat_bbox(
         if len(coords) not in [4, 6]:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid bbox format: Expected 4 or 6 coordinates, got {len(coords)}"
+                detail=f"Invalid bbox format: Expected 4 or 6 coordinates, got {len(coords)}",
             )
 
         return coords
@@ -50,7 +50,7 @@ def reformat_bbox(
         raise HTTPException(
             status_code=400,
             detail=f"Invalid bbox format: Unable to parse coordinates as numbers. Expected format: 'minx,miny,maxx,maxy'"
-                   f", received '{bbox[0]}'"
+            f", received '{bbox[0]}'",
         )
 
 
@@ -195,7 +195,7 @@ class ListingQueryParams:
         self.profile = profile
         self.page = page
         self.limit = limit
-        self.offset = offset if not hasattr(offset, 'default') else offset.default
+        self.offset = offset if not hasattr(offset, "default") else offset.default
         self.facet_profile = facet_profile
         self.bbox = bbox
         self.filter_lang = filter_lang
@@ -206,30 +206,36 @@ class ListingQueryParams:
         self._filter = _filter
         self.mediatype = mediatype
         self.subscription_key = subscription_key
-        self.startindex = startindex if not hasattr(startindex, 'default') else startindex.default
+        self.startindex = (
+            startindex if not hasattr(startindex, "default") else startindex.default
+        )
         self.validate_pagination_params()
         self.validate_filter()
 
     def validate_pagination_params(self):
         """Validate mutually exclusive pagination parameters."""
         from fastapi import HTTPException
-        
+
         # Debug print to see what values we have
-        print(f"DEBUG - page: {self.page}, offset: {self.offset}, startindex: {self.startindex}")
-        
+        print(
+            f"DEBUG - page: {self.page}, offset: {self.offset}, startindex: {self.startindex}"
+        )
+
         pagination_params = [
             (self.page != 1, "page"),  # page=1 is default, so only conflict if changed
             (self.offset is not None, "offset"),
-            (self.startindex is not None, "startindex")
+            (self.startindex is not None, "startindex"),
         ]
-        
-        provided_params = [(provided, name) for provided, name in pagination_params if provided]
-        
+
+        provided_params = [
+            (provided, name) for provided, name in pagination_params if provided
+        ]
+
         if len(provided_params) > 1:
             param_names = [name for _, name in provided_params]
             raise HTTPException(
-                status_code=400, 
-                detail=f"Mutually exclusive pagination parameters provided: {', '.join(param_names)}. Use only one of: page, offset, or startindex."
+                status_code=400,
+                detail=f"Mutually exclusive pagination parameters provided: {', '.join(param_names)}. Use only one of: page, offset, or startindex.",
             )
 
     def validate_filter(self):

--- a/prez/services/query_generation/cql.py
+++ b/prez/services/query_generation/cql.py
@@ -22,7 +22,8 @@ from sparql_grammar_pydantic import (
     TriplesBlock,
     TriplesSameSubjectPath,
     Var,
-    WhereClause, IRIOrFunction,
+    WhereClause,
+    IRIOrFunction,
 )
 
 from prez.cache import prez_system_graph
@@ -46,7 +47,8 @@ from prez.services.query_generation.grammar_helpers import (
     create_temporal_or_gpnt,
     create_filter_bool_gpnt,
     create_temporal_and_gpnt,
-    create_filter_not_exists, _create_filter_in,
+    create_filter_not_exists,
+    _create_filter_in,
 )
 from prez.services.query_generation.shacl import PropertyShape
 from prez.services.query_generation.spatial_filter import (
@@ -109,9 +111,7 @@ class CQLParser:
         # Get patterns from parsing with focus_node optimization applied at each level
         parsed_ggps = next(self.parse_logical_operators(root))
 
-        where = WhereClause(
-            group_graph_pattern=GroupGraphPattern(content=parsed_ggps)
-        )
+        where = WhereClause(group_graph_pattern=GroupGraphPattern(content=parsed_ggps))
 
         if self.tss_list:
             construct_triples = ConstructTriples.from_tss_list(self.tss_list)
@@ -274,7 +274,9 @@ class CQLParser:
 
             # Re-parse to collect TSSP patterns properly
             temp_ggps = next(self.parse_logical_operators(nested_arg), None)
-            combined_nested_patterns = self.combine_all_patterns(temp_ggps if temp_ggps else GroupGraphPatternSub())
+            combined_nested_patterns = self.combine_all_patterns(
+                temp_ggps if temp_ggps else GroupGraphPatternSub()
+            )
 
             # Restore original TSSP list
             self.tssp_list = temp_tssp_list
@@ -306,7 +308,9 @@ class CQLParser:
             )
             self._add_tssp_to_ggps(ggps, tssp)
 
-    def _add_tssp_to_ggps(self, ggps: GroupGraphPatternSub, tssp: TriplesSameSubjectPath) -> None:
+    def _add_tssp_to_ggps(
+        self, ggps: GroupGraphPatternSub, tssp: TriplesSameSubjectPath
+    ) -> None:
         """Add a TSSP as a TriplesBlock to the GGPS."""
         new_tb_for_this_tssp = TriplesBlock(triples=tssp)
 

--- a/prez/services/query_generation/grammar_helpers.py
+++ b/prez/services/query_generation/grammar_helpers.py
@@ -54,7 +54,8 @@ from sparql_grammar_pydantic import (
     TriplesSameSubjectPath,
     UnaryExpression,
     ValueLogical,
-    Var, NotExistsFunc,
+    Var,
+    NotExistsFunc,
     Var,
     VarOrTerm,
     VerbPath,
@@ -568,9 +569,7 @@ def _create_filter_in(variable: Var, values: list) -> GraphPatternNotTriples:
     right_primary_expressions = []
     for value in values:
         rdf_term = convert_value_to_rdf_term(value)
-        right_primary_expressions.append(
-            PrimaryExpression(content=rdf_term)
-        )
+        right_primary_expressions.append(PrimaryExpression(content=rdf_term))
 
     in_expr = Expression.create_in_expression(
         left_primary_expression=PrimaryExpression(content=variable),
@@ -580,8 +579,6 @@ def _create_filter_in(variable: Var, values: list) -> GraphPatternNotTriples:
 
     return GraphPatternNotTriples(
         content=Filter(
-            constraint=Constraint(
-                content=BrackettedExpression(expression=in_expr)
-            )
+            constraint=Constraint(content=BrackettedExpression(expression=in_expr))
         )
     )

--- a/prez/services/query_generation/spatial_filter.py
+++ b/prez/services/query_generation/spatial_filter.py
@@ -389,7 +389,7 @@ def generate_bbox_filter(
                 ),
                 TriplesSameSubjectPath.from_spo(
                     geom_bn_var, IRI(value=GEO.asWKT), geom_lit_var
-                )
+                ),
             ]
         )
 
@@ -400,7 +400,9 @@ def generate_bbox_filter(
                 triples=TriplesSameSubjectPath.from_spo(
                     geom_bn_var,
                     IRI(value=GEO.sfIntersects),
-                    RDFLiteral(value=processed_wkt, datatype=IRI(value=str(GEO.wktLiteral))),
+                    RDFLiteral(
+                        value=processed_wkt, datatype=IRI(value=str(GEO.wktLiteral))
+                    ),
                 )
             )
         )
@@ -418,7 +420,9 @@ def generate_bbox_filter(
             target_system=target_system,
         )
         if not spatial_filter_gpnts:
-            raise ValueError("generate_spatial_filter_clause returned no patterns for GeoSPARQL bbox.")
+            raise ValueError(
+                "generate_spatial_filter_clause returned no patterns for GeoSPARQL bbox."
+            )
 
         for gpnt in spatial_filter_gpnts:
             ggps.add_pattern(gpnt)
@@ -426,11 +430,7 @@ def generate_bbox_filter(
         # do not use a FILTER EXISTS, assume the triplestore query optimiser will execute performantly
         final_gpnt = GraphPatternNotTriples(
             content=GroupOrUnionGraphPattern(
-                group_graph_patterns=[
-                    GroupGraphPattern(
-                        content=ggps
-                    )
-                ]
+                group_graph_patterns=[GroupGraphPattern(content=ggps)]
             )
         )
 

--- a/prez/services/query_generation/umbrella.py
+++ b/prez/services/query_generation/umbrella.py
@@ -316,7 +316,7 @@ def merge_listing_query_grammar_inputs(
         triple = (
             Var(value="focus_node"),
             IRI(value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
-            Var(value="prof_1_node_1")
+            Var(value="prof_1_node_1"),
         )
         tss = TriplesSameSubject.from_spo(*triple)
         tssp = TriplesSameSubjectPath.from_spo(*triple)

--- a/tests/test_cql.py
+++ b/tests/test_cql.py
@@ -131,7 +131,9 @@ UNION
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
     assert len(original_patterns) == len(expected_inner_select_gpntotb_list_str)
     assert original_patterns[0].to_string().replace(" ", "").replace(
         "\n", ""
@@ -202,19 +204,27 @@ def test_cql_nested_and_operator():
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
 
     # With focus_node optimization, AND operations now generate individual TriplesBlocks
     # Combine them into a single string to match the test expectation
-    if len(original_patterns) > 1 and all(hasattr(p, 'to_string') for p in original_patterns):
+    if len(original_patterns) > 1 and all(
+        hasattr(p, "to_string") for p in original_patterns
+    ):
         # Remove duplicates by converting to set of strings, then back to list
         pattern_strings = list(set(p.to_string().strip() for p in original_patterns))
-        combined_pattern = "\n".join(sorted(pattern_strings))  # Sort for consistent ordering
+        combined_pattern = "\n".join(
+            sorted(pattern_strings)
+        )  # Sort for consistent ordering
     else:
         combined_pattern = original_patterns[0].to_string() if original_patterns else ""
 
     expected_combined = expected_inner_select_gpntotb_list_str[0]
-    assert combined_pattern.replace(" ", "").replace("\n", "") == expected_combined.replace(" ", "").replace("\n", "")
+    assert combined_pattern.replace(" ", "").replace(
+        "\n", ""
+    ) == expected_combined.replace(" ", "").replace("\n", "")
 
 
 # --- Tests for nested AND/OR operators ---
@@ -276,10 +286,12 @@ def _extract_patterns_from_filter_exists(inner_select_gpntotb_list):
         pattern = inner_select_gpntotb_list[0]
 
         # Check if it's a FILTER EXISTS wrapper
-        if (hasattr(pattern, 'content') and
-            hasattr(pattern.content, 'constraint') and
-            hasattr(pattern.content.constraint, 'content') and
-            hasattr(pattern.content.constraint.content, 'other_expressions')):
+        if (
+            hasattr(pattern, "content")
+            and hasattr(pattern.content, "constraint")
+            and hasattr(pattern.content.constraint, "content")
+            and hasattr(pattern.content.constraint.content, "other_expressions")
+        ):
 
             # Navigate through the FILTER EXISTS structure:
             # GraphPatternNotTriples -> Filter -> Constraint -> BuiltInCall -> ExistsFunc -> GroupGraphPattern -> GroupGraphPatternSub
@@ -328,7 +340,9 @@ UNION
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
     assert len(original_patterns) == len(expected_inner_select_gpntotb_list_str)
     assert original_patterns[0].to_string().replace(" ", "").replace(
         "\n", ""
@@ -365,7 +379,9 @@ UNION
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
     assert len(original_patterns) == len(expected_inner_select_gpntotb_list_str)
     assert original_patterns[0].to_string().replace(" ", "").replace(
         "\n", ""
@@ -394,7 +410,9 @@ def test_cql_and_of_and_AB_C():
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
     assert len(original_patterns) == len(expected_inner_select_gpntotb_list_str)
     assert original_patterns[0].to_string().replace(" ", "").replace(
         "\n", ""
@@ -482,7 +500,9 @@ UNION
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
     assert len(original_patterns) == len(expected_inner_select_gpntotb_list_str)
     assert original_patterns[0].to_string().replace(" ", "").replace(
         "\n", ""
@@ -527,7 +547,9 @@ UNION
     ]
 
     # Extract original patterns from within FILTER EXISTS wrapper
-    original_patterns = _extract_patterns_from_filter_exists(parser.inner_select_gpntotb_list)
+    original_patterns = _extract_patterns_from_filter_exists(
+        parser.inner_select_gpntotb_list
+    )
     assert len(original_patterns) == len(expected_inner_select_gpntotb_list_str)
     assert original_patterns[0].to_string().replace(" ", "").replace(
         "\n", ""
@@ -787,7 +809,7 @@ def test_cql_not_operator_with_complex_expression():
                                     "true",
                                 ],
                             },
-                        ]
+                        ],
                     }
                 ],
             },
@@ -836,7 +858,9 @@ def test_cql_double_negation():
     query_str = parser.query_str
     # Should have nested FILTER NOT EXISTS statements
     not_exists_count = query_str.count("FILTER NOT EXISTS")
-    assert not_exists_count == 2, f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
+    assert (
+        not_exists_count == 2
+    ), f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
     assert '"active"' in query_str
 
 
@@ -883,7 +907,9 @@ def test_cql_or_with_not_branches():
     # Should have UNION with FILTER NOT EXISTS in each branch
     assert "UNION" in query_str
     not_exists_count = query_str.count("FILTER NOT EXISTS")
-    assert not_exists_count == 2, f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
+    assert (
+        not_exists_count == 2
+    ), f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
     assert '"inactive"' in query_str
     assert '"true"' in query_str
 
@@ -933,7 +959,9 @@ def test_cql_complex_nested_not_and_or():
                                             {
                                                 "op": "=",
                                                 "args": [
-                                                    {"property": "http://example.org/verified"},
+                                                    {
+                                                        "property": "http://example.org/verified"
+                                                    },
                                                     "true",
                                                 ],
                                             },
@@ -954,7 +982,9 @@ def test_cql_complex_nested_not_and_or():
     query_str = parser.query_str
     # Should have nested structure with multiple FILTER NOT EXISTS
     not_exists_count = query_str.count("FILTER NOT EXISTS")
-    assert not_exists_count == 2, f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
+    assert (
+        not_exists_count == 2
+    ), f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
     assert "UNION" in query_str  # From OR inside first NOT
     assert '"alice"' in query_str
     assert '"banned"' in query_str
@@ -1004,7 +1034,9 @@ def test_cql_not_of_and_with_not():
     query_str = parser.query_str
     # Should have nested FILTER NOT EXISTS structures
     not_exists_count = query_str.count("FILTER NOT EXISTS")
-    assert not_exists_count == 2, f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
+    assert (
+        not_exists_count == 2
+    ), f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
     assert '"premium"' in query_str
     assert '"true"' in query_str
 
@@ -1044,7 +1076,9 @@ def test_cql_triple_negation():
     query_str = parser.query_str
     # Should have three nested FILTER NOT EXISTS statements
     not_exists_count = query_str.count("FILTER NOT EXISTS")
-    assert not_exists_count == 3, f"Expected 3 FILTER NOT EXISTS, got {not_exists_count}"
+    assert (
+        not_exists_count == 3
+    ), f"Expected 3 FILTER NOT EXISTS, got {not_exists_count}"
     assert '"enabled"' in query_str
 
 
@@ -1115,7 +1149,9 @@ def test_cql_mixed_operators_with_multiple_nots():
     # Should have UNION with different NOT structures in each branch
     assert "UNION" in query_str
     not_exists_count = query_str.count("FILTER NOT EXISTS")
-    assert not_exists_count == 2, f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
+    assert (
+        not_exists_count == 2
+    ), f"Expected 2 FILTER NOT EXISTS, got {not_exists_count}"
     assert '"user"' in query_str
     assert "suspended" in query_str  # Property name will be in the URI
     assert '"guest"' in query_str

--- a/tests/test_filter_combinations.py
+++ b/tests/test_filter_combinations.py
@@ -2,6 +2,7 @@
 Tests for combinations of datetime, bbox, and CQL filters to ensure
 FILTER EXISTS optimization works correctly when multiple filters are applied.
 """
+
 import pytest
 from datetime import datetime
 from prez.services.query_generation.cql import CQLParser
@@ -25,24 +26,22 @@ def test_cql_datetime_combination():
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create datetime filter
     dt1 = datetime(2023, 1, 1)
     dt2 = datetime(2023, 12, 31)
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
+        limit=10,
+        page=1,
         _filter=None,
-        bbox=[], 
-        datetime=(dt1, dt2), 
+        bbox=[],
+        datetime=(dt1, dt2),
         order_by=None,
-        order_by_direction=None
+        order_by_direction=None,
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
 
@@ -50,7 +49,7 @@ def test_cql_datetime_combination():
     assert "http://www.w3.org/ns/sosa/Sample" in query_string
     assert "2023-01-01T00:00:00" in query_string
     assert "2023-12-31T00:00:00" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
 
@@ -67,32 +66,30 @@ def test_cql_bbox_combination():
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create bbox filter
     bbox = [144.0, -38.0, 145.0, -37.0]
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
-        _filter=None, 
-        bbox=bbox, 
-        datetime=None, 
+        limit=10,
+        page=1,
+        _filter=None,
+        bbox=bbox,
+        datetime=None,
         order_by=None,
         order_by_direction=None,
-        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326"
+        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326",
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
-    
+
     # Should contain both the CQL REGEX pattern and geometry patterns
     assert "REGEX" in query_string
     assert "test.*" in query_string
     assert "hasGeometry" in query_string or "sfIntersects" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
 
@@ -101,31 +98,29 @@ def test_datetime_bbox_combination():
     """Test datetime filter combined with bbox filter."""
     # Create datetime filter
     dt1 = datetime(2023, 6, 15)
-    
-    # Create bbox filter  
+
+    # Create bbox filter
     bbox = [150.0, -35.0, 151.0, -34.0]
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
-        _filter=None, 
-        bbox=bbox, 
-        datetime=(dt1, None), 
+        limit=10,
+        page=1,
+        _filter=None,
+        bbox=bbox,
+        datetime=(dt1, None),
         order_by=None,
         order_by_direction=None,
-        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326"
+        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326",
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=None, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=None, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
-    
+
     # Should contain both datetime and geometry patterns
     assert "2023-06-15T00:00:00" in query_string
     assert "hasGeometry" in query_string or "sfIntersects" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
 
@@ -149,50 +144,48 @@ def test_cql_datetime_bbox_triple_combination():
                     {"property": "http://example.org/temperature"},
                     20,
                 ],
-            }
+            },
         ],
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create datetime interval filter
     dt1 = datetime(2023, 3, 1)
     dt2 = datetime(2023, 9, 30)
-    
+
     # Create bbox filter
     bbox = [145.0, -37.5, 146.0, -36.5]
-    
+
     qp = ListingQueryParams(
-        limit=20, 
-        page=1, 
-        _filter=None, 
-        bbox=bbox, 
-        datetime=(dt1, dt2), 
+        limit=20,
+        page=1,
+        _filter=None,
+        bbox=bbox,
+        datetime=(dt1, dt2),
         order_by=None,
         order_by_direction=None,
-        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326"
+        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326",
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
 
     # Should contain CQL patterns
     assert "http://www.w3.org/ns/sosa/Sample" in query_string
     assert "http://example.org/temperature" in query_string
-    
+
     # Should contain datetime patterns
     assert "2023-03-01T00:00:00" in query_string
     assert "2023-09-30T00:00:00" in query_string
-    
+
     # Should contain geometry patterns
     assert "hasGeometry" in query_string or "sfIntersects" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
-    
+
     # Should have proper LIMIT
     assert "LIMIT 20" in query_string
 
@@ -214,36 +207,34 @@ def test_cql_not_operator_with_datetime():
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create datetime filter (single point in time)
     dt1 = datetime(2023, 7, 4, 12, 0, 0)
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
-        _filter=None, 
-        bbox=[], 
-        datetime=(dt1, None), 
+        limit=10,
+        page=1,
+        _filter=None,
+        bbox=[],
+        datetime=(dt1, None),
         order_by=None,
-        order_by_direction=None
+        order_by_direction=None,
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
 
     # Should contain FILTER NOT EXISTS for the CQL NOT operator
     assert "FILTER NOT EXISTS" in query_string
-    
+
     # Should contain the negated property
     assert "http://example.org/status" in query_string
     assert "inactive" in query_string
-    
+
     # Should contain datetime pattern
     assert "2023-07-04T12:00:00" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
 
@@ -277,45 +268,43 @@ def test_complex_cql_or_with_bbox():
                             {"property": "http://example.org/elevation"},
                             100,
                         ],
-                    }
-                ]
-            }
+                    },
+                ],
+            },
         ],
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create bbox filter
     bbox = [147.0, -36.0, 148.0, -35.0]
-    
+
     qp = ListingQueryParams(
-        limit=15, 
-        page=1, 
-        _filter=None, 
-        bbox=bbox, 
-        datetime=None, 
+        limit=15,
+        page=1,
+        _filter=None,
+        bbox=bbox,
+        datetime=None,
         order_by=None,
         order_by_direction=None,
-        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326"
+        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326",
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
 
     # Should contain UNION for OR operation
     assert "UNION" in query_string
-    
+
     # Should contain the category values
     assert "water" in query_string
     assert "land" in query_string
     assert "http://example.org/elevation" in query_string
-    
+
     # Should contain geometry patterns
     assert "hasGeometry" in query_string or "sfIntersects" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
 
@@ -332,23 +321,21 @@ def test_filter_exists_patterns_structure():
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create datetime filter
     dt1 = datetime(2023, 1, 1)
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
-        _filter=None, 
-        bbox=[], 
-        datetime=(dt1, None), 
+        limit=10,
+        page=1,
+        _filter=None,
+        bbox=[],
+        datetime=(dt1, None),
         order_by=None,
-        order_by_direction=None
+        order_by_direction=None,
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
 
@@ -365,27 +352,25 @@ def test_empty_filters_combination():
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
-        _filter=None, 
-        bbox=[], # Empty bbox
-        datetime=None, # No datetime
+        limit=10,
+        page=1,
+        _filter=None,
+        bbox=[],  # Empty bbox
+        datetime=None,  # No datetime
         order_by=None,
-        order_by_direction=None
+        order_by_direction=None,
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
-    
+
     # Should contain the CQL filter content
     assert "http://example.org/test" in query_string
     assert "value" in query_string
-    
+
     # Should have inner select with focus_node
     assert "SELECT DISTINCT ?focus_node" in query_string
 
@@ -402,35 +387,33 @@ def test_order_by_with_filter_combinations():
     }
     parser = CQLParser(cql_json=cql_json_data)
     parser.parse()
-    
+
     # Create bbox filter
     bbox = [149.0, -35.5, 150.0, -34.5]
-    
+
     qp = ListingQueryParams(
-        limit=10, 
-        page=1, 
-        _filter=None, 
-        bbox=bbox, 
-        datetime=None, 
+        limit=10,
+        page=1,
+        _filter=None,
+        bbox=bbox,
+        datetime=None,
         order_by="http://www.w3.org/2000/01/rdf-schema#label",
         order_by_direction=OrderByDirectionEnum.DESC,
-        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326"
+        filter_crs="http://www.opengis.net/def/crs/EPSG/0/4326",
     )
-    
-    kwargs = merge_listing_query_grammar_inputs(
-        cql_parser=parser, query_params=qp
-    )
+
+    kwargs = merge_listing_query_grammar_inputs(cql_parser=parser, query_params=qp)
     query = PrezQueryConstructor(**kwargs)
     query_string = query.to_string()
 
     # Should have ORDER BY clause
     assert "ORDER BY DESC" in query_string
     assert "STR" in query_string  # STR function for label ordering
-    
+
     # Should contain both filter patterns
     assert "http://example.org/score" in query_string
     assert "hasGeometry" in query_string or "sfIntersects" in query_string
-    
+
     # Should have inner select with focus_node and order_by_val
     assert "SELECT DISTINCT ?focus_node" in query_string
     assert "?order_by_val" in query_string


### PR DESCRIPTION
This change is specific to focus node selection so only applies to listing endpoints.
It wraps each of any:
~1. CQL expression (posted to /cql, or as a query parameter on any listing endpoint via the filter query param)~
~2. `datetime` query parameter expression~
3. `bbox` query parameter expression - only in the case of GraphDB

This is intended to improve the performance of focus_node selection, as triplestores (may) provide a faster response where the results of the expression no longer need to be returned.

To support this change an additional check has been added such that, if the **only** contents of the focus node subselect would be a `FILTER EXISTS` expression, an additional focus node class selection triple is added, which will match the default class selection triple used in property selection (`?focus_node rdf:type ?prof_1_node_1`). This ensures that at least one value is bound in the subselect.
Edit: This change should no longer be needed for FILTER EXISTS but remains for the FILTER NOT EXISTS case

An additional feature was added to support negation in CQL, i.e. the CQL "not" operator. This was implemented by wrapping child arguments in a `FILTER NOT EXISTS` expression.

Addresses https://github.com/RDFLib/prez/issues/405
