### PR TITLE
feat: allow no query string search

### DIFF
--- a/docs/faceted_search.md
+++ b/docs/faceted_search.md
@@ -78,3 +78,23 @@ WHERE {
   }GROUP BY ?facetName ?facetValue
 }
 ```
+
+## Open Faceting
+
+Open faceting is allowed, meaning you can perform faceted search without providing a search term by using only the `facet_profile` parameter:
+
+```
+/search?facet_profile=xyz
+```
+
+When no search term is provided, Prez automatically injects a `?focus_node a ?type` triple in the subselect query. This ensures that only instances of classes are faceted on, rather than attempting to facet across all nodes in the dataset.
+
+**Performance Considerations:**
+
+Open faceting works well for smaller datasets, but performance can become an issue with larger datasets since it needs to process all class instances without any filtering constraints.
+
+For larger datasets, it is recommended to:
+- Perform a search first to narrow the result set
+- Add additional filters or search terms to reduce the scope (using parameters: filter, bbox, datetime, q)
+- Use a separate full text search/faceting implementation designed for large-scale operations such as open search or lucene
+```

--- a/prez/services/query_generation/facet.py
+++ b/prez/services/query_generation/facet.py
@@ -33,7 +33,11 @@ from sparql_grammar_pydantic import (
     Var,
     TriplesNode,
 )
-from sparql_grammar_pydantic.grammar import PropertyList, IRIOrFunction, TriplesSameSubjectPath
+from sparql_grammar_pydantic.grammar import (
+    PropertyList,
+    IRIOrFunction,
+    TriplesSameSubjectPath,
+)
 
 from prez.cache import profiles_graph_cache
 from prez.exceptions.model_exceptions import PrefixNotBoundException
