### PR TITLE
fix: generates separate unique identifiers for intermediate nodes in fuseki fts profiles

### DIFF
--- a/docs/fuseki_fts_functionality.md
+++ b/docs/fuseki_fts_functionality.md
@@ -7,7 +7,7 @@ Prez integrates with Apache Jena Fuseki's full-text search capabilities to enabl
 Use the `predicates` URL query parameter to specify which indexed properties or property shapes to search:
 
 ```
-/search?q=geological&predicates=rdfs:label,skos:definition,ocr
+/search?q=geological&predicates=http://www.w3.org/2000/01/rdf-schema#label,http://www.w3.org/2004/02/skos/core#definition,ocr
 ```
 
 ## Property Shapes for Complex Paths

--- a/docs/fuseki_fts_functionality.md
+++ b/docs/fuseki_fts_functionality.md
@@ -1,0 +1,77 @@
+# Fuseki FTS (Full-Text Search) Integration
+
+Prez integrates with Apache Jena Fuseki's full-text search capabilities to enable efficient text search across RDF data.
+
+## Basic Usage
+
+Use the `predicates` URL query parameter to specify which indexed properties or property shapes to search:
+
+```
+/search?q=geological&predicates=rdfs:label,skos:definition,ocr
+```
+
+## Property Shapes for Complex Paths
+
+If you don't want the search result IRI to be immediately on the search term triple, you can use an FTS property shape. This allows searching through complex property paths.
+
+### Example Property Shape
+
+```turtle
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ont: <https://prez.dev/ont/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ex: <http://example.com/> .
+@prefix po: <http://www.essepuntato.it/2008/12/pattern#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:GSWA-OCR
+    a sh:PropertyShape ;
+    a ont:JenaFTSPropertyShape ;
+    sh:path ( po:contains po:contains ) ;
+    sh:name "Returns document focus nodes for full text search" ;
+    dcterms:identifier "ocr" ;
+    ont:searchPredicate rdf:value ;
+.
+```
+
+### Using Property Shapes
+
+Reference the property shape using its `dcterms:identifier` in the `predicates` parameter:
+
+```
+/search?q=geology&predicates=ocr
+```
+
+This will search for "geology" in `rdf:value` literals, but return search result IRIs that are connected through the `po:contains / po:contains` path.
+
+## Predicates Parameter Values
+
+The `predicates` parameter accepts:
+
+1. **RDF predicate URIs** - Direct references to Lucene indexed properties (e.g., `rdfs:label`, `skos:definition`)
+2. **Property shape identifiers** - The `dcterms:identifier` value of FTS property shapes (e.g., `ocr`)
+3. **PropList URIs** - References to Fuseki text index property lists (e.g., `ex:label`, `ex:fulltext`)
+
+## Fuseki Configuration Example
+
+```turtle
+<#indexLucene> a text:TextIndexLucene ;
+    text:directory "/fuseki/databases/ds/lucene" ;
+    text:entityMap <#entMap> ;
+    text:propLists
+        (
+            [
+                text:propListProp ex:label ;
+                text:props ( rdfs:label sdo:name skos:prefLabel dcterms:title ) ;
+            ]
+        ) .
+
+<#entMap> a text:EntityMap ;
+    text:map (
+         [ text:field "label" ; text:predicate rdfs:label ]
+         [ text:field "fulltext" ; text:predicate rdf:value ]
+         # ... other mappings
+    ) .
+```
+
+With this configuration, you can use `ex:label` or `rdf:value` in the predicates parameter to search across multiple related properties.

--- a/docs/fuseki_fts_functionality.md
+++ b/docs/fuseki_fts_functionality.md
@@ -50,7 +50,7 @@ The `predicates` parameter accepts:
 
 1. **RDF predicate URIs** - Direct references to Lucene indexed properties (e.g., `rdfs:label`, `skos:definition`)
 2. **Property shape identifiers** - The `dcterms:identifier` value of FTS property shapes (e.g., `ocr`)
-3. **PropList URIs** - References to Fuseki text index property lists (e.g., `ex:label`, `ex:fulltext`)
+3. **PropList URIs** - References to Fuseki text index property lists (e.g., `ex:label` in the example below)
 
 ## Fuseki Configuration Example
 

--- a/docs/fuseki_fts_functionality.md
+++ b/docs/fuseki_fts_functionality.md
@@ -24,7 +24,7 @@ If you don't want the search result IRI to be immediately on the search term tri
 @prefix po: <http://www.essepuntato.it/2008/12/pattern#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-ex:GSWA-OCR
+ex:OCR
     a sh:PropertyShape ;
     a ont:JenaFTSPropertyShape ;
     sh:path ( po:contains po:contains ) ;
@@ -48,13 +48,17 @@ This will search for "geology" in `rdf:value` literals, but return search result
 
 The `predicates` parameter accepts:
 
-1. **RDF predicate URIs** - Direct references to Lucene indexed properties (e.g., `rdfs:label`, `skos:definition`)
+1. **RDF predicate IRIs** - Direct references to Lucene indexed properties (e.g., `http://www.w3.org/2000/01/rdf-schema#label`, `http://www.w3.org/2004/02/skos/core#definition`)
 2. **Property shape identifiers** - The `dcterms:identifier` value of FTS property shapes (e.g., `ocr`)
-3. **PropList URIs** - References to Fuseki text index property lists (e.g., `ex:label` in the example below)
+3. **PropList IRIs** - References to Fuseki text index property lists, as IRIs (e.g., `http://example.com/label` in the example below)
 
 ## Fuseki Configuration Example
 
 ```turtle
+@prefix sdo: <https://schema.org/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 <#indexLucene> a text:TextIndexLucene ;
     text:directory "/fuseki/databases/ds/lucene" ;
     text:entityMap <#entMap> ;
@@ -69,9 +73,11 @@ The `predicates` parameter accepts:
 <#entMap> a text:EntityMap ;
     text:map (
          [ text:field "label" ; text:predicate rdfs:label ]
-         [ text:field "fulltext" ; text:predicate rdf:value ]
+         [ text:field "name" ; text:predicate sdo:name ]
+         [ text:field "preflabel" ; text:predicate skos:prefLabel ]
+         [ text:field "title" ; text:predicate dcterms:title ]
          # ... other mappings
     ) .
 ```
 
-With this configuration, you can use `ex:label` or `rdf:value` in the predicates parameter to search across multiple related properties.
+With this configuration, you can use `http://example.com/label` or `http://www.w3.org/1999/02/22-rdf-syntax-ns#value` in the predicates parameter to search across multiple related properties.

--- a/prez/services/query_generation/search_fuseki_fts.py
+++ b/prez/services/query_generation/search_fuseki_fts.py
@@ -128,8 +128,7 @@ class SearchQueryFusekiFTS(ConstructQuery):
                 "At least one of `non_shacl_predicates` and `shacl_tssp_preds` must be given"
             )
         limit += 1  # increase the limit by one, so we know if there are further pages of results.
-        # join search terms with '+' for better results
-        term = "+".join(term.split(" "))
+        term = term.replace('"', '\\"')
 
         sr_uri: Var = Var(value="focus_node")
         weight: Var = Var(value="weight")


### PR DESCRIPTION
When using the FTS profile functionality (which caters to focus nodes not directly linked to search result matches).

Presumably this worked when the functionality was first introduced and has since regressed.

I thought the functionality was documented but I cannot find it so I've added a doc.

Edit: I've decided to roll in the fix for https://github.com/RDFLib/prez/issues/412 here too.

This is a design decision - if end users want specific lucene behaviour they can pass in valid lucene syntax; prez will only escape as necessary and otherwise not touch the query.