### PR TITLE
add limit to text query

### DIFF
--- a/prez/config.py
+++ b/prez/config.py
@@ -113,6 +113,9 @@ class Settings(BaseSettings):
     search_uses_listing_count_limit: bool = False
     # If True, allow a single rdfs:subClassOf hop when selecting profiles. If False, exact class only.
     profile_constraint_allow_subclass: bool = False
+    # Optional inner limit for Fuseki FTS text:query. When None, no limit is added to the text:query.
+    # When set to an integer, adds that value as a limit argument to the FTS query.
+    fts_limit: Optional[int] = None
 
     @field_validator("prez_version")
     @classmethod

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -371,6 +371,7 @@ async def generate_search_query(
                 tss_list=tss_list,
                 limit=limit,
                 offset=offset,
+                fts_limit=settings.fts_limit,
             )
         else:
             raise NotImplementedError(

--- a/prez/services/listings.py
+++ b/prez/services/listings.py
@@ -7,49 +7,49 @@ import logging
 
 from fastapi.responses import PlainTextResponse
 from oxrdflib._converter import to_ox
-from pyoxigraph import BlankNode as OxiBlankNode
-from pyoxigraph import DefaultGraph as OxiDefaultGraph
-from pyoxigraph import Literal as OxiLiteral
-from pyoxigraph import NamedNode as OxiNamedNode
-from pyoxigraph import Quad as OxiQuad
 from pyoxigraph import (
     RdfFormat,
+    Store as OxiStore,
+    Quad as OxiQuad,
+    NamedNode as OxiNamedNode,
+    BlankNode as OxiBlankNode,
+    Literal as OxiLiteral,
+    DefaultGraph as OxiDefaultGraph,
 )
-from pyoxigraph import Store as OxiStore
 from rdf2geojson import convert
 from rdflib import Literal, Namespace
-from rdflib.namespace import GEO, PROF, RDF, RDFS
+from rdflib.namespace import GEO, RDF, PROF, RDFS
 from sparql_grammar_pydantic import (
     IRI,
+    TriplesSameSubject,
+    Var,
+    SelectClause,
+    WhereClause,
     GroupGraphPattern,
     GroupGraphPatternSub,
-    LimitClause,
-    LimitOffsetClauses,
-    OffsetClause,
-    SelectClause,
+    TriplesBlock,
+    TriplesSameSubjectPath,
     SolutionModifier,
     SubSelect,
-    TriplesBlock,
-    TriplesSameSubject,
-    TriplesSameSubjectPath,
-    Var,
-    WhereClause,
+    LimitOffsetClauses,
+    LimitClause,
+    OffsetClause,
 )
 
 from prez.cache import prefix_graph
 from prez.config import settings
 from prez.dependencies import DummySearchMarker
-from prez.enums import AnnotatedRDFMediaType, NonAnnotatedRDFMediaType
+from prez.enums import NonAnnotatedRDFMediaType, AnnotatedRDFMediaType
 from prez.reference_data.prez_ns import ALTREXT, OGCFEAT, PREZ
 from prez.renderers.renderer import (
-    create_collections_json,
-    generate_geojson_extras,
-    generate_link_headers,
-    generate_queryables_from_shacl_definition,
-    get_geojson_int_count,
-    handle_alt_profile,
     return_annotated_rdf_for_oxigraph,
     return_from_graph,
+    generate_geojson_extras,
+    handle_alt_profile,
+    generate_queryables_from_shacl_definition,
+    create_collections_json,
+    generate_link_headers,
+    get_geojson_int_count,
 )
 from prez.repositories import Repo
 from prez.services.connegp_service import OXIGRAPH_SERIALIZER_TYPES_MAP
@@ -58,14 +58,12 @@ from prez.services.generate_queryables import generate_queryables_json
 from prez.services.link_generation import add_prez_links_for_oxigraph
 from prez.services.query_generation.count import CountQuery
 from prez.services.query_generation.facet import FacetQuery
-from prez.services.query_generation.search_fuseki_fts import SearchQueryFusekiFTS
 from prez.services.query_generation.umbrella import (
     PrezQueryConstructor,
     merge_listing_query_grammar_inputs,
 )
 
 log = logging.getLogger(__name__)
-
 
 DWC = Namespace("http://rs.tdwg.org/dwc/terms/")
 
@@ -285,68 +283,7 @@ async def listing_function(
         or (pmts.selected["mediatype"] == "application/geo+json")
         or (search_query and settings.search_uses_listing_count_limit)
     ):
-        # If its a FTS query, adjust the limit in the text:query to match
-        # the limit of the outer select, which will be the listing count limit
-        # setting or greater based on the limit + offset specified in the query.
-        #
-        # I'm sure this is not an ideal why to do this, but I don't know
-        # how else. Essentially This just reconstructs the SearchQuery in the same
-        # way as it is done at the start of this function.
-        if search_query and isinstance(search_query, SearchQueryFusekiFTS):
-            current_offset = (
-                main_query.inner_select.solution_modifier.limit_offset.offset_clause.offset
-            )
-            current_limit = (
-                main_query.inner_select.solution_modifier.limit_offset.limit_clause.limit
-            )
-            if (current_offset + current_limit) > settings.listing_count_limit:
-                limit = current_offset + current_limit
-            else:
-                limit = settings.listing_count_limit
-            limit_plus_one = limit + 1
-            search_query_copy: SearchQueryFusekiFTS = copy.deepcopy(search_query)
-            search_query_copy.update_fts_limit_arg(new_limit=limit_plus_one)
-            subselect_kwargs = merge_listing_query_grammar_inputs(
-                cql_parser=cql_parser,
-                endpoint_nodeshape=endpoint_nodeshape,
-                search_query=search_query_copy,
-                concept_hierarchy_query=concept_hierarchy_query,
-                query_params=query_params,
-            )
-            if (
-                pmts.selected["mediatype"] == "application/geo+json"
-            ):  # Ensure the focus nodes have a geometry in the SPARQL
-                # subselect. If they are missing, the subsequent GeoJSON conversion will drop any Features without geometries.
-                _add_geom_triple_pattern_match(
-                    subselect_kwargs["inner_select_tssp_list"]
-                )
-
-            # merge subselect and profile triples same subject (for construct triples)
-            construct_tss_list = []
-            subselect_tss_list = subselect_kwargs.pop("construct_tss_list")
-            if subselect_tss_list:
-                construct_tss_list.extend(subselect_tss_list)
-            if profile_nodeshape.tss_list:
-                construct_tss_list.extend(profile_nodeshape.tss_list)
-
-            # add focus node declaration if it's an annotated mediatype
-            if "anot+" in pmts.selected["mediatype"]:
-                construct_tss_list.append(
-                    TriplesSameSubject.from_spo(
-                        subject=profile_nodeshape.focus_node,
-                        predicate=IRI(value="https://prez.dev/type"),
-                        object=IRI(value="https://prez.dev/FocusNode"),
-                    )
-                )
-            main_query_copy = PrezQueryConstructor(
-                construct_tss_list=construct_tss_list,
-                profile_triples=profile_nodeshape.tssp_list,
-                profile_gpnt=profile_nodeshape.gpnt_list,
-                **subselect_kwargs,
-            )
-            subselect = main_query_copy.inner_select
-        else:
-            subselect = copy.deepcopy(main_query.inner_select)
+        subselect = copy.deepcopy(main_query.inner_select)
         count_query = CountQuery(original_subselect=subselect).to_string()
         queries.append(count_query)
 
@@ -388,9 +325,7 @@ async def listing_function(
             for focus_node_quad in focus_node_quads:
                 # focus_node_quad.subject is already an OxiNamedNode
                 focus_node = focus_node_quad.subject
-                focus_node_uri = (
-                    focus_node.value
-                )  # Get the URI string without angle brackets
+                focus_node_uri = focus_node.value  # Get the URI string without angle brackets
 
                 # Create a unique hash ID for this dummy search result
                 hash_input = f"{focus_node_uri}:dummy"
@@ -440,11 +375,7 @@ async def listing_function(
                 )
 
     # count search results - hard to do in SPARQL as the SELECT part of the query is NOT aggregated
-    if (
-        search_query
-        and not isinstance(search_query, DummySearchMarker)
-        and not settings.search_uses_listing_count_limit
-    ):
+    if search_query and not isinstance(search_query, DummySearchMarker) and not settings.search_uses_listing_count_limit:
         count = len(
             list(
                 item_store.quads_for_pattern(

--- a/prez/services/query_generation/search_fuseki_fts.py
+++ b/prez/services/query_generation/search_fuseki_fts.py
@@ -192,7 +192,7 @@ class SearchQueryFusekiFTS(ConstructQuery):
                 base_list.append(
                     GraphNodePath(
                         varorterm_or_triplesnodepath=VarOrTerm(
-                            varorterm=GraphTerm(content=NumericLiteral(value=fts_limit))
+                            varorterm=GraphTerm(content=NumericLiteral(value=fts_limit + offset))
                         )
                     )
                 )

--- a/tests/test_search_fuseki_fts_class.py
+++ b/tests/test_search_fuseki_fts_class.py
@@ -121,3 +121,106 @@ def test_one_or_more_path(mock_settings, client):
     mock_settings.search_method = SearchMethod.FTS_FUSEKI
     r = client.get("/search?q=test&predicates=oomp&_mediatype=application/sparql-query")
     assert r.status_code == 200
+
+
+def test_fts_limit_none():
+    """Test that when fts_limit is None, no limit is added to the text:query"""
+    query_obj = SearchQueryFusekiFTS(
+        term="test",
+        limit=10,
+        offset=0,
+        non_shacl_predicates=[RDFS.label, RDFS.comment],
+        fts_limit=None,
+    )
+    query_string = query_obj.to_string()
+
+    # The query should contain the search term but NOT a numeric limit after it
+    # Pattern: (<pred1> <pred2> "test") - no third element
+    assert '<http://www.w3.org/2000/01/rdf-schema#label>' in query_string
+    assert '<http://www.w3.org/2000/01/rdf-schema#comment>' in query_string
+    assert '"test"' in query_string
+
+    # Count occurrences - should have predicates and search term, but no additional numeric value
+    # in the text:query parameter list
+    lines = query_string.split('\n')
+    text_query_section = '\n'.join([line for line in lines if 'text#query' in line or 'test' in line])
+
+    # Should NOT have a standalone integer after the search term in the collection
+    # This is a bit fragile but checks that we don't have ") 11" or similar patterns
+    # that would indicate a limit parameter
+    assert ') 11' not in query_string  # 10 + 1 from limit increment
+
+
+def test_fts_limit_set():
+    """Test that when fts_limit is set to an integer, it's added to the text:query"""
+    query_obj = SearchQueryFusekiFTS(
+        term="test",
+        limit=10,
+        offset=0,
+        non_shacl_predicates=[RDFS.label, RDFS.comment],
+        fts_limit=50,
+    )
+    query_string = query_obj.to_string()
+
+    # The query should contain the search term AND the fts_limit value
+    assert '<http://www.w3.org/2000/01/rdf-schema#label>' in query_string
+    assert '<http://www.w3.org/2000/01/rdf-schema#comment>' in query_string
+    assert '"test"' in query_string
+    assert '50' in query_string  # The fts_limit value should appear as a numeric literal
+
+    # Verify it's not accidentally using limit + offset
+    assert 'LIMIT 11' in query_string  # The outer LIMIT should be 11 (10 + 1)
+    # The FTS limit should be 50, not 10 or 11
+    # Check that the text:query contains 50
+    assert '"test"50' in query_string or '"test" 50' in query_string.replace('\n', ' ')
+
+
+def test_fts_limit_with_shacl():
+    """Test that fts_limit works correctly with SHACL predicates too"""
+    tssp_list = [
+        TriplesSameSubjectPath.from_spo(
+            Var(value="focus_node"),
+            IRI(value="http://example.com/hasFeatureOfInterest"),
+            Var(value="path_node_1"),
+        ),
+        TriplesSameSubjectPath.from_spo(
+            Var(value="path_node_1"),
+            IRI(value="http://www.w3.org/2000/01/rdf-schema#label"),
+            Var(value="fts_search_node"),
+        ),
+    ]
+
+    query_obj = SearchQueryFusekiFTS(
+        term="test",
+        limit=10,
+        offset=5,
+        shacl_tssp_preds=[(tssp_list, [RDFS.label])],
+        fts_limit=100,
+    )
+    query_string = query_obj.to_string()
+
+    # Should have the fts_limit value
+    assert '100' in query_string
+    assert '"test"' in query_string
+
+    # Should NOT have limit + offset (which would be 15)
+    # Note: the outer limit will be 11 (10+1), offset will be 5
+    # But the FTS limit should be exactly 100
+    assert 'LIMIT 11' in query_string  # outer limit
+    assert 'OFFSET 5' in query_string  # outer offset
+
+
+def test_fts_limit_default_none():
+    """Test that fts_limit defaults to None when not specified"""
+    query_obj = SearchQueryFusekiFTS(
+        term="test",
+        limit=10,
+        offset=0,
+        non_shacl_predicates=[RDFS.label],
+        # fts_limit not specified - should default to None
+    )
+    query_string = query_obj.to_string()
+
+    # Should work the same as explicitly passing None
+    assert '<http://www.w3.org/2000/01/rdf-schema#label>' in query_string
+    assert '"test"' in query_string


### PR DESCRIPTION
Improves performance of Fuseki FTS queries by adding a limit clause directly to the FTS search pattern.

i.e.

```sparql
?focus_node text:query (<pred> "term" 11) .
```

Where 11 is calculated as (limit + offset).

Might be some side effects I haven't thought about.