@@ -76,18 +80,16 @@ class FacetQuery(ConstructQuery):
     """
 
     def __init__(
-            self,
-            original_subselect: SubSelect = None,
-            property_shape=None,
-            focus_node_uri=None,
-            open_facet: bool = False,
+        self,
+        original_subselect: SubSelect = None,
+        property_shape=None,
+        focus_node_uri=None,
+        open_facet: bool = False,
     ):
         # Validate that exactly one of the three modes is specified
-        modes_specified = sum([
-            original_subselect is not None,
-            focus_node_uri is not None,
-            open_facet
-        ])
+        modes_specified = sum(
+            [original_subselect is not None, focus_node_uri is not None, open_facet]
+        )
         if modes_specified != 1:
             raise ValueError(
                 "Exactly one of 'original_subselect', 'focus_node_uri', or 'open_facet=True' must be specified"
@@ -147,7 +149,9 @@ class FacetQuery(ConstructQuery):
                     [
                         TriplesSameSubjectPath.from_spo(
                             subject=Var(value="focus_node"),
-                            predicate=IRI(value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                            predicate=IRI(
+                                value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                            ),
                             object=Var(value="type"),
                         )
                     ]

--- a/prez/services/query_generation/facet.py
+++ b/prez/services/query_generation/facet.py
@@ -84,15 +84,14 @@ class FacetQuery(ConstructQuery):
         original_subselect: SubSelect = None,
         property_shape=None,
         focus_node_uri=None,
-        open_facet: bool = False,
     ):
-        # Validate that exactly one of the three modes is specified
+        # Validate that exactly one of the two modes is specified
         modes_specified = sum(
-            [original_subselect is not None, focus_node_uri is not None, open_facet]
+            [original_subselect is not None, focus_node_uri is not None]
         )
         if modes_specified != 1:
             raise ValueError(
-                "Exactly one of 'original_subselect', 'focus_node_uri', or 'open_facet=True' must be specified"
+                "Exactly one of 'original_subselect' or 'focus_node_uri' must be specified"
             )
 
         # Define variables used
@@ -140,21 +139,6 @@ class FacetQuery(ConstructQuery):
                     content=GroupOrUnionGraphPattern(
                         group_graph_patterns=[GroupGraphPattern(content=inner_ss)]
                     )
-                )
-            )
-        elif open_facet:
-            # For open facet queries - no subselect, just basic ?focus_node patterns
-            inner_gpnts_or_tb.append(
-                TriplesBlock.from_tssp_list(
-                    [
-                        TriplesSameSubjectPath.from_spo(
-                            subject=Var(value="focus_node"),
-                            predicate=IRI(
-                                value="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-                            ),
-                            object=Var(value="type"),
-                        )
-                    ]
                 )
             )
 
@@ -283,18 +267,12 @@ class FacetQuery(ConstructQuery):
                     property_shape=facet_property_shape,
                     focus_node_uri=focus_node_uri,
                 )
-            elif main_query and hasattr(main_query, "inner_select"):
-                # For listing queries with subselect
+            else:
+                # For listing queries with subselect, or open facet queries
                 subselect_for_faceting = copy.deepcopy(main_query.inner_select)
                 facets_query = FacetQuery(
                     original_subselect=subselect_for_faceting,
                     property_shape=facet_property_shape,
-                )
-            else:
-                # no subselect or focus node given - this is an "open" facet, add a type triple only.
-                facets_query = FacetQuery(
-                    property_shape=facet_property_shape,
-                    open_facet=True,
                 )
             return profile_uri, facets_query
 

--- a/tests/test_search_empty_term.py
+++ b/tests/test_search_empty_term.py
@@ -5,14 +5,20 @@ def test_search_empty_term_no_filters(client: TestClient):
     """Test that empty search term without filters returns 400 error (BEFORE behavior)."""
     response = client.get("/search?q=")
     assert response.status_code == 400
-    assert "Search query parameter 'q' must be provided, or use filtering parameters" in response.json()["detail"]
+    assert (
+        "Search query parameter 'q' must be provided, or use filtering parameters"
+        in response.json()["detail"]
+    )
 
 
 def test_search_missing_term_no_filters(client: TestClient):
     """Test that missing search term without filters returns 400 error (BEFORE behavior)."""
     response = client.get("/search")
     assert response.status_code == 400
-    assert "Search query parameter 'q' must be provided, or use filtering parameters" in response.json()["detail"]
+    assert (
+        "Search query parameter 'q' must be provided, or use filtering parameters"
+        in response.json()["detail"]
+    )
 
 
 def test_search_empty_term_with_facet_profile(client: TestClient, monkeypatch):
@@ -45,9 +51,15 @@ def test_search_empty_term_with_facet_profile(client: TestClient, monkeypatch):
 
     prez_system_graph += mock_system_graph
 
-    response = client.get("/search?q=&facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=application/sparql-query")
+    response = client.get(
+        "/search?q=&facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=application/sparql-query"
+    )
     # Should not return 400 error about missing search term
-    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+    assert (
+        response.status_code != 400
+        or "Search query parameter 'q' must be provided"
+        not in response.json().get("detail", "")
+    )
 
 
 def test_search_empty_term_with_cql_filter(client: TestClient):
@@ -55,21 +67,37 @@ def test_search_empty_term_with_cql_filter(client: TestClient):
     cql_filter = '{"op":"=","args":[{"property":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},"https://myclass"]}'
     response = client.get(f"/search?q=&filter={cql_filter}")
     # Should not return 400 error about missing search term
-    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+    assert (
+        response.status_code != 400
+        or "Search query parameter 'q' must be provided"
+        not in response.json().get("detail", "")
+    )
 
 
 def test_search_empty_term_with_bbox(client: TestClient):
     """Test that empty search term with bbox is allowed (AFTER behavior)."""
-    response = client.get("/search?q=&bbox=113.338953078,-43.6345972634,153.569469029,-10.6681857235")
+    response = client.get(
+        "/search?q=&bbox=113.338953078,-43.6345972634,153.569469029,-10.6681857235"
+    )
     # Should not return 400 error about missing search term
-    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+    assert (
+        response.status_code != 400
+        or "Search query parameter 'q' must be provided"
+        not in response.json().get("detail", "")
+    )
 
 
 def test_search_empty_term_with_datetime(client: TestClient):
     """Test that empty search term with datetime is allowed (AFTER behavior)."""
-    response = client.get("/search?q=&datetime=2018-02-12T23:20:50Z/2018-03-18T12:31:12Z")
+    response = client.get(
+        "/search?q=&datetime=2018-02-12T23:20:50Z/2018-03-18T12:31:12Z"
+    )
     # Should not return 400 error about missing search term
-    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+    assert (
+        response.status_code != 400
+        or "Search query parameter 'q' must be provided"
+        not in response.json().get("detail", "")
+    )
 
 
 def test_search_missing_term_with_facet_profile(client: TestClient, monkeypatch):
@@ -102,9 +130,15 @@ def test_search_missing_term_with_facet_profile(client: TestClient, monkeypatch)
 
     prez_system_graph += mock_system_graph
 
-    response = client.get("/search?facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/turtle")
+    response = client.get(
+        "/search?facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/turtle"
+    )
     # Should not return 400 error about missing search term
-    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+    assert (
+        response.status_code != 400
+        or "Search query parameter 'q' must be provided"
+        not in response.json().get("detail", "")
+    )
 
 
 def test_search_missing_term_with_cql_filter(client: TestClient):
@@ -112,4 +146,8 @@ def test_search_missing_term_with_cql_filter(client: TestClient):
     cql_filter = '{"op":"=","args":[{"property":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},"feature"]}'
     response = client.get(f"/search?filter={cql_filter}")
     # Should not return 400 error about missing search term
-    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+    assert (
+        response.status_code != 400
+        or "Search query parameter 'q' must be provided"
+        not in response.json().get("detail", "")
+    )

--- a/tests/test_search_empty_term.py
+++ b/tests/test_search_empty_term.py
@@ -53,7 +53,7 @@ def test_search_empty_term_with_facet_profile(client: TestClient, monkeypatch):
     profiles_graph_cache += mock_profiles_graph
 
     response = client.get(
-        "/search?q=&facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=application/sparql-query"
+        "/search?q=&facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/anot+turtle"
     )
     # Should not return 400 error about missing search term
     assert (
@@ -133,7 +133,7 @@ def test_search_missing_term_with_facet_profile(client: TestClient, monkeypatch)
     profiles_graph_cache += mock_profiles_graph
 
     response = client.get(
-        "/search?facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/turtle"
+        "/search?facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/anot+turtle"
     )
     # Should not return 400 error about missing search term
     assert (

--- a/tests/test_search_empty_term.py
+++ b/tests/test_search_empty_term.py
@@ -1,0 +1,115 @@
+from fastapi.testclient import TestClient
+
+
+def test_search_empty_term_no_filters(client: TestClient):
+    """Test that empty search term without filters returns 400 error (BEFORE behavior)."""
+    response = client.get("/search?q=")
+    assert response.status_code == 400
+    assert "Search query parameter 'q' must be provided, or use filtering parameters" in response.json()["detail"]
+
+
+def test_search_missing_term_no_filters(client: TestClient):
+    """Test that missing search term without filters returns 400 error (BEFORE behavior)."""
+    response = client.get("/search")
+    assert response.status_code == 400
+    assert "Search query parameter 'q' must be provided, or use filtering parameters" in response.json()["detail"]
+
+
+def test_search_empty_term_with_facet_profile(client: TestClient, monkeypatch):
+    """Test that empty search term with facet_profile is allowed (AFTER behavior)."""
+    from rdflib import Graph
+
+    # Mock the system graph with facet profile
+    mock_system_graph = Graph()
+    mock_system_graph.parse(
+        data="""
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix dcterms: <http://purl.org/dc/terms/> .
+            @prefix prof: <http://www.w3.org/ns/dx/prof/> .
+            @prefix prez: <https://prez.dev/> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+            <https://prez.dev/profile/facet-by-type>
+                a prof:Profile , prez:ListingProfile ;
+                dcterms:identifier "facet-type"^^xsd:token ;
+                dcterms:title "Facet things by type" ;
+                dcterms:description "Allows faceting by rdf:type" ;
+                sh:property [ sh:path [ sh:union ( rdf:type ) ] ] .
+        """,
+        format="turtle",
+    )
+
+    # Add the mock data to the actual system graph
+    from prez.cache import prez_system_graph
+
+    prez_system_graph += mock_system_graph
+
+    response = client.get("/search?q=&facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=application/sparql-query")
+    # Should not return 400 error about missing search term
+    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+
+
+def test_search_empty_term_with_cql_filter(client: TestClient):
+    """Test that empty search term with CQL filter is allowed (AFTER behavior)."""
+    cql_filter = '{"op":"=","args":[{"property":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},"https://myclass"]}'
+    response = client.get(f"/search?q=&filter={cql_filter}")
+    # Should not return 400 error about missing search term
+    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+
+
+def test_search_empty_term_with_bbox(client: TestClient):
+    """Test that empty search term with bbox is allowed (AFTER behavior)."""
+    response = client.get("/search?q=&bbox=113.338953078,-43.6345972634,153.569469029,-10.6681857235")
+    # Should not return 400 error about missing search term
+    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+
+
+def test_search_empty_term_with_datetime(client: TestClient):
+    """Test that empty search term with datetime is allowed (AFTER behavior)."""
+    response = client.get("/search?q=&datetime=2018-02-12T23:20:50Z/2018-03-18T12:31:12Z")
+    # Should not return 400 error about missing search term
+    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+
+
+def test_search_missing_term_with_facet_profile(client: TestClient, monkeypatch):
+    """Test that missing search term with facet_profile is allowed (AFTER behavior)."""
+    from rdflib import Graph
+
+    # Mock the system graph with facet profile
+    mock_system_graph = Graph()
+    mock_system_graph.parse(
+        data="""
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix dcterms: <http://purl.org/dc/terms/> .
+            @prefix prof: <http://www.w3.org/ns/dx/prof/> .
+            @prefix prez: <https://prez.dev/> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+            <https://prez.dev/profile/facet-by-type>
+                a prof:Profile , prez:ListingProfile ;
+                dcterms:identifier "facet-type"^^xsd:token ;
+                dcterms:title "Facet things by type" ;
+                dcterms:description "Allows faceting by rdf:type" ;
+                sh:property [ sh:path [ sh:union ( rdf:type ) ] ] .
+        """,
+        format="turtle",
+    )
+
+    # Add the mock data to the actual system graph
+    from prez.cache import prez_system_graph
+
+    prez_system_graph += mock_system_graph
+
+    response = client.get("/search?facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/turtle")
+    # Should not return 400 error about missing search term
+    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")
+
+
+def test_search_missing_term_with_cql_filter(client: TestClient):
+    """Test that missing search term with CQL filter is allowed (AFTER behavior)."""
+    cql_filter = '{"op":"=","args":[{"property":"http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},"feature"]}'
+    response = client.get(f"/search?filter={cql_filter}")
+    # Should not return 400 error about missing search term
+    assert response.status_code != 400 or "Search query parameter 'q' must be provided" not in response.json().get("detail", "")

--- a/tests/test_search_empty_term.py
+++ b/tests/test_search_empty_term.py
@@ -25,11 +25,12 @@ def test_search_empty_term_with_facet_profile(client: TestClient, monkeypatch):
     """Test that empty search term with facet_profile is allowed (AFTER behavior)."""
     from rdflib import Graph
 
-    # Mock the system graph with facet profile
-    mock_system_graph = Graph()
-    mock_system_graph.parse(
+    # Mock the profiles graph with facet profile
+    mock_profiles_graph = Graph()
+    mock_profiles_graph.parse(
         data="""
             @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
             @prefix sh: <http://www.w3.org/ns/shacl#> .
             @prefix dcterms: <http://purl.org/dc/terms/> .
             @prefix prof: <http://www.w3.org/ns/dx/prof/> .
