### PR TITLE
feat: add /functions endpoint for CQL and add a number of common func…

### DIFF
--- a/dev/cql_functions.http
+++ b/dev/cql_functions.http
@@ -1,0 +1,84 @@
+### observationFilterSimpleResult
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "observationFilterSimpleResult",
+      "args": ["http://www.w3.org/ns/sosa/usedProcedure", "http://example.org/field-name-procedure", "http://www.w3.org/ns/sosa/hasSimpleResult", "rabbit"]
+    }
+Accept: application/sparql-query
+
+### observationFilterSimpleResult
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "in",
+      "args": [
+        { "property": "eo:sun_elevation" },
+        ["one","two","three"]
+      ]
+    }
+Accept: application/sparql-query
+
+### hasObservation single values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "hasObservation",
+      "args": [
+        ["https://example.org/vocab/prop1"],
+        ["val1"]
+      ]
+    }
+Accept: application/sparql-query
+
+### hasObservation multiple values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "hasObservation",
+      "args": [
+        ["https://example.org/vocab/prop1", "https://example.org/vocab/prop2"],
+        ["val1", "val2"]
+      ]
+    }
+Accept: application/sparql-query
+
+### hasAttribute single values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "hasAttribute",
+      "args": [
+        ["https://example.org/vocab/prop1"],
+        ["val1"]
+      ]
+    }
+Accept: application/sparql-query
+
+### hasAttribute multiple values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "hasAttribute",
+      "args": [
+        ["https://example.org/vocab/prop1", "https://example.org/vocab/prop2"],
+        ["val1", "val2"]
+      ]
+    }
+Accept: application/sparql-query
+
+### hasAdditional single values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "hasAdditional",
+      "args": [
+        ["https://example.org/vocab/prop1"],
+        ["val1"]
+      ]
+    }
+Accept: application/sparql-query
+
+### hasAdditional multiple values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "hasAdditional",
+      "args": [
+        ["https://example.org/vocab/prop1", "https://example.org/vocab/prop2"],
+        ["val1", "val2"]
+      ]
+    }
+Accept: application/sparql-query

--- a/dev/cql_functions.http
+++ b/dev/cql_functions.http
@@ -1,19 +1,16 @@
-### observationFilterSimpleResult
+### FOIObservationFilterDirect
 GET {{baseUrl}}/cql
     ?filter={
-      "op": "observationFilterSimpleResult",
+      "op": "FOIObservationFilterDirect",
       "args": ["http://www.w3.org/ns/sosa/usedProcedure", "http://example.org/field-name-procedure", "http://www.w3.org/ns/sosa/hasSimpleResult", "rabbit"]
     }
 Accept: application/sparql-query
 
-### observationFilterSimpleResult
+### FOIObservationFilterSequence
 GET {{baseUrl}}/cql
     ?filter={
-      "op": "in",
-      "args": [
-        { "property": "eo:sun_elevation" },
-        ["one","two","three"]
-      ]
+      "op": "FOIObservationFilterSequence",
+      "args": ["http://www.w3.org/ns/sosa/usedProcedure", "http://example.org/field-name-procedure", "http://www.w3.org/ns/sosa/hasResult", "http://www.w3.org/1999/02/22-rdf-syntax-ns#value", "rabbit"]
     }
 Accept: application/sparql-query
 

--- a/dev/http-client.env.json
+++ b/dev/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "localhost-8010": {
+    "baseUrl": "http://localhost:8010"
+  },
+    "localhost-8060": {
+    "baseUrl": "http://localhost:8060"
+  }
+}

--- a/prez/models/ogc_features.py
+++ b/prez/models/ogc_features.py
@@ -264,6 +264,67 @@ class Queryables(BaseModel):
 
 
 ########################################################################################################################
