### PR TITLE
feat: pass on timeout to remote triplestores and ensure httpx errors are returned

### DIFF
--- a/prez/app.py
+++ b/prez/app.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, Optional, Union
 
+import httpx
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from rdflib import Graph
@@ -58,6 +59,7 @@ from prez.services.exception_catchers import (
     catch_404,
     catch_500,
     catch_class_not_found_exception,
+    catch_httpx_error,
     catch_invalid_sparql_query,
     catch_no_endpoint_nodeshape_exception,
     catch_no_profiles_exception,
@@ -213,7 +215,8 @@ def assemble_app(
             NoProfilesException: catch_no_profiles_exception,
             InvalidSPARQLQueryException: catch_invalid_sparql_query,
             NoEndpointNodeshapeException: catch_no_endpoint_nodeshape_exception,
-            MissingFilterQueryError: catch_missing_filter_query_param
+            MissingFilterQueryError: catch_missing_filter_query_param,
+            httpx.HTTPError: catch_httpx_error,
         },
         **kwargs
     )

--- a/prez/config.py
+++ b/prez/config.py
@@ -75,7 +75,8 @@ class Settings(BaseSettings):
     ]
     other_predicates: list = [SDO.color, REG.status]
     sparql_repo_type: SparqlRepoType = SparqlRepoType.remote
-    sparql_timeout: int = 30
+    sparql_timeout: int = 60
+    sparql_timeout_param_name: Optional[str] = "timeout"
     pyoxigraph_data_dir: str = "pyoxigraph_data_dir"
     log_level: str = "INFO"
     log_output: str = "stdout"