@@ -40,16 +41,16 @@ def test_search_empty_term_with_facet_profile(client: TestClient, monkeypatch):
                 a prof:Profile , prez:ListingProfile ;
                 dcterms:identifier "facet-type"^^xsd:token ;
                 dcterms:title "Facet things by type" ;
-                dcterms:description "Allows faceting by rdf:type" ;
-                sh:property [ sh:path [ sh:union ( rdf:type ) ] ] .
+                dcterms:description "Allows faceting by rdf:type rdfs:label" ;
+                sh:property [ sh:path [ sh:union ( rdf:type rdfs:label ) ] ] .
         """,
         format="turtle",
     )
 
-    # Add the mock data to the actual system graph
-    from prez.cache import prez_system_graph
+    # Add the mock data to the profiles graph cache
+    from prez.cache import profiles_graph_cache
 
-    prez_system_graph += mock_system_graph
+    profiles_graph_cache += mock_profiles_graph
 
     response = client.get(
         "/search?q=&facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=application/sparql-query"
@@ -105,10 +106,11 @@ def test_search_missing_term_with_facet_profile(client: TestClient, monkeypatch)
     from rdflib import Graph
 
     # Mock the system graph with facet profile
-    mock_system_graph = Graph()
-    mock_system_graph.parse(
+    mock_profiles_graph = Graph()
+    mock_profiles_graph.parse(
         data="""
             @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
             @prefix sh: <http://www.w3.org/ns/shacl#> .
             @prefix dcterms: <http://purl.org/dc/terms/> .
             @prefix prof: <http://www.w3.org/ns/dx/prof/> .