+# Functions
+
+
+class FunctionArgumentType(str, Enum):
+    STRING = "string"
+    NUMBER = "number" 
+    INTEGER = "integer"
+    DATETIME = "datetime"
+    GEOMETRY = "geometry"
+    BOOLEAN = "boolean"
+    ARRAY = "array"
+
+
+class FunctionArgument(BaseModel):
+    title: Optional[str] = Field(None, description="Title of the argument")
+    description: Optional[str] = Field(None, description="Description of the argument")
+    type: List[FunctionArgumentType] = Field(..., description="Data types accepted for this argument")
+
+
+class Function(BaseModel):
+    name: str = Field(..., description="Name of the function")
+    description: Optional[str] = Field(None, description="Description of the function")
+    metadataUrl: Optional[str] = Field(None, description="URL to metadata about the function")
+    arguments: Optional[List[FunctionArgument]] = Field(None, description="Arguments accepted by the function")
+    returns: List[FunctionArgumentType] = Field(..., description="Data types returned by the function")
+
+
+class FunctionsResponse(BaseModel):
+    functions: List[Function] = Field(..., description="List of functions supported by the server")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "functions": [
+                    {
+                        "name": "min",
+                        "arguments": [
+                            {"type": ["string", "number", "datetime"]},
+                            {"type": ["string", "number", "datetime"]},
+                        ],
+                        "returns": ["string", "number", "datetime"],
+                    },
+                    {
+                        "name": "max",
+                        "arguments": [
+                            {"type": ["string", "number", "datetime"]},
+                            {"type": ["string", "number", "datetime"]},
+                        ],
+                        "returns": ["string", "number", "datetime"],
+                    },
+                    {
+                        "name": "geometryType",
+                        "arguments": [{"type": ["geometry"]}],
+                        "returns": ["string"],
+                    },
+                ]
+            }
+        }
+
+
+########################################################################################################################
 # generate link headers
 
 

--- a/prez/routers/ogc_features_router.py
+++ b/prez/routers/ogc_features_router.py
@@ -28,7 +28,11 @@ from prez.exceptions.model_exceptions import (
     PrefixNotBoundException,
     URINotFoundException
 )
-from prez.models.ogc_features import OGCFeaturesLandingPage, generate_landing_page_links
+from prez.models.ogc_features import (
+    FunctionsResponse,
+    OGCFeaturesLandingPage,
+    generate_landing_page_links,
+)
 from prez.models.query_params import ListingQueryParams
 from prez.reference_data.prez_ns import OGCFEAT
 from prez.renderers.renderer import generate_link_headers
@@ -44,10 +48,11 @@ from prez.services.exception_catchers import (
     catch_no_endpoint_nodeshape_exception,
     catch_no_profiles_exception,
     catch_prefix_not_found_exception,
-    catch_uri_not_found_exception, catch_missing_filter_query_param,
+    catch_uri_not_found_exception,
 )
 from prez.services.listings import ogc_features_listing_function
 from prez.services.objects import ogc_features_object_function
+from prez.services.ogc_functions_data import get_ogc_functions_response
 from prez.services.query_generation.cql import CQLParser
 from prez.services.query_generation.shacl import NodeShape
 
@@ -107,6 +112,21 @@ async def ogc_features_api(
         content=lp.model_dump(),
         headers={"Content-Type": "application/json"} | link_headers,
     )
+
+
+@features_subapi.api_route(
+    "/functions",
+    summary="OGC Features Functions",
+    methods=ALLOWED_METHODS,
+    response_model=FunctionsResponse,
+)
+async def get_functions() -> FunctionsResponse:
+    """
+    Get the list of functions supported by this server.
+
+    Implements OGC API - Features - Part 3: Filtering - Functions requirement.
+    """
+    return get_ogc_functions_response()
 
 
 ########################################################################################################################

