### PR TITLE
fix: remove extra serialize line that breaks oxigraph serialize

### DIFF
--- a/prez/services/listings.py
+++ b/prez/services/listings.py
@@ -508,5 +508,4 @@ async def ogc_features_listing_function(
         # TODO, what happens if the store has content in a named graph? This can only dump the default graph.
         item_store.dump(content, serializer_format, from_graph=default, prefixes=oxigraph_prefixes)
         content.seek(0)  # Reset the stream position to the beginning
-        content = io.BytesIO(item_graph.serialize(format=non_anot_mt, encoding="utf-8"))
     return content, link_headers

--- a/tests/test_ogc_features_manual.py
+++ b/tests/test_ogc_features_manual.py
@@ -80,3 +80,20 @@ def test_bbox_graphdb_200_4326_crs(client):
         assert r.status_code == 200
     finally:
         settings.spatial_query_format = original_format
+
+
+def test_ogc_features_listing_annotated(client):
+    # General regression test that would have caught the bug fixed in #413
+    r = client.get(
+        "/catalogs/ex:DemoCatalog/collections/ex:GeoDataset/features/collections?_profile=mem&_mediatype=text/anot%2Bturtle"
+    )
+    assert r.status_code == 200
+    assert len(r.content) > 0
+
+def test_ogc_features_object_annotated(client):
+    # General regression test
+    r = client.get(
+        "/catalogs/ex:DemoCatalog/collections/ex:GeoDataset/features/collections/ex:FeatureCollection?_mediatype=text/anot%2Bturtle&_profile=ogcfeat-minimal"
+    )
+    assert r.status_code == 200
+    assert len(r.content) > 0


### PR DESCRIPTION
Looks like a copy+paste error made its way into the Oxigraph changes.
When using the OGC-Featues API listing endpoint, if requesting an annotation mediatype like `anot+turtle` then Prez crashes because it tries to serialize the oxigraph ItemStore twice.