### PR TITLE
fix: cql boolean handling should come out in sparql as true false not 1 or 0

### DIFF
--- a/prez/services/query_generation/grammar_helpers.py
+++ b/prez/services/query_generation/grammar_helpers.py
@@ -54,10 +54,14 @@ from sparql_grammar_pydantic import (
 )
 
 
-def convert_value_to_rdf_term(val) -> IRI | NumericLiteral | RDFLiteral:
+def convert_value_to_rdf_term(
+    val,
+) -> IRI | NumericLiteral | RDFLiteral | BooleanLiteral:
     """Convert a Python value to the appropriate RDF term."""
     if isinstance(val, str) and val.startswith("http"):
         return IRI(value=val)
+    elif isinstance(val, bool):
+        return BooleanLiteral(value=val)
     elif isinstance(val, (int, float)):
         return NumericLiteral(value=val)
     else:
@@ -95,7 +99,9 @@ def create_regex_filter(variable: Var, pattern: str) -> GraphPatternNotTriples:
 
 
 def create_relational_filter(
-    left_var: Var, operator: str, right_value: IRI | NumericLiteral | RDFLiteral
+    left_var: Var,
+    operator: str,
+    right_value: IRI | NumericLiteral | RDFLiteral | BooleanLiteral,
 ) -> GraphPatternNotTriples:
     """Create a SPARQL FILTER with relational comparison.
 

--- a/tests/test_cql.py
+++ b/tests/test_cql.py
@@ -501,6 +501,25 @@ def test_focus_node_in_subquery():
     assert Var(value="focus_node") in parser.inner_select_vars
 
 
+def test_cql_boolean_equals_filter():
+    """Ensure boolean literals in CQL become boolean literals in the SPARQL FILTER."""
+    from prez.services.query_generation.cql import CQLParser
+
+    cql_json_data = {
+        "op": "=",
+        "args": [
+            {"property": "http://example.org/flag"},
+            True,
+        ],
+    }
+
+    parser = CQLParser(cql_json=cql_json_data)
+    parser.parse()
+
+    query_str = parser.query_str
+    assert "FILTER (?var_1 = true)" in query_str
+
+
 def test_cql_not_equal_operator_with_literal():
     """
     Tests the '<>' operator (not equal) with a literal string value.


### PR DESCRIPTION
Translate CQL boolean literals into true/false filters in SPARQL by teaching convert_value_to_rdf_term to return BooleanLiteral instances for Python bools, which keeps the generated FILTER clauses semantically correct. Added a regression test that
  exercises a simple boolean equality and confirms the emitted query now reads FILTER (?var_1 = true). Test run: pytest tests/test_cql.py::test_cql_boolean_equals_filter.