--- a/prez/services/ogc_functions_data.py
+++ b/prez/services/ogc_functions_data.py
@@ -1,0 +1,152 @@
+"""
+OGC Features Functions data module.
+
+This module provides the functions list for the /functions endpoint,
+based on the actual CQL functions implemented in cql_functions.py.
+"""
+
+from prez.models.ogc_features import Function, FunctionArgument, FunctionArgumentType, FunctionsResponse
+from rdflib import URIRef
+
+from prez.services.query_generation.cql_functions import REGISTERED_CQL_FUNCTIONS
+
+
+def get_ogc_functions_response() -> FunctionsResponse:
+    """
+    Get the functions response for the OGC Features /functions endpoint.
+
+    Returns FunctionsResponse with the actual implemented CQL functions.
+    """
+    functions = []
+
+    # Define function metadata based on actual implementations
+    function_metadata = {
+        "FOIObservationFilterDirect": {
+            "description": "Filter observations related to a Feature of Interest by specifying two direct "
+                           "property values on an observation.",
+            "arguments": [
+                FunctionArgument(
+                    title="Property one predicate",
+                    description="IRI of the first observation property to filter on",
+                    type=[FunctionArgumentType.STRING],
+                ),
+                FunctionArgument(
+                    title="Property one value",
+                    description="Filter value for the first observation property",
+                    type=[FunctionArgumentType.STRING, FunctionArgumentType.NUMBER],
+                ),
+                FunctionArgument(
+                    title="Property two predicate",
+                    description="IRI of the second observation property to filter on",
+                    type=[FunctionArgumentType.STRING],
+                ),
+                FunctionArgument(
+                    title="Property two value",
+                    description="Filter value for the second observation property",
+                    type=[FunctionArgumentType.STRING, FunctionArgumentType.NUMBER],
+                ),
+            ],
+            "returns": [FunctionArgumentType.BOOLEAN],
+        },
+        "FOIObservationFilterSequence": {
+            "description": "Filter observations related to a Feature of Interest by specifying one direct"
+                           " property value and one sequence path property value.",
+            "arguments": [
+                FunctionArgument(
+                    title="Property one predicate",
+                    description="IRI of the first observation property to filter on",
+                    type=[FunctionArgumentType.STRING],
+                ),
+                FunctionArgument(
+                    title="Property one value",
+                    description="Filter value for the first observation property",
+                    type=[FunctionArgumentType.STRING, FunctionArgumentType.NUMBER],
+                ),
+                FunctionArgument(
+                    title="Sequence path first predicate",
+                    description="First IRI in the sequence path of the second observation property chain"
+                                " to filter on",
+                    type=[FunctionArgumentType.STRING],
+                ),
+                FunctionArgument(
+                    title="Sequence path second predicate",
+                    description="Second IRI in the sequence path of the second observation property chain"
+                                " to filter on",
+                    type=[FunctionArgumentType.STRING],
+                ),
+                FunctionArgument(
+                    title="Property two value",
+                    description="Filter value for the second observation property chain",
+                    type=[FunctionArgumentType.STRING, FunctionArgumentType.NUMBER],
+                ),
+            ],
+            "returns": [FunctionArgumentType.BOOLEAN],
+        },
+        "hasObservation": {
+            "description": "Filter focus nodes by sosa observed properties (sosa:observedProperty) and their "
+                           "corresponding values (union of sosa:hasSimpleResult, sosa:hasResult, and "
+                           "sosa:hasResult/rdf:value).",
+            "arguments": [
+                FunctionArgument(
+                    title="Observed Property IRIs",
+                    description="Array of observed property IRIs (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+                FunctionArgument(
+                    title="Results",
+                    description="Array of observation result values (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+            ],
+            "returns": [FunctionArgumentType.BOOLEAN],
+        },
+        "hasAttribute": {
+            "description": "Filter focus nodes by tern attributes (tern:attribute) and their corresponding "
+                           "values (union of tern:hasSimpleValue, tern:hasValue, and tern:hasValue/rdf:value).",
+            "arguments": [
+                FunctionArgument(
+                    title="Attribute Names",
+                    description="Array of attribute name IRIs (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+                FunctionArgument(
+                    title="Attribute Values",
+                    description="Array of attribute values (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+            ],
+            "returns": [FunctionArgumentType.BOOLEAN],
+        },
+        "hasAdditional": {
+            "description": "Filter on the names/values of a schema:additionalProperty of an object.",
+            "arguments": [
+                FunctionArgument(
+                    title="PropertyIds or Names",
+                    description="Array of schema:propertyID or schema:name values (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+                FunctionArgument(
+                    title="Attribute Values",
+                    description="Array of any of schema:value, rdf:value, or schema:value/rdf:value values "
+                                "(passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+            ],
+            "returns": [FunctionArgumentType.BOOLEAN],
+        },
+    }
+
+    # Create Function objects for each registered CQL function
+    for func_name in REGISTERED_CQL_FUNCTIONS:
+        metadata = function_metadata.get(func_name)
+        if metadata:
+            functions.append(
+                Function(
+                    name=func_name,
+                    description=metadata["description"],
+                    arguments=metadata["arguments"],
+                    returns=metadata["returns"],
+                )
+            )
+
+    return FunctionsResponse(functions=functions)

--- a/prez/services/query_generation/cql.py
+++ b/prez/services/query_generation/cql.py
@@ -5,22 +5,23 @@ from typing import Generator, Literal
 from rdflib import Namespace, URIRef
 from rdflib.namespace import GEO
 from sparql_grammar_pydantic import (
-    IRI,
     ConstructQuery,
     ConstructTemplate,
     ConstructTriples,
     GraphPatternNotTriples,
     GroupGraphPattern,
-    GroupGraphPatternSub,
     GroupOrUnionGraphPattern,
     IRIOrFunction,
     RDFLiteral,
     SolutionModifier,
-    TriplesBlock,
     TriplesSameSubject,
+    WhereClause, )
+from sparql_grammar_pydantic import (
+    IRI,
+    GroupGraphPatternSub,
+    TriplesBlock,
     TriplesSameSubjectPath,
     Var,
-    WhereClause,
 )
 
 from prez.cache import prez_system_graph
@@ -30,19 +31,21 @@ from prez.reference_data.cql.geo_function_mapping import (
     cql_sparql_spatial_mapping,
     cql_graphdb_spatial_properties,
 )
+from prez.services.query_generation.cql_functions import REGISTERED_CQL_FUNCTIONS, handle_custom_functions
+from prez.services.query_generation.grammar_helpers import (
+    convert_value_to_rdf_term,
+    create_values_constraint,
+)
+from prez.services.query_generation.grammar_helpers import (
+    create_regex_filter,
+    create_relational_filter,
+    create_temporal_or_gpnt,
+    create_filter_bool_gpnt,
+    create_temporal_and_gpnt, )
+from prez.services.query_generation.shacl import PropertyShape
 from prez.services.query_generation.spatial_filter import (
     generate_spatial_filter_clause,
     get_wkt_from_coords,
-)
-from prez.services.query_generation.shacl import PropertyShape
-from prez.services.query_generation.grammar_helpers import (
-    convert_value_to_rdf_term,
-    create_regex_filter,
-    create_relational_filter,
-    create_values_constraint,
-    create_temporal_or_gpnt,
-    create_filter_bool_gpnt,
-    create_temporal_and_gpnt,
 )
 
 CQL = Namespace("http://www.opengis.net/doc/IS/cql2/1.0/")
@@ -77,10 +80,10 @@ SHACL_FILTER_NAMESPACE = Namespace("https://cql-shacl-filter/")
 
 class CQLParser:
     def __init__(
-        self,
-        cql_json: dict | None = None,
-        crs: str | None = None,
-        queryable_props: dict[str, str] | None = None,
+            self,
+            cql_json: dict | None = None,
+            crs: str | None = None,
+            queryable_props: dict[str, str] | None = None,
     ):
         self.inner_select_gpntotb_list: list[GraphPatternNotTriples] = []
         # Always include at least ?focus_node SELECT var
@@ -118,7 +121,7 @@ class CQLParser:
             self.inner_select_gpntotb_list = gpotb.graph_patterns_or_triples_blocks
 
     def parse_logical_operators(
-        self, element: dict, existing_ggps: GroupGraphPatternSub | None = None
+            self, element: dict, existing_ggps: GroupGraphPatternSub | None = None
     ) -> Generator[GroupGraphPatternSub, None, None]:
         operator = element.get("op")
         args = element.get("args")
@@ -153,15 +156,19 @@ class CQLParser:
             self._handle_temporal(operator, args, ggps)
             if existing_ggps is None:
                 yield ggps
+        elif operator in REGISTERED_CQL_FUNCTIONS:
+            handle_custom_functions(operator, args, ggps)
+            if existing_ggps is None:
+                yield ggps
         else:
             # This else is reached if operator is not 'and', 'or', or any of the handled elementary operators.
             raise NotImplementedError(f"Operator {operator} not implemented.")
 
     def _handle_and_operator(
-        self,
-        args: list[dict],
-        ggps: GroupGraphPatternSub,
-        existing_ggps: GroupGraphPatternSub | None,
+            self,
+            args: list[dict],
+            ggps: GroupGraphPatternSub,
+            existing_ggps: GroupGraphPatternSub | None,
     ) -> Generator[GroupGraphPatternSub, None, None]:
         """Handle AND logical operator."""
         for arg in args:
@@ -172,10 +179,10 @@ class CQLParser:
             yield ggps
 
     def _handle_or_operator(
-        self,
-        args: list[dict],
-        ggps: GroupGraphPatternSub,
-        existing_ggps: GroupGraphPatternSub | None,
+            self,
+            args: list[dict],
+            ggps: GroupGraphPatternSub,
+            existing_ggps: GroupGraphPatternSub | None,
     ) -> Generator[GroupGraphPatternSub, None, None]:
         """Handle OR logical operator."""
         try:
@@ -228,17 +235,17 @@ class CQLParser:
             pass  # Cleanup if needed
 
         if (
-            existing_ggps is None
+                existing_ggps is None
         ):  # If this OR was top-level for this call and created its own ggps
             yield ggps
 
     def _add_triple(
-        self,
-        ggps: GroupGraphPatternSub,
-        subject: Var | IRI,
-        predicate: IRI,
-        obj: Var | IRI | RDFLiteral,
-        to: Literal["tss_and_tssp", "tss", "tssp"] = "tss_and_tssp",
+            self,
+            ggps: GroupGraphPatternSub,
+            subject: Var | IRI,
+            predicate: IRI,
+            obj: Var | IRI | RDFLiteral,
+            to: Literal["tss_and_tssp", "tss", "tssp"] = "tss_and_tssp",
     ) -> None:
         if to in ["tss_and_tssp", "tss"]:
             tss = TriplesSameSubject.from_spo(
@@ -279,10 +286,10 @@ class CQLParser:
             # All patterns are channeled into the graph_patterns_or_triples_blocks list.
 
     def _handle_comparison(
-        self,
-        operator: str,
-        args: list[dict],
-        existing_ggps: GroupGraphPatternSub | None = None,
+            self,
+            operator: str,
+            args: list[dict],
+            existing_ggps: GroupGraphPatternSub | None = None,
     ) -> None:
         value = convert_value_to_rdf_term(args[1])
 
@@ -303,10 +310,10 @@ class CQLParser:
             ggps.add_pattern(filter_gpnt)
 
     def _add_tss_tssp(
-        self,
-        args: list[dict],
-        existing_ggps: GroupGraphPatternSub | None,
-        obj: Var | IRI | RDFLiteral | None = None,
+            self,
+            args: list[dict],
+            existing_ggps: GroupGraphPatternSub | None,
+            obj: Var | IRI | RDFLiteral | None = None,
     ) -> tuple[GroupGraphPatternSub, Var | IRI | RDFLiteral]:
         self.var_counter += 1
         ggps = existing_ggps if existing_ggps is not None else GroupGraphPatternSub()
@@ -325,7 +332,7 @@ class CQLParser:
         return ggps, obj
 
     def _handle_like(
-        self, args: list[dict], existing_ggps: GroupGraphPatternSub | None = None
+            self, args: list[dict], existing_ggps: GroupGraphPatternSub | None = None
     ) -> None:
         ggps, obj = self._add_tss_tssp(args, existing_ggps)
 
@@ -334,10 +341,10 @@ class CQLParser:
         ggps.add_pattern(filter_gpnt)
 
     def _handle_spatial(
-        self,
-        operator: str,
-        args: list[dict],
-        existing_ggps: GroupGraphPatternSub | None = None,
+            self,
+            operator: str,
+            args: list[dict],
+            existing_ggps: GroupGraphPatternSub | None = None,
     ) -> None:
         self.var_counter += 1
         ggps = existing_ggps if existing_ggps is not None else GroupGraphPatternSub()
@@ -404,7 +411,7 @@ class CQLParser:
                     ggps.add_pattern(gpnt_item)
 
     def _handle_in(
-        self, args: list[dict], existing_ggps: GroupGraphPatternSub | None = None
+            self, args: list[dict | list], existing_ggps: GroupGraphPatternSub | None = None
     ) -> None:
         ggps, obj = self._add_tss_tssp(args, existing_ggps)
 
@@ -418,10 +425,10 @@ class CQLParser:
         return obj_var
 
     def _handle_temporal(
-        self,
-        comp_func: str,
-        args: list[dict],
-        existing_ggps: GroupGraphPatternSub | None = None,
+            self,
+            comp_func: str,
+            args: list[dict],
+            existing_ggps: GroupGraphPatternSub | None = None,
     ) -> None:
         """For temporal filtering within CQL JSON expressions, NOT within the temporal query parameter."""
         ggps = existing_ggps if existing_ggps is not None else GroupGraphPatternSub()
@@ -539,8 +546,8 @@ class CQLParser:
             )
 
     def queryable_id_to_tssp(
-        self,
-        queryable_uri: str,
+            self,
+            queryable_uri: str,
     ) -> tuple[list[TriplesSameSubjectPath], Var]:
         queryable_shape = prez_system_graph.cbd(URIRef(queryable_uri))
         ps = PropertyShape(


### PR DESCRIPTION
This PR adds support for specific focus node filtering scenarios related to the tern and sosa ontologies, with a little support for more generalised complex scenarios.

This support is implemented in accordance with the [OGC Features functions section](https://portal.ogc.org/files/96288#functions) 

The functions are detailed here in code: https://github.com/RDFLib/prez/blob/0c77328ab596e9140afd032f525ed78966fa2931/prez/services/ogc_functions_data.py#L23 and can be viewed as JSON when running Prez at the new `features/functions` endpoint.

Examples of how to call the functions have been added in [an http file](https://github.com/RDFLib/prez/blob/e53e5f438b62944e56eb7d7c56125b7666453aa6/dev/cql_functions.http)

It is intended that once users have had a chance to use these for some time, usage patterns and any pain points should be clearer. At this point an RDF declarative form could be implemented, perhaps in SHACL or templated SPARQL queries.