--- a/tests/test_remote_sparql_timeout.py
+++ b/tests/test_remote_sparql_timeout.py
@@ -1,0 +1,166 @@
+import pytest
+from unittest.mock import AsyncMock, Mock, patch
+import httpx
+from prez.repositories.remote_sparql import RemoteSparqlRepo
+from prez.config import settings
+
+
+@pytest.fixture
+def mock_async_client():
+    """Mock httpx AsyncClient for testing."""
+    return Mock(spec=httpx.AsyncClient)
+
+
+@pytest.fixture
+def remote_repo(mock_async_client):
+    """Create RemoteSparqlRepo with mocked client."""
+    with patch.object(settings, 'sparql_endpoint', 'http://test-sparql-endpoint.com'):
+        return RemoteSparqlRepo(mock_async_client)
+
+
+class TestRemoteSparqlTimeout:
+    """Test timeout parameter functionality in RemoteSparqlRepo."""
+
+    @pytest.mark.asyncio
+    async def test_send_query_with_timeout_param(self, remote_repo, mock_async_client):
+        """Test that timeout parameter is added to form data when configured."""
+        # Setup
+        mock_response = Mock(spec=httpx.Response)
+        mock_async_client.build_request.return_value = Mock()
+        mock_async_client.send.return_value = mock_response
+        
+        with patch.object(settings, 'sparql_timeout_param_name', 'timeout'), \
+             patch.object(settings, 'sparql_timeout', 30):
+            
+            # Execute
+            await remote_repo._send_query("SELECT * WHERE { ?s ?p ?o }")
+            
+            # Verify
+            mock_async_client.build_request.assert_called_once()
+            call_args = mock_async_client.build_request.call_args
+            
+            # Check that timeout parameter was added to data
+            assert call_args[1]['data']['query'] == "SELECT * WHERE { ?s ?p ?o }"
+            assert call_args[1]['data']['timeout'] == "30"
+
+    @pytest.mark.asyncio
+    async def test_send_query_without_timeout_param(self, remote_repo, mock_async_client):
+        """Test that no timeout parameter is added when not configured."""
+        # Setup
+        mock_response = Mock(spec=httpx.Response)
+        mock_async_client.build_request.return_value = Mock()
+        mock_async_client.send.return_value = mock_response
+        
+        with patch.object(settings, 'sparql_timeout_param_name', None):
+            
+            # Execute
+            await remote_repo._send_query("SELECT * WHERE { ?s ?p ?o }")
+            
+            # Verify
+            call_args = mock_async_client.build_request.call_args
+            
+            # Check that only query is in data, no timeout parameter
+            assert call_args[1]['data'] == {'query': "SELECT * WHERE { ?s ?p ?o }"}
+
+    @pytest.mark.asyncio
+    async def test_sparql_get_with_timeout_param(self, remote_repo, mock_async_client):
+        """Test that timeout parameter is added to GET query string."""
+        # Setup
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.raise_for_status.return_value = None
+        mock_async_client.send.return_value = mock_response
+        
+        with patch.object(settings, 'sparql_timeout_param_name', 'maxExecutionTime'), \
+             patch.object(settings, 'sparql_timeout', 60), \
+             patch.object(settings, 'sparql_endpoint', 'http://test-endpoint.com'):
+            
+            # Execute
+            await remote_repo.sparql("SELECT * WHERE { ?s ?p ?o }", [], method="GET")
+            
+            # Verify
+            mock_async_client.send.assert_called_once()
+            request = mock_async_client.send.call_args[0][0]
+            
+            # Check that timeout parameter was added to URL
+            assert 'maxExecutionTime=60' in str(request.url)
+            assert 'query=' in str(request.url)
+
+    @pytest.mark.asyncio
+    async def test_sparql_post_with_timeout_param(self, remote_repo, mock_async_client):
+        """Test that timeout parameter is added to POST form data."""
+        # Setup
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.raise_for_status.return_value = None
+        mock_async_client.send.return_value = mock_response
+        
+        with patch.object(settings, 'sparql_timeout_param_name', 'timeout'), \
+             patch.object(settings, 'sparql_timeout', 45), \
+             patch.object(settings, 'sparql_endpoint', 'http://test-endpoint.com'):
+            
+            # Execute
+            await remote_repo.sparql("SELECT * WHERE { ?s ?p ?o }", [], method="POST")
+            
+            # Verify
+            request = mock_async_client.send.call_args[0][0]
+            
+            # Check that timeout parameter was added to form data
+            content = request.content.decode('utf-8')
+            assert 'timeout=45' in content
+            assert 'query=' in content
+
+    @pytest.mark.asyncio
+    async def test_different_timeout_param_names(self, remote_repo, mock_async_client):
+        """Test various timeout parameter names work correctly."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_async_client.build_request.return_value = Mock()
+        mock_async_client.send.return_value = mock_response
+        
+        timeout_params = ['timeout', 'maxExecutionTime', 'queryTimeout', 'timeoutMs']
+        
+        for param_name in timeout_params:
+            with patch.object(settings, 'sparql_timeout_param_name', param_name), \
+                 patch.object(settings, 'sparql_timeout', 120):
+                
+                await remote_repo._send_query("SELECT * WHERE { ?s ?p ?o }")
+                
+                call_args = mock_async_client.build_request.call_args
+                assert call_args[1]['data'][param_name] == "120"
+
+    @pytest.mark.asyncio  
+    async def test_timeout_error_handling_with_nice_message(self, remote_repo, mock_async_client):
+        """Test that timeout errors include helpful context about the timeout configuration."""
+        # Setup timeout exception
+        timeout_error = httpx.TimeoutException("Request timed out")
+        mock_async_client.send.side_effect = timeout_error
+        mock_async_client.build_request.return_value = Mock()
+        
+        with patch.object(settings, 'sparql_timeout_param_name', 'timeout'), \
+             patch.object(settings, 'sparql_timeout', 30):
+            
+            # Execute and verify exception with enhanced message
+            with pytest.raises(httpx.TimeoutException) as exc_info:
+                await remote_repo._send_query("SELECT * WHERE { ?s ?p ?o }")
+            
+            # This should fail initially because we haven't added error handling yet
+            error_message = str(exc_info.value)
+            assert "30 seconds" in error_message
+            assert "timeout=30" in error_message
+            assert "remote endpoint" in error_message
+
+    @pytest.mark.asyncio  
+    async def test_timeout_error_without_param_name(self, remote_repo, mock_async_client):
+        """Test timeout error message when no param name is configured."""
+        timeout_error = httpx.TimeoutException("Request timed out")
+        mock_async_client.send.side_effect = timeout_error  
+        mock_async_client.build_request.return_value = Mock()
+        
+        with patch.object(settings, 'sparql_timeout_param_name', None), \
+             patch.object(settings, 'sparql_timeout', 45):
+            
+            with pytest.raises(httpx.TimeoutException) as exc_info:
+                await remote_repo._send_query("SELECT * WHERE { ?s ?p ?o }")
+            
+            error_message = str(exc_info.value)
+            assert "45 seconds" in error_message
+            # Should NOT mention remote endpoint since no param is configured
+            assert "remote endpoint" not in error_message


### PR DESCRIPTION
1. The existing timeout parameter which applied for requests to Prez is now also passed on to remote triplestore backends as a query parameter, with the name of the query parameter specified via the `sparql_timeout_param_name` config setting (settle by an upper case environment variable of the same name). It has been defaulted to the name "timeout" as this is used by both Fuseki and GraphDB which are the triplestores predominantly used with Prez.
This is to prevent long running execution of SPARQL queries in the triplestore after Prez has already timed out on a given query.

2. The default timeout for Prez has been updated to 60 seconds, it remains configurable using "sparql_timeout". The same timeout value is passed to the triplestore.

3. Timeout exceptions are now raised as httpx.TimeoutException

These changes address #407 

4. httpx exceptions in general are now caught and returned to the user. Testing this change with mocks was difficult, so these changes were tested by starting prez, killing the remote SPARQL endpoint, and then making a request.

