### PR TITLE
feat: add qualified attribution / hadRole CQL function

### DIFF
--- a/dev/cql_functions.http
+++ b/dev/cql_functions.http
@@ -93,6 +93,28 @@ GET {{baseUrl}}/cql
     &datetime=2021-01-01T00:00:00Z/2021-01-02T00:00:00Z
 Accept: application/sparql-query
 
+### qualifiedAttribution single values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "qualifiedAttribution",
+      "args": [
+        ["https://example.org/vocab/role/contributor"],
+        ["https://example.org/vocab/org/org2"]
+      ]
+    }
+Accept: application/sparql-query
+
+### qualifiedAttribution multiple values
+GET {{baseUrl}}/cql
+    ?filter={
+      "op": "qualifiedAttribution",
+      "args": [
+        ["https://example.org/vocab/role/creator", "https://example.org/vocab/role/contributor"],
+        ["https://example.org/vocab/org/org1", "https://example.org/vocab/org/org2"]
+      ]
+    }
+Accept: application/sparql-query
+
 ### check or logic variable separation
 ### hasAdditional multiple values
 GET {{baseUrl}}/cql

--- a/prez/services/ogc_functions_data.py
+++ b/prez/services/ogc_functions_data.py
@@ -139,6 +139,23 @@ def get_ogc_functions_response() -> FunctionsResponse:
             ],
             "returns": [FunctionArgumentType.BOOLEAN],
         },
+        "qualifiedAttribution": {
+            "description": "Filter focus nodes by PROV qualified attribution patterns, matching features that have "
+            "specific agents with particular roles in their qualified attribution.",
+            "arguments": [
+                FunctionArgument(
+                    title="Role IRIs",
+                    description="Array of role IRIs for prov:hadRole (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+                FunctionArgument(
+                    title="Agent IRIs",
+                    description="Array of agent IRIs for prov:agent (passed as CQL arrayLiteral)",
+                    type=[FunctionArgumentType.ARRAY],
+                ),
+            ],
+            "returns": [FunctionArgumentType.BOOLEAN],
+        },
     }
 
     # Create Function objects for each registered CQL function

--- a/prez/services/query_generation/cql_functions.py
+++ b/prez/services/query_generation/cql_functions.py
@@ -8,7 +8,7 @@ from sparql_grammar_pydantic import (
     GraphTerm,
 )
 from rdflib import Namespace
-from rdflib.namespace import SOSA, RDF, SDO
+from rdflib.namespace import SOSA, RDF, SDO, PROV
 
 TERN = Namespace("https://w3id.org/tern/ontologies/tern/")
 
@@ -26,6 +26,7 @@ REGISTERED_CQL_FUNCTIONS = [
     "hasObservation",
     "hasAttribute",
     "hasAdditional",
+    "qualifiedAttribution",
 ]
 
 
@@ -229,3 +230,42 @@ def handle_custom_functions(
         ggps.add_pattern(union_gpnt)
         ggps.add_pattern(arg_1_values_gpnt)
         ggps.add_pattern(arg_2_values_gpnt)
+    elif operator in ["qualifiedAttribution"]:
+        """
+        allows filtering on the prov qualified pattern where a known agent has a particular role
+        {
+            ?focus prov:qualifiedAttribution ?qa_1 .
+            ?qa_1 prov:hadRole $arg1 .
+            ?qa_1 prov:agent $arg2 .
+            VALUES $arg1 { <https://example.org/vocab/role/contributor> }
+            VALUES $arg2 { <https://example.org/vocab/org/org2> }
+        }
+        """
+        qa_bn_var = Var(value=f"qa_bn_var{suffix}")
+        role_var = Var(value=f"role_var{suffix}")
+        agent_var = Var(value=f"agent_var{suffix}")
+
+        focus_to_qa_tssp = TriplesSameSubjectPath.from_spo(
+            subject=focus_node_vot.varorterm,
+            predicate=IRI(value=str(PROV.qualifiedAttribution)),
+            object=qa_bn_var,
+        )
+        qa_to_role_tssp = TriplesSameSubjectPath.from_spo(
+            subject=qa_bn_var,
+            predicate=IRI(value=str(PROV.hadRole)),
+            object=role_var,
+        )
+        qa_to_agent_tssp = TriplesSameSubjectPath.from_spo(
+            subject=qa_bn_var,
+            predicate=IRI(value=str(PROV.agent)),
+            object=agent_var,
+        )
+
+        role_values_gpnt = create_values_constraint(role_var, args[0])  # args[0] is array for roles
+        agent_values_gpnt = create_values_constraint(agent_var, args[1])  # args[1] is array for agents
+
+        ggps.add_pattern(
+            TriplesBlock.from_tssp_list([qa_to_agent_tssp, qa_to_role_tssp, focus_to_qa_tssp])
+        )
+        ggps.add_pattern(role_values_gpnt)
+        ggps.add_pattern(agent_values_gpnt)


### PR DESCRIPTION
Resolves https://github.com/RDFLib/prez/issues/419

Follows existing pattern.

Example CQL filter:

```json
{
  "op": "qualifiedAttribution",
  "args": [
    ["https://example.org/vocab/role/creator", "https://example.org/vocab/role/contributor"],
    ["https://example.org/vocab/org/org1", "https://example.org/vocab/org/org2"]
  ]
}
```

Example generated queries (from `dev/cql_functions.http`):

```sparql
CONSTRUCT {
?focus_node <https://prez.dev/type> <https://prez.dev/FocusNode> .
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1
}
WHERE {


{
SELECT DISTINCT ?focus_node
WHERE {
?focus_node <http://www.w3.org/ns/prov#qualifiedAttribution> ?qa_bn_var_1 .
?qa_bn_var_1 <http://www.w3.org/ns/prov#hadRole> ?role_var_1 .
?qa_bn_var_1 <http://www.w3.org/ns/prov#agent> ?agent_var_1 .

	VALUES ?role_var_1{ <https://example.org/vocab/role/contributor>  }

	VALUES ?agent_var_1{ <https://example.org/vocab/org/org2>  }
}LIMIT 10 OFFSET 0

}?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1 .
}
```
```sparql
CONSTRUCT {
?focus_node <https://prez.dev/type> <https://prez.dev/FocusNode> .
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1
}
WHERE {


{
SELECT DISTINCT ?focus_node
WHERE {
?focus_node <http://www.w3.org/ns/prov#qualifiedAttribution> ?qa_bn_var_1 .
?qa_bn_var_1 <http://www.w3.org/ns/prov#hadRole> ?role_var_1 .
?qa_bn_var_1 <http://www.w3.org/ns/prov#agent> ?agent_var_1 .

	VALUES ?role_var_1{ <https://example.org/vocab/role/contributor>  }

	VALUES ?agent_var_1{ <https://example.org/vocab/org/org2>  }
}LIMIT 10 OFFSET 0

}?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?prof_1_node_1 .
}
```