@@ -119,16 +121,16 @@ def test_search_missing_term_with_facet_profile(client: TestClient, monkeypatch)
                 a prof:Profile , prez:ListingProfile ;
                 dcterms:identifier "facet-type"^^xsd:token ;
                 dcterms:title "Facet things by type" ;
-                dcterms:description "Allows faceting by rdf:type" ;
-                sh:property [ sh:path [ sh:union ( rdf:type ) ] ] .
+                dcterms:description "Allows faceting by rdf:type rdfs:label" ;
+                sh:property [ sh:path [ sh:union ( rdf:type rdfs:label ) ] ] .
         """,
         format="turtle",
     )
 
     # Add the mock data to the actual system graph
-    from prez.cache import prez_system_graph
+    from prez.cache import profiles_graph_cache
 
-    prez_system_graph += mock_system_graph
+    profiles_graph_cache += mock_profiles_graph
 
     response = client.get(
         "/search?facet_profile=https://prez.dev/profile/facet-by-type&_mediatype=text/turtle"


### PR DESCRIPTION
  This branch allows search queries without a search term (q parameter) when filtering/faceting parameters are provided.

  Key Changes:
  - Enhanced search flexibility: Modified prez/dependencies.py:270-305 to allow empty/missing search terms when filtering parameters (facet_profile, filter, bbox, datetime) are present
  - Improved error messaging: Updated error message to guide users toward available filtering options
  - Comprehensive test coverage: Added tests/test_search_empty_term.py with 8 test cases covering both legacy behavior (requiring search term) and new behavior (allowing empty term with filters)

  Before: Search endpoint required a search term (q) parameter, returning 400 error if missing
  After: Search endpoint accepts empty/missing search term when any filtering parameter is provided, enabling pure faceting/filtering workflows without text search