### PR TITLE
fix: add complete Darwin Core annotations

### DIFF
--- a/prez/reference_data/annotations/dwc-annotations.ttl
+++ b/prez/reference_data/annotations/dwc-annotations.ttl
@@ -3,6 +3,15 @@ PREFIX schema: <https://schema.org/>
 
 <http://rs.tdwg.org/dwc/terms/>
     rdfs:label "Core terms defined by Darwin Core"@en ;
-    schema:description "This term list includes all currently valid terms that have been defined in the core Darwin Core namespace dwc:.  To comment on this schema, please create a new issue in https://github.com/tdwg/dwc/issues"@en ;
+    schema:description "This term list includes all currently valid terms that have been defined in the core Darwin Core namespace dwc:.  To comment on this schema, please create a new issue in https://github.com/tdwg/dwc/issues"
 .
 
+<http://rs.tdwg.org/dwc/terms/Occurrence>
+    rdfs:label "Occurrence"@en ;
+    schema:description "An existence of a dwc:Organism at a particular place at a particular time."@en
+.
+
+<http://rs.tdwg.org/dwc/terms/Identification>
+    rdfs:label "Identification"@en ;
+    schema:description "A taxonomic determination (e.g., the assignment to a dwc:Taxon)."@en
+.

--- a/prez/reference_data/annotations/dwc-annotations.ttl
+++ b/prez/reference_data/annotations/dwc-annotations.ttl
@@ -1,17 +1,3373 @@
+# Darwin Core annotations for Prez.
+# Source: https://github.com/tdwg/rs.tdwg.org/tree/master/terms and /iri
+# Retrieved: 2026-07-20
+# Source content: CC BY 4.0, https://creativecommons.org/licenses/by/4.0/
+#
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+<http://rs.tdwg.org/dwc/iri/>
+    rdfs:label "Darwin Core IRI-value Term Analogs"@en ;
+    dcterms:description "The terms on this list are intended to be used with IRI values."@en ;
+    skos:prefLabel "Darwin Core IRI-value Term Analogs"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/assayType>
+    rdfs:label "Assay Type (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
+    skos:definition "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Assay Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/assertionBy>
+    rdfs:label "Assertion By (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An IRI identifying a dcterms:Agent responsible for making a dwc:Assertion."@en ;
+    skos:definition "An IRI identifying a dcterms:Agent responsible for making a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion By (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/assertionType>
+    rdfs:label "Assertion Type (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:Assertion."@en ;
+    skos:definition "A category that best matches the nature of a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/assertionUnit>
+    rdfs:label "Assertion Unit (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.ontology-of-units-of-measure.org for SI units, derived units, or other non-SI units accepted for use within the SI. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A unit associated with the value in dwc:assertionValue."@en ;
+    skos:definition "A unit associated with the value in dwc:assertionValue."@en ;
+    skos:prefLabel "Assertion Unit (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/assertionValue>
+    rdfs:label "Assertion Value (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An asserted value."@en ;
+    skos:definition "An asserted value."@en ;
+    skos:prefLabel "Assertion Value (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/behavior>
+    rdfs:label "Behavior (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A behavior shown by a dwc:Organism."@en ;
+    skos:definition "A behavior shown by a dwc:Organism."@en ;
+    skos:prefLabel "Behavior (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/caste>
+    rdfs:label "Caste (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary that aligns best with a dwc:Taxon. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A social caste of a dwc:Organism."@en ;
+    skos:definition "A social caste of a dwc:Organism."@en ;
+    skos:prefLabel "Caste (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/dataGeneralizations>
+    rdfs:label "Data Generalizations (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:definition "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:prefLabel "Data Generalizations (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/degreeOfEstablishment>
+    rdfs:label "Degree of Establishment (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use IRIs from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/doe/. For details, refer to https://doi.org/10.3897/biss.3.38084 . Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
+    skos:definition "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
+    skos:prefLabel "Degree of Establishment (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/discipline>
+    rdfs:label "Discipline (IRI)"@en ;
+    dcterms:description "This term can be used to classify records according to branches of knowledge. Recommended best practice is to use a controlled vocabulary. Terms in the dwciri namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The primary branch or branches of knowledge represented by the record."@en ;
+    skos:definition "The primary branch or branches of knowledge represented by the record."@en ;
+    skos:prefLabel "Discipline (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/disposition>
+    rdfs:label "Disposition (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
+    skos:definition "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
+    skos:prefLabel "Disposition (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/earliestGeochronologicalEra>
+    rdfs:label "Earliest Geochronological Era"@en ;
+    dcterms:description "Recommended best practice is to use an IRI from a controlled vocabulary. A \"convenience property\" that replaces Darwin Core literal-value terms related to geological context. See Section 2.7.6 of the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the earliest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the earliest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Earliest Geochronological Era"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/establishmentMeans>
+    rdfs:label "Establishment Means (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use IRIs from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/em/. For details, refer to https://doi.org/10.3897/biss.3.38084 . Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
+    skos:definition "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
+    skos:prefLabel "Establishment Means (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/eventCategory>
+    rdfs:label "Event Category (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A broad category that best matches the nature of a dwc:Event."@en ;
+    skos:definition "A broad category that best matches the nature of a dwc:Event."@en ;
+    skos:prefLabel "Event Category (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/eventType>
+    rdfs:label "Event Type (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A narrow category that best matches the nature of a dwc:Event."@en ;
+    skos:definition "A narrow category that best matches the nature of a dwc:Event."@en ;
+    skos:prefLabel "Event Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/fieldNotes>
+    rdfs:label "Field Notes (IRI)"@en ;
+    dcterms:description "The subject is a dwc:Event instance and the object is a (possibly IRI-identified) resource that is the field notes."@en ;
+    rdfs:comment "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
+    skos:definition "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
+    skos:prefLabel "Field Notes (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/fieldNumber>
+    rdfs:label "Field Number (IRI)"@en ;
+    dcterms:description "Often serves as a link between field notes and a dwc:Event. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An identifier given to a dwc:Event in the field."@en ;
+    skos:definition "An identifier given to a dwc:Event in the field."@en ;
+    skos:prefLabel "Field Number (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/footprintSRS>
+    rdfs:label "Footprint SRS (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use an IRI for the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary IRI for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary IRI for the name or code of the ellipsoid, if known. Otherwise use an IRI for the value corresponding to `not recorded`."@en ;
+    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
+    skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
+    skos:prefLabel "Footprint SRS (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/footprintWKT>
+    rdfs:label "Footprint WKT (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines the dcterms:Location. A dcterms:Location may have both a point-radius representation (see dwc:decimalLatitude) and a footprint representation, and they may differ from each other."@en ;
+    skos:definition "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines the dcterms:Location. A dcterms:Location may have both a point-radius representation (see dwc:decimalLatitude) and a footprint representation, and they may differ from each other."@en ;
+    skos:prefLabel "Footprint WKT (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/fromLithostratigraphicUnit>
+    rdfs:label "From Lithostratigraphic Unit"@en ;
+    dcterms:description "Recommended best practice is to use an IRI from a controlled vocabulary. A \"convenience property\" that replaces Darwin Core literal-value terms related to geological context. See Section 2.7.7 of the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link a dwc:GeologicalContext instance to an IRI-identified lithostratigraphic unit at the lowest possible level in a hierarchy."@en ;
+    skos:definition "Use to link a dwc:GeologicalContext instance to an IRI-identified lithostratigraphic unit at the lowest possible level in a hierarchy."@en ;
+    skos:prefLabel "From Lithostratigraphic Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/fundingAttribution>
+    rdfs:label "Funding Attribution (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An organization or agency that provided funding for a project."@en ;
+    skos:definition "An organization or agency that provided funding for a project."@en ;
+    skos:prefLabel "Funding Attribution (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/geodeticDatum>
+    rdfs:label "Geodetic Datum (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use an IRI for the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use an IRI corresponding to the value `not recorded`."@en ;
+    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
+    skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
+    skos:prefLabel "Geodetic Datum (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/georeferenceProtocol>
+    rdfs:label "Georeference Protocol (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
+    skos:definition "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
+    skos:prefLabel "Georeference Protocol (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/georeferenceSources>
+    rdfs:label "Georeference Sources (IRI)"@en ;
+    dcterms:description "Recommended best practice is describe a georeference with no more than one sampled georeference source. In the case of a georeference that cannot be attributed to a specific source, the recommended best practice is to repeat the property for each IRI that denotes a different source that applies to the georeference. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An IRI for a map, gazetteer, or other resource used to georeference a dcterms:Location."@en ;
+    skos:definition "An IRI for a map, gazetteer, or other resource used to georeference a dcterms:Location."@en ;
+    skos:prefLabel "Georeference Sources (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/georeferenceVerificationStatus>
+    rdfs:label "Georeference Verification Status (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
+    skos:definition "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
+    skos:prefLabel "Georeference Verification Status (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/georeferencedBy>
+    rdfs:label "Georeferenced By (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An IRI identifying a dcterms:Agent responsible for providing a georeference."@en ;
+    skos:definition "An IRI identifying a dcterms:Agent responsible for providing a georeference."@en ;
+    skos:prefLabel "Georeferenced By (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/habitat>
+    rdfs:label "Habitat (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A category or description of the habitat in which the dwc:Event occurred."@en ;
+    skos:definition "A category or description of the habitat in which the dwc:Event occurred."@en ;
+    skos:prefLabel "Habitat (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/identificationQualifier>
+    rdfs:label "Identification Qualifier (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A controlled value to express the determiner's doubts about the dwc:Identification."@en ;
+    skos:definition "A controlled value to express the determiner's doubts about the dwc:Identification."@en ;
+    skos:prefLabel "Identification Qualifier (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/identificationType>
+    rdfs:label "Identification Type (IRI)"@en ;
+    dcterms:description "The evidentiary basis, analytical approach, or inferential method by which an identification was determined. Values describe the dominant source of information supporting the identification (e.g., morphology, geography, molecular data, functional attributes, relationships, or taxonomic revision), independent of confidence level or taxonomic outcome. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:Identification."@en ;
+    skos:definition "A category that best matches the nature of a dwc:Identification."@en ;
+    skos:prefLabel "Identification Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/identificationVerificationStatus>
+    rdfs:label "Identification Verification Status (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as that used in HISPID and ABCD. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
+    skos:definition "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
+    skos:prefLabel "Identification Verification Status (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/identifiedBy>
+    rdfs:label "Identified By (IRI)"@en ;
+    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An IRI identifying a dcterms:Agent responsible for making a dwc:Identification."@en ;
+    skos:definition "An IRI identifying a dcterms:Agent responsible for making a dwc:Identification."@en ;
+    skos:prefLabel "Identified By (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/inCollection>
+    rdfs:label "In Collection"@en ;
+    dcterms:description "Recommended best practice is to use an IRI from a controlled registry. A \"convenience property\" that replaces literal-value terms related to collections and institutions. See Section 2.7.3 of the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link any subject resource that is part of a collection to the collection containing the resource."@en ;
+    skos:definition "Use to link any subject resource that is part of a collection to the collection containing the resource."@en ;
+    skos:prefLabel "In Collection"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/inDataset>
+    rdfs:label "In Dataset"@en ;
+    dcterms:description "A string literal name of the dataset can be provided using the term dwc:datasetName. See the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link a subject dataset record to the dataset which contains it."@en ;
+    skos:definition "Use to link a subject dataset record to the dataset which contains it."@en ;
+    skos:prefLabel "In Dataset"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/inDescribedPlace>
+    rdfs:label "In Described Place"@en ;
+    dcterms:description "Recommended best practice is to use an IRI from a controlled registry. A \"convenience property\" that replaces Darwin Core literal-value terms related to locations. See Section 2.7.5 of the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link a dcterms:Location instance subject to the lowest level standardized hierarchically-described resource."@en ;
+    skos:definition "Use to link a dcterms:Location instance subject to the lowest level standardized hierarchically-described resource."@en ;
+    skos:prefLabel "In Described Place"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/informationWithheld>
+    rdfs:label "Information Withheld (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:definition "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:prefLabel "Information Withheld (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/latestGeochronologicalEra>
+    rdfs:label "Latest Geochronological Era"@en ;
+    dcterms:description "Recommended best practice is to use an IRI from a controlled vocabulary. A \"convenience property\" that replaces Darwin Core literal-value terms related to geological context. See Section 2.7.6 of the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the latest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the latest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Latest Geochronological Era"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/lifeStage>
+    rdfs:label "Life Stage (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An age class or life stage of a dwc:Organism."@en ;
+    skos:definition "An age class or life stage of a dwc:Organism."@en ;
+    skos:prefLabel "Life Stage (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/locationAccordingTo>
+    rdfs:label "Location According To (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
+    skos:definition "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
+    skos:prefLabel "Location According To (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/materialEntityCategory>
+    rdfs:label "Material Entity Category (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
+    skos:definition "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Material Entity Category (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/materialEntityType>
+    rdfs:label "Material Entity Type (IRI)"@en ;
+    dcterms:description "A more generic classification of a dwc:MaterialEntity than dwc:preparations. Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
+    skos:definition "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
+    skos:prefLabel "Material Entity Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/measurementDeterminedBy>
+    rdfs:label "Measurement Determined By (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A person, group, or organization who determined the value of the dwc:MeasurementOrFact."@en ;
+    skos:definition "A person, group, or organization who determined the value of the dwc:MeasurementOrFact."@en ;
+    skos:prefLabel "Measurement Determined By (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/measurementMethod>
+    rdfs:label "Measurement Method (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
+    skos:definition "The method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
+    skos:prefLabel "Measurement Method (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/measurementType>
+    rdfs:label "Measurement Type (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The nature of the measurement, fact, characteristic, or assertion."@en ;
+    skos:definition "The nature of the measurement, fact, characteristic, or assertion."@en ;
+    skos:prefLabel "Measurement Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/measurementUnit>
+    rdfs:label "Measurement Unit (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.wurvoc.org/vocabularies/om-1.8/ of SI units, derived units, or other non-SI units accepted for use within the SI."@en ;
+    rdfs:comment "The units associated with the dwc:measurementValue."@en ;
+    skos:definition "The units associated with the dwc:measurementValue."@en ;
+    skos:prefLabel "Measurement Unit (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/measurementValue>
+    rdfs:label "Measurement Value (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The value of the measurement, fact, characteristic, or assertion."@en ;
+    skos:definition "The value of the measurement, fact, characteristic, or assertion."@en ;
+    skos:prefLabel "Measurement Value (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/objectQuantityType>
+    rdfs:label "Object Quantity Type (IRI)"@en ;
+    dcterms:description "An dwc:objectQuantityType must have a corresponding dwc:objectQuantity. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
+    skos:definition "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
+    skos:prefLabel "Object Quantity Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/occurrenceStatus>
+    rdfs:label "Occurrence Status (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
+    skos:definition "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
+    skos:prefLabel "Occurrence Status (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/organismInteractionType>
+    rdfs:label "Organism Interaction Type (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
+    skos:definition "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
+    skos:prefLabel "Organism Interaction Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/organismQuantityType>
+    rdfs:label "Organism Quantity Type (IRI)"@en ;
+    dcterms:description "A dwc:organismQuantityType must have a corresponding dwc:organismQuantity."@en ;
+    rdfs:comment "The type of quantification system used for the quantity of organisms."@en ;
+    skos:definition "The type of quantification system used for the quantity of organisms."@en ;
+    skos:prefLabel "Organism Quantity Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/organismScope>
+    rdfs:label "Organism Scope (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term is not intended to be used to specify a type of dwc:Taxon. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
+    skos:definition "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
+    skos:prefLabel "Organism Scope (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/pathway>
+    rdfs:label "Pathway (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use IRIs from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/pw/. For details, refer to https://doi.org/10.3897/biss.3.38084 . Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
+    skos:definition "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
+    skos:prefLabel "Pathway (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/preferredSpatialRepresentation>
+    rdfs:label "Preferred Spatial Representation (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An indication of which spatial representation best represents the dcterms:Location."@en ;
+    skos:definition "An indication of which spatial representation best represents the dcterms:Location."@en ;
+    skos:prefLabel "Preferred Spatial Representation (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/preparations>
+    rdfs:label "Preparations (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A preparation or preservation method for a specimen."@en ;
+    skos:definition "A preparation or preservation method for a specimen."@en ;
+    skos:prefLabel "Preparations (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/protocolType>
+    rdfs:label "Protocol Type (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:Protocol."@en ;
+    skos:definition "A category that best matches the nature of a dwc:Protocol."@en ;
+    skos:prefLabel "Protocol Type (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/recordNumber>
+    rdfs:label "Record Number (IRI)"@en ;
+    dcterms:description "The subject is a dwc:Occurrence and the object is a (possibly IRI-identified) resource that is the field notes."@en ;
+    rdfs:comment "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
+    skos:definition "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
+    skos:prefLabel "Record Number (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/recordedBy>
+    rdfs:label "Recorded By (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An IRI identifying a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
+    skos:definition "An IRI identifying a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
+    skos:prefLabel "Recorded By (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/reproductiveCondition>
+    rdfs:label "Reproductive Condition (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A reproductive condition of a dwc:Organism."@en ;
+    skos:definition "A reproductive condition of a dwc:Organism."@en ;
+    skos:prefLabel "Reproductive Condition (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/sampleSizeUnit>
+    rdfs:label "Sampling Size Unit (IRI)"@en ;
+    dcterms:description "A dwciri:sampleSizeUnit must have a corresponding dwc:sampleSizeValue. Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.wurvoc.org/vocabularies/om-1.8/ of SI units, derived units, or other non-SI units accepted for use within the SI."@en ;
+    rdfs:comment "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
+    skos:definition "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
+    skos:prefLabel "Sampling Size Unit (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/sampledSubstrateCategory>
+    rdfs:label "Sampled Substrate Category (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A category or type of substrate sampled during a dwc:Event."@en ;
+    skos:definition "A category or type of substrate sampled during a dwc:Event."@en ;
+    skos:prefLabel "Sampled Substrate Category (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/sampledSubstrateLayer>
+    rdfs:label "Sampled Substrate Layer (IRI)"@en ;
+    dcterms:description "Recommended best practice is describe a dwc:Event with no more than one sampled substrate layer. In the case of a dwc:Event that cannot be attributed to a specific layer, the recommended best practice is to repeat the property for each IRI that denotes a different layer that applies to the dwc:Event. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An IRI identifying a substrate layer sampled during a dwc:Event."@en ;
+    skos:definition "An IRI identifying a substrate layer sampled during a dwc:Event."@en ;
+    skos:prefLabel "Sampled Substrate Layer (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/samplingProtocol>
+    rdfs:label "Sampling Protocol (IRI)"@en ;
+    dcterms:description "Recommended best practice is to describe a dwc:Event with no more than one sampling protocol. In the case of a summary dwc:Event in which a specific protocol can not be attributed to specific dwc:Occurrences, the recommended best practice is to repeat the property for each IRI that denotes a different sampling protocol that applies to the dwc:Occurrence."@en ;
+    rdfs:comment "The methods or protocols used during a dwc:Event, denoted by an IRI."@en ;
+    skos:definition "The methods or protocols used during a dwc:Event, denoted by an IRI."@en ;
+    skos:prefLabel "Sampling Protocol (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/sex>
+    rdfs:label "Sex (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A sex of a dwc:Organism."@en ;
+    skos:definition "A sex of a dwc:Organism."@en ;
+    skos:prefLabel "Sex (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/siteNumber>
+    rdfs:label "Site Number (IRI)"@en ;
+    dcterms:description "Usually an institutional identifier for a specific named place as opposed to dwc:locationID, which is an identifier for the entire set of distinct information for an instance of dcterms:Location. This term differs from dwciri:fieldNumber in that dwciri:siteNumber is not related strictly to one dwc:Event. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An identifier for a named site."@en ;
+    skos:definition "An identifier for a named site."@en ;
+    skos:prefLabel "Site Number (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/taxonFormula>
+    rdfs:label "Taxon Formula (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
+    skos:definition "A pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
+    skos:prefLabel "Taxon Formula (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/toDigitalSpecimen>
+    rdfs:label "To Digital Specimen"@en ;
+    dcterms:description "Use to link a dwc:MaterialEntity instance subject to a Digital Specimem entity."@en ;
+    rdfs:comment "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
+    skos:definition "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
+    skos:prefLabel "To Digital Specimen"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/toTaxon>
+    rdfs:label "To Taxon"@en ;
+    dcterms:description "A \"convenience property\" that replaces Darwin Core literal-value terms related to taxonomic entities. See Section 2.7.4 of the Darwin Core RDF Guide for details."@en ;
+    rdfs:comment "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
+    skos:definition "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
+    skos:prefLabel "To Taxon"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/typeStatus>
+    rdfs:label "Type Status (IRI)"@en ;
+    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A nomenclatural type (type status, typified scientific name, publication) applied to the subject."@en ;
+    skos:definition "A nomenclatural type (type status, typified scientific name, publication) applied to the subject."@en ;
+    skos:prefLabel "Type Status (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/verbatimCoordinateSystem>
+    rdfs:label "Verbatim Coordinate System (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
+    skos:definition "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
+    skos:prefLabel "Verbatim Coordinate System (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/verbatimSRS>
+    rdfs:label "Verbatim SRS (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use an IRI for the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary IRI for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary IRI for the name or code of the ellipsoid, if known. Otherwise use an IRI for the value corresponding to `not recorded`."@en ;
+    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
+    skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
+    skos:prefLabel "Verbatim SRS (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/verticalDatum>
+    rdfs:label "Vertical Datum (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
+    skos:definition "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
+    skos:prefLabel "Vertical Datum (IRI)"@en ;
+.
+
+<http://rs.tdwg.org/dwc/iri/vitality>
+    rdfs:label "Vitality (IRI)"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
+    rdfs:comment "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
+    skos:definition "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
+    skos:prefLabel "Vitality (IRI)"@en ;
+.
 
 <http://rs.tdwg.org/dwc/terms/>
     rdfs:label "Core terms defined by Darwin Core"@en ;
-    schema:description "This term list includes all currently valid terms that have been defined in the core Darwin Core namespace dwc:.  To comment on this schema, please create a new issue in https://github.com/tdwg/dwc/issues"
+    dcterms:description "This term list includes all currently valid terms that have been defined in the core Darwin Core namespace dwc:."@en ;
+    skos:prefLabel "Core terms defined by Darwin Core"@en ;
 .
 
-<http://rs.tdwg.org/dwc/terms/Occurrence>
-    rdfs:label "Occurrence"@en ;
-    schema:description "An existence of a dwc:Organism at a particular place at a particular time."@en
+<http://rs.tdwg.org/dwc/terms/AcceptedTaxon>
+    rdfs:label "Accepted Taxon"@en ;
+    rdfs:comment "The currently valid (zoological) or accepted (botanical) name for the ScientificName."@en ;
+    skos:definition "The currently valid (zoological) or accepted (botanical) name for the ScientificName."@en ;
+    skos:prefLabel "Accepted Taxon"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/AcceptedTaxonID>
+    rdfs:label "Accepted Taxon ID"@en ;
+    rdfs:comment "A global unique identifier for the parent to the AcceptedTaxon."@en ;
+    skos:definition "A global unique identifier for the parent to the AcceptedTaxon."@en ;
+    skos:prefLabel "Accepted Taxon ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/AccessConstraints>
+    rdfs:label "Access Constraints"@en ;
+    dcterms:description "Example: \"not-for-profit use only\"."@en ;
+    rdfs:comment "A description of constraints on the use of the data as shared or access to further data that is not shared."@en ;
+    skos:definition "A description of constraints on the use of the data as shared or access to further data that is not shared."@en ;
+    skos:prefLabel "Access Constraints"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Assertion>
+    rdfs:label "Assertion"@en ;
+    dcterms:description "Resources can be thought of as identifiable records or instances of classes and may include, but need not be limited to instances of dwc:Occurrence, dwc:Organism, dwc:MaterialEntity, dwc:Event, dcterms:Location, dwc:GeologicalContext, dwc:Identification, or dwc:Taxon."@en ;
+    rdfs:comment "A statement about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
+    skos:definition "A statement about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
+    skos:prefLabel "Assertion"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/CatalogNumberNumeric>
+    rdfs:label "Catalog Number Numeric"@en ;
+    rdfs:comment "The numeric value of the catalogNumber, used to facilitate numerical sorting and searching by ranges."@en ;
+    skos:definition "The numeric value of the catalogNumber, used to facilitate numerical sorting and searching by ranges."@en ;
+    skos:prefLabel "Catalog Number Numeric"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Dataset>
+    rdfs:label "Dataset"@en ;
+    rdfs:comment "The category of information pertaining to a logical set of records."@en ;
+    skos:definition "The category of information pertaining to a logical set of records."@en ;
+    skos:prefLabel "Dataset"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/DwCType>
+    rdfs:label "Darwin Core Type"@en ;
+    rdfs:comment "The set of classes specified by the Darwin Core Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
+    skos:definition "The set of classes specified by the Darwin Core Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
+    skos:prefLabel "Darwin Core Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EarliestDateCollected>
+    rdfs:label "Earliest Date Collected"@en ;
+    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+    rdfs:comment "The earliest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:definition "The earliest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:prefLabel "Earliest Date Collected"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EndTimeOfDay>
+    rdfs:label "End Time of Day"@en ;
+    dcterms:description "Examples: \"12.0\" (= noon), \"13.5\" (= 1:30pm)"@en ;
+    rdfs:comment "The time of day when the event ended, expressed as decimal hours from midnight, local time."@en ;
+    skos:definition "The time of day when the event ended, expressed as decimal hours from midnight, local time."@en ;
+    skos:prefLabel "End Time of Day"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Event>
+    rdfs:label "Event"@en ;
+    rdfs:comment "An action, process, or set of circumstances occurring at a dcterms:Location during a period of time."@en ;
+    skos:definition "An action, process, or set of circumstances occurring at a dcterms:Location during a period of time."@en ;
+    skos:prefLabel "Event"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttribute>
+    rdfs:label "Event Attribute"@en ;
+    rdfs:comment "Container class for information about attributes related to a given sampling event."@en ;
+    skos:definition "Container class for information about attributes related to a given sampling event."@en ;
+    skos:prefLabel "Event Attribute"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeAccuracy>
+    rdfs:label "Event Attribute Accuracy"@en ;
+    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
+    rdfs:comment "The description of the error associated with the EventAttributeValue."@en ;
+    skos:definition "The description of the error associated with the EventAttributeValue."@en ;
+    skos:prefLabel "Event Attribute Accuracy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeDeterminedBy>
+    rdfs:label "Event Attribute Determined By"@en ;
+    dcterms:description "Example: \"Robert Hijmans\""@en ;
+    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the sampling event."@en ;
+    skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the sampling event."@en ;
+    skos:prefLabel "Event Attribute Determined By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeDeterminedDate>
+    rdfs:label "Event Attribute Determined Date"@en ;
+    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+    rdfs:comment "The date on which the the measurement or characteristic of the sampling event was made."@en ;
+    skos:definition "The date on which the the measurement or characteristic of the sampling event was made."@en ;
+    skos:prefLabel "Event Attribute Determined Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeID>
+    rdfs:label "Event Attribute ID"@en ;
+    rdfs:comment "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Event Attribute ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeRemarks>
+    rdfs:label "Event Attribute Remarks"@en ;
+    dcterms:description "Example: \"temperature taken at 15:00\""@en ;
+    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the sampling event."@en ;
+    skos:definition "Comments or notes accompanying the measurement or characteristic of the sampling event."@en ;
+    skos:prefLabel "Event Attribute Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeType>
+    rdfs:label "Event Attribute Type"@en ;
+    dcterms:description "Example: \"Temperature\""@en ;
+    rdfs:comment "The nature of the measurement or characteristic of the sampling event. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:definition "The nature of the measurement or characteristic of the sampling event. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:prefLabel "Event Attribute Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeUnit>
+    rdfs:label "Event Attribute Unit"@en ;
+    dcterms:description "Example: \"C\""@en ;
+    rdfs:comment "The units for the value of the measurement or characteristic of the sampling event. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:definition "The units for the value of the measurement or characteristic of the sampling event. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:prefLabel "Event Attribute Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventAttributeValue>
+    rdfs:label "Event Attribute"@en ;
+    dcterms:description "Example: \"22\""@en ;
+    rdfs:comment "The value of the measurement or characteristic of the sampling event."@en ;
+    skos:definition "The value of the measurement or characteristic of the sampling event."@en ;
+    skos:prefLabel "Event Attribute"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/EventMeasurement>
+    rdfs:label "Event Measurement"@en ;
+    rdfs:comment "The category of information pertaining to measurements associated with an event."@en ;
+    skos:definition "The category of information pertaining to measurements associated with an event."@en ;
+    skos:prefLabel "Event Measurement"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/FossilSpecimen>
+    rdfs:label "Fossil Specimen"@en ;
+    rdfs:comment "A preserved specimen that is a fossil."@en ;
+    skos:definition "A preserved specimen that is a fossil."@en ;
+    skos:prefLabel "Fossil Specimen"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Generalizations>
+    rdfs:label "Generalizations"@en ;
+    dcterms:description "Examples: \"Coordinates generalized from original GPS coordinates to the nearest half degree grid cell\", \"locality information given only to nearest county\"."@en ;
+    rdfs:comment "Actions taken to make the data as shared less specific or complete than in its original form. Suggests that alternative data of highly quality may be available on request."@en ;
+    skos:definition "Actions taken to make the data as shared less specific or complete than in its original form. Suggests that alternative data of highly quality may be available on request."@en ;
+    skos:prefLabel "Generalizations"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/GeologicalContext>
+    rdfs:label "Geological Context"@en ;
+    rdfs:comment "A set of geological designations, such as stratigraphy, that qualifies a dcterms:Location or source of a dwc:MaterialEntity."@en ;
+    skos:definition "A set of geological designations, such as stratigraphy, that qualifies a dcterms:Location or source of a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Geological Context"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/HigherTaxon>
+    rdfs:label "Higher Taxon"@en ;
+    dcterms:description "Example: \"Animalia, Chordata, Vertebrata, Mammalia, Theria, Eutheria, Rodentia, Hystricognatha, Hystricognathi, Ctenomyidae, Ctenomyini, Ctenomys\"."@en ;
+    rdfs:comment "A list (concatenated and separated) of the names for the taxonomic ranks less specific than the ScientificName."@en ;
+    skos:definition "A list (concatenated and separated) of the names for the taxonomic ranks less specific than the ScientificName."@en ;
+    skos:prefLabel "Higher Taxon"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/HigherTaxonID>
+    rdfs:label "Higher Taxon ID"@en ;
+    rdfs:comment "A global unique identifier for the parent to the taxon."@en ;
+    skos:definition "A global unique identifier for the parent to the taxon."@en ;
+    skos:prefLabel "Higher Taxon ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/HumanObservation>
+    rdfs:label "Human Observation"@en ;
+    rdfs:comment "An output of a human observation process."@en ;
+    skos:definition "An output of a human observation process."@en ;
+    skos:prefLabel "Human Observation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Identification>
     rdfs:label "Identification"@en ;
-    schema:description "A taxonomic determination (e.g., the assignment to a dwc:Taxon)."@en
+    dcterms:description "For biology, the assignment of a scientific name or taxon concept to a dwc:Organism."@en ;
+    rdfs:comment "A classification of a resource according to a classification scheme."@en ;
+    skos:definition "A classification of a resource according to a classification scheme."@en ;
+    skos:prefLabel "Identification"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/LatestDateCollected>
+    rdfs:label "Latest Date Collected"@en ;
+    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+    rdfs:comment "The latest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:definition "The latest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:prefLabel "Latest Date Collected"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/LivingSpecimen>
+    rdfs:label "Living Specimen"@en ;
+    rdfs:comment "A specimen that is alive."@en ;
+    skos:definition "A specimen that is alive."@en ;
+    skos:prefLabel "Living Specimen"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/MachineObservation>
+    rdfs:label "Machine Observation"@en ;
+    rdfs:comment "An output of a machine observation process."@en ;
+    skos:definition "An output of a machine observation process."@en ;
+    skos:prefLabel "Machine Observation"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/MaterialCitation>
+    rdfs:label "Material Citation"@en ;
+    dcterms:description "This class constitutes a new value for the controlled vocabulary in the recommendations for basisOfRecord. When importing Darwin Core Archives of literature-based datasets to GBIF, the basisOfRecord should be changed from \"Occurrence\", \"PreservedSpecimen\" or \"Literature\" to \"MaterialCitation\"."@en ;
+    rdfs:comment "A reference to or citation of one, a part of, or multiple specimens in scholarly publications."@en ;
+    skos:definition "A reference to or citation of one, a part of, or multiple specimens in scholarly publications."@en ;
+    skos:prefLabel "Material Citation"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/MaterialEntity>
+    rdfs:label "Material Entity"@en ;
+    dcterms:description "The term is defined at the most general level to admit descriptions of any subtype of material entity within the scope of Darwin Core. In particular, any kind of material sample, preserved specimen, fossil, or exemplar from living collections is intended to be subsumed under this term. In Darwin Core, dwc:Organism, dwc:Occurrence, and dwc:MaterialEntity are related, but distinct concepts. A dwc:Organism is a biological individual or group with an identity and life history that persists independently of the particular dwc:MaterialEntities through which it is manifested. A dwc:Occurrence is a dwc:Event that represents the presence or state of a dwc:Organism at a place during an interval of time, with no explicit dependency on any dwc:MaterialEntity. A dwc:MaterialEntity represents physical matter, including whole bodies, parts, or derivatives of dwc:Organisms, that may directly or indirectly serve as evidence of a dwc:Occurrence."@en ;
+    rdfs:comment "An entity that can be identified, exists for some period of time, and consists in whole or in part of physical matter while it exists."@en ;
+    skos:definition "An entity that can be identified, exists for some period of time, and consists in whole or in part of physical matter while it exists."@en ;
+    skos:prefLabel "Material Entity"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/MaterialSample>
+    rdfs:label "Material Sample"@en ;
+    rdfs:comment "A material entity that represents an entity of interest in whole or in part."@en ;
+    skos:definition "A material entity that represents an entity of interest in whole or in part."@en ;
+    skos:prefLabel "Material Sample"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/MeasurementOrFact>
+    rdfs:label "Measurement Or Fact"@en ;
+    dcterms:description "Resources can be thought of as identifiable records or instances of classes and may include, but need not be limited to instances of dwc:Occurrence, dwc:Organism, dwc:MaterialEntity, dwc:Event, dcterms:Location, dwc:GeologicalContext, dwc:Identification, or dwc:Taxon."@en ;
+    rdfs:comment "A measurement of or fact about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
+    skos:definition "A measurement of or fact about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
+    skos:prefLabel "Measurement Or Fact"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/MolecularProtocol>
+    rdfs:label "Molecular Protocol"@en ;
+    rdfs:comment "A protocol used to perform a dwc:NucleotideAnalysis and potentially derive a dwc:NucleotideSequence from a dwc:MaterialEntity."@en ;
+    skos:definition "A protocol used to perform a dwc:NucleotideAnalysis and potentially derive a dwc:NucleotideSequence from a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Molecular Protocol"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/NucleotideAnalysis>
+    rdfs:label "Nucleotide Analysis"@en ;
+    rdfs:comment "A link between a dwc:NucleotideSequence or a dwc:Identification and a dwc:Event and a dwc:MaterialEntity from which it was derived, using a specified dwc:Protocol."@en ;
+    skos:definition "A link between a dwc:NucleotideSequence or a dwc:Identification and a dwc:Event and a dwc:MaterialEntity from which it was derived, using a specified dwc:Protocol."@en ;
+    skos:prefLabel "Nucleotide Analysis"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/NucleotideSequence>
+    rdfs:label "Nucleotide Sequence"@en ;
+    rdfs:comment "A digital representation of a nucleotide sequence."@en ;
+    skos:definition "A digital representation of a nucleotide sequence."@en ;
+    skos:prefLabel "Nucleotide Sequence"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Occurrence>
+    rdfs:label "Occurrence"@en ;
+    dcterms:description "In Darwin Core, dwc:Organism, dwc:Occurrence, and dwc:MaterialEntity are related, but distinct concepts. A dwc:Organism is a biological individual or group with an identity and life history that persists independently of the particular dwc:MaterialEntities through which it is manifested. A dwc:Occurrence is a dwc:Event that represents the presence or state of a dwc:Organism at a place during an interval of time, with no explicit dependency on any dwc:MaterialEntity. A dwc:MaterialEntity represents physical matter, including whole bodies, parts, or derivatives of dwc:Organisms, that may directly or indirectly serve as evidence of a dwc:Occurrence."@en ;
+    rdfs:comment "A dwc:Event that establishes the state of a dwc:Organism at a particular place and time."@en ;
+    skos:definition "A dwc:Event that establishes the state of a dwc:Organism at a particular place and time."@en ;
+    skos:prefLabel "Occurrence"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/OccurrenceMeasurement>
+    rdfs:label "Occurrence Measurement"@en ;
+    rdfs:comment "The category of information pertaining to measurements accociated with an occurrence."@en ;
+    skos:definition "The category of information pertaining to measurements accociated with an occurrence."@en ;
+    skos:prefLabel "Occurrence Measurement"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Organism>
+    rdfs:label "Organism"@en ;
+    dcterms:description "Instances of the dwc:Organism class are intended to facilitate linking one or more dwc:Identification instances to one or more dwc:Occurrence instances. Therefore, things that are typically assigned scientific names (such as viruses, hybrids, and lichens) and aggregates whose dwc:Occurrences are typically recorded (such as packs, clones, and colonies) are included in the scope of this class. In Darwin Core, dwc:Organism, dwc:Occurrence, and dwc:MaterialEntity are related, but distinct concepts. A dwc:Organism is a biological individual or group with an identity and life history that persists independently of the particular dwc:MaterialEntities through which it is manifested. A dwc:Occurrence is a dwc:Event that represents the presence or state of a dwc:Organism at a place during an interval of time, with no explicit dependency on any dwc:MaterialEntity. A dwc:MaterialEntity represents physical matter, including whole bodies, parts, or derivatives of dwc:Organisms, that may directly or indirectly serve as evidence of a dwc:Occurrence."@en ;
+    rdfs:comment "A particular organism or defined group of organisms considered to be taxonomically homogeneous."@en ;
+    skos:definition "A particular organism or defined group of organisms considered to be taxonomically homogeneous."@en ;
+    skos:prefLabel "Organism"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/OrganismInteraction>
+    rdfs:label "Organism Interaction"@en ;
+    dcterms:description "Supports only primary observed interactions, not habitual or derived taxon-level interactions. Pairwise interactions must be used to represent multi-organism interactions. When possible, typify the action rather than the state from which an action is inferred, with the actor as the subject dwc:Occurrence and the acted-upon as the related dwc:Occurrence. Only one direction of a two-way interaction is necessary, though both are permissible as distinct OrganismInteractions with distinct subject dwc:Occurrences."@en ;
+    rdfs:comment "An interaction between two dwc:Organisms during a dwc:Event."@en ;
+    skos:definition "An interaction between two dwc:Organisms during a dwc:Event."@en ;
+    skos:prefLabel "Organism Interaction"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/PreservedSpecimen>
+    rdfs:label "Preserved Specimen"@en ;
+    rdfs:comment "A specimen that has been preserved."@en ;
+    skos:definition "A specimen that has been preserved."@en ;
+    skos:prefLabel "Preserved Specimen"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/PreviousIdentifications>
+    rdfs:label "Previous Identifications"@en ;
+    dcterms:description "Example: \"Anthus correndera\"."@en ;
+    rdfs:comment "A list (concatenated and separated) of previous ScientificNames to which the sample was identified."@en ;
+    skos:definition "A list (concatenated and separated) of previous ScientificNames to which the sample was identified."@en ;
+    skos:prefLabel "Previous Identifications"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Protocol>
+    rdfs:label "Protocol"@en ;
+    rdfs:comment "A method used during an action."@en ;
+    skos:definition "A method used during an action."@en ;
+    skos:prefLabel "Protocol"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Provenance>
+    rdfs:label "Provenance"@en ;
+    dcterms:description "This is a convenience class to group related properties."@en ;
+    rdfs:comment "Information about an entity’s origins."@en ;
+    skos:definition "Information about an entity’s origins."@en ;
+    skos:prefLabel "Provenance"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/RelatedBasisOfRecord>
+    rdfs:label "Related Basis of Record"@en ;
+    dcterms:description "Example: \"PreservedSpecimen\""@en ;
+    rdfs:comment "The nature of the related resource. Recommended best practice is to use the same controlled vocabulary as for basisOfRecord."@en ;
+    skos:definition "The nature of the related resource. Recommended best practice is to use the same controlled vocabulary as for basisOfRecord."@en ;
+    skos:prefLabel "Related Basis of Record"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/ResourceRelationship>
+    rdfs:label "Resource Relationship"@en ;
+    dcterms:description "Resources can be thought of as identifiable records or instances of classes and may include, but need not be limited to instances of dwc:Occurrence, dwc:Organism, dwc:MaterialEntity, dwc:Event, dcterms:Location, dwc:GeologicalContext, dwc:Identification, or dwc:Taxon."@en ;
+    rdfs:comment "A relationship of one rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource) to another."@en ;
+    skos:definition "A relationship of one rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource) to another."@en ;
+    skos:prefLabel "Resource Relationship"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Sample>
+    rdfs:label "Sample"@en ;
+    rdfs:comment "Container class for information about the results of a sampling event (specimen, observation, etc.)"@en ;
+    skos:definition "Container class for information about the results of a sampling event (specimen, observation, etc.)"@en ;
+    skos:prefLabel "Sample"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttribute>
+    rdfs:label "Sample Attribute"@en ;
+    rdfs:comment "Container class for information about attributes related to a given sample."@en ;
+    skos:definition "Container class for information about attributes related to a given sample."@en ;
+    skos:prefLabel "Sample Attribute"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttributeAccuracy>
+    rdfs:label "Sample Attribute Accuracy"@en ;
+    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
+    rdfs:comment "The description of the error associated with the SampleAttributeValue."@en ;
+    skos:definition "The description of the error associated with the SampleAttributeValue."@en ;
+    skos:prefLabel "Sample Attribute Accuracy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttributeDeterminedBy>
+    rdfs:label "Sample Attribute Determined By"@en ;
+    dcterms:description "Example: \"Javier de la Torre\""@en ;
+    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the sample."@en ;
+    skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the sample."@en ;
+    skos:prefLabel "Sample Attribute Determined By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttributeDeterminedDate>
+    rdfs:label "Sample Attribute Determined Date"@en ;
+    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
+    rdfs:comment "The date on which the the measurement or characteristic of the sample was made."@en ;
+    skos:definition "The date on which the the measurement or characteristic of the sample was made."@en ;
+    skos:prefLabel "Sample Attribute Determined Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttributeRemarks>
+    rdfs:label "Sample Attribute Remarks"@en ;
+    dcterms:description "Example: \"tip of tail missing\""@en ;
+    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the sample."@en ;
+    skos:definition "Comments or notes accompanying the measurement or characteristic of the sample."@en ;
+    skos:prefLabel "Sample Attribute Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttributeUnit>
+    rdfs:label "Sample Attribute Unit"@en ;
+    dcterms:description "Example: \"mm\""@en ;
+    rdfs:comment "The units for the value of the measurement or characteristic of the sample. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:definition "The units for the value of the measurement or characteristic of the sample. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:prefLabel "Sample Attribute Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleAttributeValue>
+    rdfs:label "Sample Attribute Value"@en ;
+    dcterms:description "Example: \"45\""@en ;
+    rdfs:comment "The value of the measurement or characteristic of the sample."@en ;
+    skos:definition "The value of the measurement or characteristic of the sample."@en ;
+    skos:prefLabel "Sample Attribute Value"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SampleRemarks>
+    rdfs:label "Sample Remarks"@en ;
+    dcterms:description "Example: \"found dead on road\""@en ;
+    rdfs:comment "Comments or notes about the sample or record."@en ;
+    skos:definition "Comments or notes about the sample or record."@en ;
+    skos:prefLabel "Sample Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingAttributeID>
+    rdfs:label "Sample Attribute ID"@en ;
+    rdfs:comment "An identifier for the sampling attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the sampling attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Sample Attribute ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingAttributeType>
+    rdfs:label "Sample Attribute Type"@en ;
+    dcterms:description "Example: \"tail length\""@en ;
+    rdfs:comment "The nature of the measurement or characteristic of the sample. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:definition "The nature of the measurement or characteristic of the sample. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:prefLabel "Sample Attribute Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingEvent>
+    rdfs:label "Sampling Event"@en ;
+    rdfs:comment "Container class for information about the conditions and methods of acquisition of samples."@en ;
+    skos:definition "Container class for information about the conditions and methods of acquisition of samples."@en ;
+    skos:prefLabel "Sampling Event"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingEventAttributes>
+    rdfs:label "Sampling Event Attributes"@en ;
+    dcterms:description "Example: \"Relative humidity: 28 %; Temperature: 22 C; Sample size: 10 kg\""@en ;
+    rdfs:comment "A list (concatenated and separated) of additional measurements or characteristics of the sampling event."@en ;
+    skos:definition "A list (concatenated and separated) of additional measurements or characteristics of the sampling event."@en ;
+    skos:prefLabel "Sampling Event Attributes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingEventID>
+    rdfs:label "Sampling Event ID"@en ;
+    rdfs:comment "An identifier for the sampling event. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the sampling event. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Sampling Event ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingEventRemarks>
+    rdfs:label "Sampling Event Remarks"@en ;
+    dcterms:description "Example: \"found dead on road\""@en ;
+    rdfs:comment "Comments or notes about the sampling event."@en ;
+    skos:definition "Comments or notes about the sampling event."@en ;
+    skos:prefLabel "Sampling Event Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingLocation>
+    rdfs:label "Sampling Location"@en ;
+    rdfs:comment "Container class for information about the location where a sampling event occurred."@en ;
+    skos:definition "Container class for information about the location where a sampling event occurred."@en ;
+    skos:prefLabel "Sampling Location"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingLocationID>
+    rdfs:label "Sampling Location ID"@en ;
+    dcterms:description "Example: \"MVZ:LocID:12345\""@en ;
+    rdfs:comment "An identifier for the sampling location. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the sampling location. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Sampling Location ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/SamplingLocationRemarks>
+    rdfs:label "Sampling Location Remarks"@en ;
+    dcterms:description "Example: \"under water since 2005\""@en ;
+    rdfs:comment "Comments or notes about the sampling location."@en ;
+    skos:definition "Comments or notes about the sampling location."@en ;
+    skos:prefLabel "Sampling Location Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/StartTimeOfDay>
+    rdfs:label "Start Time of Day"@en ;
+    dcterms:description "Examples: \"12.0\" (= noon), \"13.5\" (= 1:30pm)"@en ;
+    rdfs:comment "The time of day when the event began, expressed as decimal hours from midnight, local time."@en ;
+    skos:definition "The time of day when the event began, expressed as decimal hours from midnight, local time."@en ;
+    skos:prefLabel "Start Time of Day"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/Taxon>
+    rdfs:label "Taxon"@en ;
+    rdfs:comment "A group of organisms (sensu http://purl.obolibrary.org/obo/OBI_0100026) considered by taxonomists to form a homogeneous unit."@en ;
+    skos:definition "A group of organisms (sensu http://purl.obolibrary.org/obo/OBI_0100026) considered by taxonomists to form a homogeneous unit."@en ;
+    skos:prefLabel "Taxon"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/TaxonID>
+    rdfs:label "Taxon ID"@en ;
+    rdfs:comment "A global unique identifier for the taxon (name in a classification)."@en ;
+    skos:definition "A global unique identifier for the taxon (name in a classification)."@en ;
+    skos:prefLabel "Taxon ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/UsagePolicy>
+    rdfs:label "Usage Policy"@en ;
+    dcterms:description "This is a convenience class to group related properties."@en ;
+    rdfs:comment "Information about rights, usage, and attribution statements applicable to an entity."@en ;
+    skos:definition "Information about rights, usage, and attribution statements applicable to an entity."@en ;
+    skos:prefLabel "Usage Policy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedNameUsage>
+    rdfs:label "Accepted Name Usage"@en ;
+    dcterms:description "The full scientific name, with authorship and date information if known, of the accepted (botanical) or valid (zoological) name in cases where the provided dwc:scientificName is considered by the reference indicated in the dwc:nameAccordingTo property, or of the content provider, to be a synonym or misapplied name. When applied to a dwc:Organism or dwc:Occurrence, this term should be used in cases where a content provider regards the provided dwc:scientificName to be inconsistent with the taxonomic perspective of the content provider. For example, there are many discrepancies within specimen collections and observation datasets between the recorded name (e.g., the most recent identification from an expert who examined a specimen, or a field identification for an observed dwc:Organism), and the name asserted by the content provider to be taxonomically accepted."@en ;
+    rdfs:comment "The full name, with authorship and date information if known, of the currently valid (zoological) or accepted (botanical) dwc:Taxon."@en ;
+    skos:definition "The full name, with authorship and date information if known, of the currently valid (zoological) or accepted (botanical) dwc:Taxon."@en ;
+    skos:prefLabel "Accepted Name Usage"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedNameUsageID>
+    rdfs:label "Accepted Name Usage ID"@en ;
+    dcterms:description "This term should be used for synonyms or misapplied names to refer to the dwc:taxonID of a dwc:Taxon record that represents the accepted (botanical) or valid (zoological) name. For Darwin Core Archives the related record should be present locally in the same archive."@en ;
+    rdfs:comment "An identifier for the name usage (documented meaning of the name according to a source) of the currently valid (zoological) or accepted (botanical) taxon."@en ;
+    skos:definition "An identifier for the name usage (documented meaning of the name according to a source) of the currently valid (zoological) or accepted (botanical) taxon."@en ;
+    skos:prefLabel "Accepted Name Usage ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedScientificName>
+    rdfs:label "Accepted Scientific Name"@en ;
+    dcterms:description "Example: \"Tamias minimus\" valid name for \"Eutamias minimus\""@en ;
+    rdfs:comment "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
+    skos:definition "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
+    skos:prefLabel "Accepted Scientific Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedScientificNameID>
+    rdfs:label "Accepted Scientific Name ID"@en ;
+    rdfs:comment "A unique identifier for the acceptedScientificName."@en ;
+    skos:definition "A unique identifier for the acceptedScientificName."@en ;
+    skos:prefLabel "Accepted Scientific Name ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedTaxonID>
+    rdfs:label "Accepted Taxon ID"@en ;
+    dcterms:description "Example: \"8fa58e08-08de-4ac1-b69c-1235340b7001\""@en ;
+    rdfs:comment "An identifier for the name of the currently valid (zoological) or accepted (botanical) taxon. See acceptedTaxon."@en ;
+    skos:definition "An identifier for the name of the currently valid (zoological) or accepted (botanical) taxon. See acceptedTaxon."@en ;
+    skos:prefLabel "Accepted Taxon ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedTaxonName>
+    rdfs:label "Accepted Taxon Name"@en ;
+    dcterms:description "Example: \"Tamias minimus\" valid name for \"Eutamias minimus\""@en ;
+    rdfs:comment "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
+    skos:definition "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
+    skos:prefLabel "Accepted Taxon Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/acceptedTaxonNameID>
+    rdfs:label "Accepted Taxon Name ID"@en ;
+    rdfs:comment "A unique identifier for the acceptedTaxonName."@en ;
+    skos:definition "A unique identifier for the acceptedTaxonName."@en ;
+    skos:prefLabel "Accepted Taxon Name ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/accordingTo>
+    rdfs:label "According To"@en ;
+    rdfs:comment "Abstract term to attribute information to a source."@en ;
+    skos:definition "Abstract term to attribute information to a source."@en ;
+    skos:prefLabel "According To"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/accuracy>
+    rdfs:label "Accuracy"@en ;
+    rdfs:comment "Abstract term to capture error information about a measurement or fact."@en ;
+    skos:definition "Abstract term to capture error information about a measurement or fact."@en ;
+    skos:prefLabel "Accuracy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/agentID>
+    rdfs:label "Agent ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dcterms:Agent."@en ;
+    skos:definition "An identifier for a dcterms:Agent."@en ;
+    skos:prefLabel "Agent ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/agentRemarks>
+    rdfs:label "Agent Remarks"@en ;
+    rdfs:comment "Comments or notes about a dcterms:Agent."@en ;
+    skos:definition "Comments or notes about a dcterms:Agent."@en ;
+    skos:prefLabel "Agent Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/agentRoleOrder>
+    rdfs:label "Agent Role Order"@en ;
+    dcterms:description "One could use dwc:agentRoleOrder to create an ordered list of collectors (agentRole = 'collector') for a dwc:MaterialEntity in a Darwin Core Data Package, for example. The first would have dwc:agentRoleOrder=1, the second would have dwc:agentRoleOrder=2."@en ;
+    rdfs:comment "A numerical position of an AgentRole in a set of AgentRoles."@en ;
+    skos:definition "A numerical position of an AgentRole in a set of AgentRoles."@en ;
+    skos:prefLabel "Agent Role Order"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/agentType>
+    rdfs:label "Agent Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
+    rdfs:comment "A category that best matches the nature of a dcterms:Agent."@en ;
+    skos:definition "A category that best matches the nature of a dcterms:Agent."@en ;
+    skos:prefLabel "Agent Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assayType>
+    rdfs:label "Assay Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
+    skos:definition "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Assay Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionBy>
+    rdfs:label "Assertion By"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A name for a dcterms:Agent responsible for making a dwc:Assertion."@en ;
+    skos:definition "A name for a dcterms:Agent responsible for making a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionEffectiveDate>
+    rdfs:label "Assertion Effective Date"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "A date on which a state or measurement of a dwc:Assertion was deemed to first be in effect."@en ;
+    skos:definition "A date on which a state or measurement of a dwc:Assertion was deemed to first be in effect."@en ;
+    skos:prefLabel "Assertion Effective Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionError>
+    rdfs:label "Assertion Error"@en ;
+    rdfs:comment "A description of the potential error associated with a dwc:assertionValue."@en ;
+    skos:definition "A description of the potential error associated with a dwc:assertionValue."@en ;
+    skos:prefLabel "Assertion Error"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionID>
+    rdfs:label "Assertion ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dwc:Assertion."@en ;
+    skos:definition "An identifier for a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionMadeDate>
+    rdfs:label "Assertion Made Date"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "A date on which a dwc:Assertion was created."@en ;
+    skos:definition "A date on which a dwc:Assertion was created."@en ;
+    skos:prefLabel "Assertion Made Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionProtocols>
+    rdfs:label "Assertion Protocols"@en ;
+    rdfs:comment "Names of, references to, or descriptions of dwc:Protocols used in making a dwc:Assertion."@en ;
+    skos:definition "Names of, references to, or descriptions of dwc:Protocols used in making a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion Protocols"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionReferences>
+    rdfs:label "Assertion References"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources associated with a dwc:Assertion."@en ;
+    skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources associated with a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion References"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionRemarks>
+    rdfs:label "Assertion Remarks"@en ;
+    rdfs:comment "Comments or notes about a dwc:Assertion."@en ;
+    skos:definition "Comments or notes about a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionType>
+    rdfs:label "Assertion Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:Assertion."@en ;
+    skos:definition "A category that best matches the nature of a dwc:Assertion."@en ;
+    skos:prefLabel "Assertion Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionUnit>
+    rdfs:label "Assertion Unit"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.ontology-of-units-of-measure.org for SI units, derived units, or other non-SI units accepted for use within the SI. For units that are composed of multiple parts, use the patterns as given in \"A Primer for Communicating Mathematics via Plain Text\" (https://cse.sc.edu/~fenner/latex-ASCII.pdf) by Stephen Fenner (e.g., `g/cm^3` for grams per cubic centimeter). For other units, provide the value as a recognizable standard (e.g., '%') or written out in full and in the plural (e.g., `individuals`). It is fine to provide non-SI units in the original language of the dataset. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A unit associated with the value in dwc:assertionValue."@en ;
+    skos:definition "A unit associated with the value in dwc:assertionValue."@en ;
+    skos:prefLabel "Assertion Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/assertionValue>
+    rdfs:label "Assertion Value"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "An asserted value."@en ;
+    skos:definition "An asserted value."@en ;
+    skos:prefLabel "Assertion Value"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/associatedMedia>
+    rdfs:label "Associated Media"@en ;
+    rdfs:comment "A list (concatenated and separated) of identifiers (publication, global unique identifier, URI) of media associated with the dwc:Occurrence."@en ;
+    skos:definition "A list (concatenated and separated) of identifiers (publication, global unique identifier, URI) of media associated with the dwc:Occurrence."@en ;
+    skos:prefLabel "Associated Media"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/associatedOccurrences>
+    rdfs:label "Associated Occurrences"@en ;
+    dcterms:description "This term can be used to provide a list of associations to other dwc:Occurrences. Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of identifiers of other dwc:Occurrence records and their associations to this dwc:Occurrence."@en ;
+    skos:definition "A list (concatenated and separated) of identifiers of other dwc:Occurrence records and their associations to this dwc:Occurrence."@en ;
+    skos:prefLabel "Associated Occurrences"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/associatedOrganisms>
+    rdfs:label "Associated Organisms"@en ;
+    dcterms:description "This term can be used to provide a list of associations to other dwc:Organisms. Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of identifiers of other dwc:Organisms and the associations of this dwc:Organism to each of them."@en ;
+    skos:definition "A list (concatenated and separated) of identifiers of other dwc:Organisms and the associations of this dwc:Organism to each of them."@en ;
+    skos:prefLabel "Associated Organisms"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/associatedReferences>
+    rdfs:label "Associated References"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. Note also that the intended usage of the term dcterms:references in Darwin Core when applied to a dwc:Occurrence is to point to the definitive source representation of that dwc:Occurrence if one is available. Note also that the intended usage of dcterms:bibliographicCitation in Darwin Core when applied to a dwc:Occurrence is to provide the preferred way to cite the dwc:Occurrence itself."@en ;
+    rdfs:comment "A list (concatenated and separated) of identifiers (publication, bibliographic reference, global unique identifier, URI) of literature associated with the dwc:Occurrence."@en ;
+    skos:definition "A list (concatenated and separated) of identifiers (publication, bibliographic reference, global unique identifier, URI) of literature associated with the dwc:Occurrence."@en ;
+    skos:prefLabel "Associated References"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/associatedSequences>
+    rdfs:label "Associated Sequences"@en ;
+    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources for dwc:NucleotideSequences associated with a dwc:MaterialEntity."@en ;
+    skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources for dwc:NucleotideSequences associated with a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Associated Sequences"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/associatedTaxa>
+    rdfs:label "Associated Taxa"@en ;
+    dcterms:description "This term can be used to provide a list of associations to dwc:Taxon records other than the one defined in the dwc:Occurrence. Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. This term is not apt for establishing relationships between dwc:Taxon records, only between specific dwc:Occurrences of a dwc:Organism with other dwc:Taxon records. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of identifiers or names of dwc:Taxon records and the associations of this dwc:Occurrence to each of them."@en ;
+    skos:definition "A list (concatenated and separated) of identifiers or names of dwc:Taxon records and the associations of this dwc:Occurrence to each of them."@en ;
+    skos:prefLabel "Associated Taxa"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/basionym>
+    rdfs:label "Basionym"@en ;
+    dcterms:description "Example: \"Pinus abies\""@en ;
+    rdfs:comment "The basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
+    skos:definition "The basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
+    skos:prefLabel "Basionym"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/basionymID>
+    rdfs:label "Basionym ID"@en ;
+    rdfs:comment "A unique identifier for the basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
+    skos:definition "A unique identifier for the basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
+    skos:prefLabel "Basionym ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/basisOfRecord>
+    rdfs:label "Basis Of Record"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the set of local names of the identifiers for classes in Darwin Core."@en ;
+    rdfs:comment "The specific nature of the data record."@en ;
+    skos:definition "The specific nature of the data record."@en ;
+    skos:prefLabel "Basis Of Record"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/bed>
+    rdfs:label "Bed"@en ;
+    rdfs:comment "The full name of the lithostratigraphic bed from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the lithostratigraphic bed from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Bed"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/behavior>
+    rdfs:label "Behavior"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A behavior shown by a dwc:Organism."@en ;
+    skos:definition "A behavior shown by a dwc:Organism."@en ;
+    skos:prefLabel "Behavior"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/binomial>
+    rdfs:label "Binomial"@en ;
+    dcterms:description "Example: \"Ctenomys sociabilis\""@en ;
+    rdfs:comment "The combination of genus and first (species) epithet of the scientificName."@en ;
+    skos:definition "The combination of genus and first (species) epithet of the scientificName."@en ;
+    skos:prefLabel "Binomial"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/caste>
+    rdfs:label "Caste"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary that aligns best with a dwc:Taxon. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A social caste of a dwc:Organism."@en ;
+    skos:definition "A social caste of a dwc:Organism."@en ;
+    skos:prefLabel "Caste"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/catalogNumber>
+    rdfs:label "Catalog Number"@en ;
+    rdfs:comment "An identifier (preferably unique) for a resource within a collection."@en ;
+    skos:definition "An identifier (preferably unique) for a resource within a collection."@en ;
+    skos:prefLabel "Catalog Number"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/causeOfDeath>
+    rdfs:label "Cause Of Death"@en ;
+    dcterms:description "The cause may be due to natural causes (e.g., disease, predation), human-related activities (e.g., roadkill, pollution), or other environmental factors (e.g., extreme weather events)."@en ;
+    rdfs:comment "An indication of the known or suspected cause of death of a dwc:Organism."@en ;
+    skos:definition "An indication of the known or suspected cause of death of a dwc:Organism."@en ;
+    skos:prefLabel "Cause Of Death"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/class>
+    rdfs:label "Class"@en ;
+    rdfs:comment "The full scientific name of the class in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the class in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Class"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/collectionCode>
+    rdfs:label "Collection Code"@en ;
+    rdfs:comment "A name, acronym, coden, or initialism identifying a collection."@en ;
+    skos:definition "A name, acronym, coden, or initialism identifying a collection."@en ;
+    skos:prefLabel "Collection Code"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/collectionID>
+    rdfs:label "Collection ID"@en ;
+    dcterms:description "For physical specimens, the recommended best practice is to use a globally unique and resolvable identifier from a collections registry such as the Global Registry of Scientific Collections (https://scientific-collections.gbif.org/)."@en ;
+    rdfs:comment "An identifier for a collection."@en ;
+    skos:definition "An identifier for a collection."@en ;
+    skos:prefLabel "Collection ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/continent>
+    rdfs:label "Continent"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
+    rdfs:comment "The name of the continent in which the dcterms:Location occurs."@en ;
+    skos:definition "The name of the continent in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Continent"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/coordinatePrecision>
+    rdfs:label "Coordinate Precision"@en ;
+    rdfs:comment "A decimal representation of the precision of the coordinates given in the dwc:decimalLatitude and dwc:decimalLongitude."@en ;
+    skos:definition "A decimal representation of the precision of the coordinates given in the dwc:decimalLatitude and dwc:decimalLongitude."@en ;
+    skos:prefLabel "Coordinate Precision"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters>
+    rdfs:label "Coordinate Uncertainty In Meters"@en ;
+    dcterms:description "Leave the value empty if the uncertainty is unknown, cannot be estimated, or is not applicable (because there are no coordinates). Zero is not a valid value for this term."@en ;
+    rdfs:comment "A horizontal distance (in meters) from a given dwc:decimalLatitude and dwc:decimalLongitude describing the smallest circle containing the whole of the dcterms:Location. Zero is not a valid value for this term."@en ;
+    skos:definition "A horizontal distance (in meters) from a given dwc:decimalLatitude and dwc:decimalLongitude describing the smallest circle containing the whole of the dcterms:Location. Zero is not a valid value for this term."@en ;
+    skos:prefLabel "Coordinate Uncertainty In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/country>
+    rdfs:label "Country"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
+    rdfs:comment "The name of the country or major administrative unit in which the dcterms:Location occurs."@en ;
+    skos:definition "The name of the country or major administrative unit in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Country"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/countryCode>
+    rdfs:label "Country Code"@en ;
+    dcterms:description "Recommended best practice is to use an ISO 3166-1-alpha-2 country code, or 'ZZ' (for an unknown location or a location unassignable to a single country code), or 'XZ' (for the high seas beyond national jurisdictions). Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
+    rdfs:comment "The standard code for the country in which the dcterms:Location occurs."@en ;
+    skos:definition "The standard code for the country in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Country Code"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/county>
+    rdfs:label "Second Order Division"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
+    rdfs:comment "The full, unabbreviated name of the next smaller administrative region than stateProvince (county, shire, department, etc.) in which the dcterms:Location occurs."@en ;
+    skos:definition "The full, unabbreviated name of the next smaller administrative region than stateProvince (county, shire, department, etc.) in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Second Order Division"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/cultivarEpithet>
+    rdfs:label "Cultivar Epithet"@en ;
+    dcterms:description "According to the Rules of the Cultivated Plant Code, a cultivar name consists of a botanical name followed by a cultivar epithet. The value given as the dwc:cultivarEpithet should exclude any quotes. The term dwc:taxonRank should be used to indicate which type of cultivated plant name (e.g., cultivar, cultivar group, grex) is concerned. This epithet, including any enclosing apostrophes or suffix, should be provided in dwc:scientificName as well."@en ;
+    rdfs:comment "Part of the name of a cultivar, cultivar group or grex that follows the dwc:scientificName."@en ;
+    skos:definition "Part of the name of a cultivar, cultivar group or grex that follows the dwc:scientificName."@en ;
+    skos:prefLabel "Cultivar Epithet"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/dataGeneralizations>
+    rdfs:label "Data Generalizations"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:definition "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:prefLabel "Data Generalizations"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/datasetID>
+    rdfs:label "Dataset ID"@en ;
+    rdfs:comment "An identifier for the set of data. May be a global unique identifier or an identifier specific to a collection or institution."@en ;
+    skos:definition "An identifier for the set of data. May be a global unique identifier or an identifier specific to a collection or institution."@en ;
+    skos:prefLabel "Dataset ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/datasetName>
+    rdfs:label "Dataset Name"@en ;
+    rdfs:comment "A name of a source dataset."@en ;
+    skos:definition "A name of a source dataset."@en ;
+    skos:prefLabel "Dataset Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/dateIdentified>
+    rdfs:label "Date Identified"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "The date on which the subject was determined as representing the dwc:Taxon."@en ;
+    skos:definition "The date on which the subject was determined as representing the dwc:Taxon."@en ;
+    skos:prefLabel "Date Identified"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/day>
+    rdfs:label "Day"@en ;
+    rdfs:comment "The integer day of the month on which the dwc:Event occurred."@en ;
+    skos:definition "The integer day of the month on which the dwc:Event occurred."@en ;
+    skos:prefLabel "Day"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/decimalLatitude>
+    rdfs:label "Decimal Latitude"@en ;
+    dcterms:description "Positive values are north of the Equator, negative values are south of it. Valid values lie between -90 and 90, inclusive."@en ;
+    rdfs:comment "A geographic latitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
+    skos:definition "A geographic latitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
+    skos:prefLabel "Decimal Latitude"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/decimalLongitude>
+    rdfs:label "Decimal Longitude"@en ;
+    dcterms:description "Positive values are east of the Greenwich Meridian, negative values are west of it. Valid values lie between -180 and 180, inclusive."@en ;
+    rdfs:comment "A geographic longitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
+    skos:definition "A geographic longitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
+    skos:prefLabel "Decimal Longitude"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/degreeOfEstablishment>
+    rdfs:label "Degree of Establishment"@en ;
+    dcterms:description "Recommended best practice is to use controlled value strings from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/doe/. For details, refer to https://doi.org/10.3897/biss.3.38084. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
+    skos:definition "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
+    skos:prefLabel "Degree of Establishment"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/digitalSpecimenID>
+    rdfs:label "Digital Specimen ID"@en ;
+    dcterms:description "A Digital Specimen is defined in https://doi.org/10.3897/rio.7.e67379. A dwc:digitalSpecimenID is intended to uniquely and persistently identify a Digital Specimen. Recommended best practice is to use a DOI with machine readable metadata in the DOI record that uses a community agreed metadata profile (also known as FDO profile) for a Digital Specimen. For an example see: https://doi.org/10.3535/N75-CR4-0SM?noredirect. The identifier is for a digital information artifact (the Digital Specimen) as opposed to an identifier for a specific instance of a dwc:MaterialEntity."@en ;
+    rdfs:comment "An identifier for a Digital Specimen resource."@en ;
+    skos:definition "An identifier for a Digital Specimen resource."@en ;
+    skos:prefLabel "Digital Specimen ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/discipline>
+    rdfs:label "Discipline"@en ;
+    dcterms:description "This term can be used to classify records according to branches of knowledge. Recommended best practice is to use a controlled vocabulary and to separate the values in a list with space vertical bar space (` | `). It is also recommended to use this field to describe specimenType in MIDS. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The primary branch or branches of knowledge represented by a dwc:MaterialEntity."@en ;
+    skos:definition "The primary branch or branches of knowledge represented by a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Discipline"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/disposition>
+    rdfs:label "Disposition"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
+    skos:definition "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
+    skos:prefLabel "Disposition"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/dynamicProperties>
+    rdfs:label "Dynamic Properties"@en ;
+    dcterms:description "Recommended best practice is to use a key:value encoding schema for a data interchange format such as JSON."@en ;
+    rdfs:comment "A list of additional measurements, facts, characteristics, or assertions about the record. Meant to provide a mechanism for structured content."@en ;
+    skos:definition "A list of additional measurements, facts, characteristics, or assertions about the record. Meant to provide a mechanism for structured content."@en ;
+    skos:prefLabel "Dynamic Properties"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/earliestAgeOrLowestStage>
+    rdfs:label "Earliest Age Or Lowest Stage"@en ;
+    rdfs:comment "The full name of the earliest possible geochronologic age or lowest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the earliest possible geochronologic age or lowest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Earliest Age Or Lowest Stage"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/earliestEonOrLowestEonothem>
+    rdfs:label "Earliest Eon Or Lowest Eonothem"@en ;
+    rdfs:comment "The full name of the earliest possible geochronologic eon or lowest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the earliest possible geochronologic eon or lowest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Earliest Eon Or Lowest Eonothem"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/earliestEpochOrLowestSeries>
+    rdfs:label "Earliest Epoch Or Lowest Series"@en ;
+    rdfs:comment "The full name of the earliest possible geochronologic epoch or lowest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the earliest possible geochronologic epoch or lowest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Earliest Epoch Or Lowest Series"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/earliestEraOrLowestErathem>
+    rdfs:label "Earliest Era Or Lowest Erathem"@en ;
+    rdfs:comment "The full name of the earliest possible geochronologic era or lowest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the earliest possible geochronologic era or lowest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Earliest Era Or Lowest Erathem"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/earliestPeriodOrLowestSystem>
+    rdfs:label "Earliest Period Or Lowest System"@en ;
+    rdfs:comment "The full name of the earliest possible geochronologic period or lowest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the earliest possible geochronologic period or lowest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Earliest Period Or Lowest System"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/endDayOfYear>
+    rdfs:label "End Day Of Year"@en ;
+    dcterms:description "The value is 1 for January 1 and 365 for December 31, except in a leap year, in which case it is 366."@en ;
+    rdfs:comment "The latest integer day of the year on which a dwc:Event occurred."@en ;
+    skos:definition "The latest integer day of the year on which a dwc:Event occurred."@en ;
+    skos:prefLabel "End Day Of Year"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/establishmentMeans>
+    rdfs:label "Establishment Means"@en ;
+    dcterms:description "Recommended best practice is to use controlled value strings from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/em/. For details, refer to https://doi.org/10.3897/biss.3.38084. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
+    skos:definition "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
+    skos:prefLabel "Establishment Means"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventAttributes>
+    rdfs:label "Event Attributes"@en ;
+    dcterms:description "Example: \"Relative humidity: 28 %; Temperature: 22 C; Sample size: 10 kg\""@en ;
+    rdfs:comment "A list (concatenated and separated) of additional measurements or characteristics of the Event."@en ;
+    skos:definition "A list (concatenated and separated) of additional measurements or characteristics of the Event."@en ;
+    skos:prefLabel "Event Attributes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventCategory>
+    rdfs:label "Event Category"@en ;
+    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. Recommended best practice is to use one of the following controlled values: `Event`, `MaterialGathering`, `Occurrence`, `OrganismInteraction`, or `Survey`. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A broad category that best matches the nature of a dwc:Event."@en ;
+    skos:definition "A broad category that best matches the nature of a dwc:Event."@en ;
+    skos:prefLabel "Event Category"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventDate>
+    rdfs:label "Event Date"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019. Not suitable for a time in a geological context."@en ;
+    rdfs:comment "A date-time or time interval during which a dwc:Event occurred."@en ;
+    skos:definition "A date-time or time interval during which a dwc:Event occurred."@en ;
+    skos:prefLabel "Event Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventID>
+    rdfs:label "Event ID"@en ;
+    rdfs:comment "An identifier for the set of information associated with a dwc:Event (something that occurs at a place and time). May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the set of information associated with a dwc:Event (something that occurs at a place and time). May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Event ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementAccuracy>
+    rdfs:label "Event Measurement Accuracy"@en ;
+    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
+    rdfs:comment "The description of the error associated with the EventAttributeValue."@en ;
+    skos:definition "The description of the error associated with the EventAttributeValue."@en ;
+    skos:prefLabel "Event Measurement Accuracy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementDeterminedBy>
+    rdfs:label "Event Measurement Determined By"@en ;
+    dcterms:description "Example: \"Robert Hijmans\""@en ;
+    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the event."@en ;
+    skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the event."@en ;
+    skos:prefLabel "Event Measurement Determined By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementDeterminedDate>
+    rdfs:label "Event Measurement Determined Date"@en ;
+    dcterms:description "Examples: \"1963-03-08T14:07-0600\" is 8 Mar 1963 2:07pm in the time zone six hours earlier than UTC, \"2009-02-20T08:40Z\" is 20 Feb 2009 8:40am UTC, \"1809-02-12\" is 12 Feb 1809, \"1906-06\" is Jun 1906, \"1971\" is just that year, \"2007-03-01T13:00:00Z/2008-05-11T15:30:00Z\" is the interval between 1 Mar 2007 1pm UTC and 11 May 2008 3:30pm UTC, \"2007-11-13/15\" is the interval between 13 Nov 2007 and 15 Nov 2007."@en ;
+    rdfs:comment "The date on which the the measurement or characteristic of the event was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:definition "The date on which the the measurement or characteristic of the event was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:prefLabel "Event Measurement Determined Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementID>
+    rdfs:label "Event Measurement ID"@en ;
+    rdfs:comment "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Event Measurement ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementRemarks>
+    rdfs:label "Event Measurement Remarks"@en ;
+    dcterms:description "Example: \"temperature taken at 15:00\""@en ;
+    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the event."@en ;
+    skos:definition "Comments or notes accompanying the measurement or characteristic of the event."@en ;
+    skos:prefLabel "Event Measurement Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementType>
+    rdfs:label "Event Measurement Type"@en ;
+    dcterms:description "Example: \"temperature\""@en ;
+    rdfs:comment "The nature of the measurement or characteristic of the event. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:definition "The nature of the measurement or characteristic of the event. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:prefLabel "Event Measurement Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementUnit>
+    rdfs:label "Event Measurement Unit"@en ;
+    dcterms:description "Example: \"C\""@en ;
+    rdfs:comment "The units for the value of the measurement or characteristic of the event. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:definition "The units for the value of the measurement or characteristic of the event. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:prefLabel "Event Measurement Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventMeasurementValue>
+    rdfs:label "Event Measurement Value"@en ;
+    dcterms:description "Example: \"22\""@en ;
+    rdfs:comment "The value of the measurement or characteristic of the event."@en ;
+    skos:definition "The value of the measurement or characteristic of the event."@en ;
+    skos:prefLabel "Event Measurement Value"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventRemarks>
+    rdfs:label "Event Remarks"@en ;
+    rdfs:comment "Comments or notes about the dwc:Event."@en ;
+    skos:definition "Comments or notes about the dwc:Event."@en ;
+    skos:prefLabel "Event Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventTime>
+    rdfs:label "Event Time"@en ;
+    dcterms:description "Recommended best practice is to use a time of day that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "The time or interval during which a dwc:Event occurred."@en ;
+    skos:definition "The time or interval during which a dwc:Event occurred."@en ;
+    skos:prefLabel "Event Time"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/eventType>
+    rdfs:label "Event Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A narrow category that best matches the nature of a dwc:Event."@en ;
+    skos:definition "A narrow category that best matches the nature of a dwc:Event."@en ;
+    skos:prefLabel "Event Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/family>
+    rdfs:label "Family"@en ;
+    rdfs:comment "The full scientific name of the family in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the family in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Family"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/feedbackURL>
+    rdfs:label "Feedback URL"@en ;
+    dcterms:description "Recommended best practice is to optionally include query strings that act to pre-populate web page form elements and communicate the context."@en ;
+    rdfs:comment "A uniform resource locator (URL) that points to a webpage on which a form may be submitted to gather feedback about the record."@en ;
+    skos:definition "A uniform resource locator (URL) that points to a webpage on which a form may be submitted to gather feedback about the record."@en ;
+    skos:prefLabel "Feedback URL"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/fieldNotes>
+    rdfs:label "Field Notes"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
+    skos:definition "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
+    skos:prefLabel "Field Notes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/fieldNumber>
+    rdfs:label "Field Number"@en ;
+    dcterms:description "Often serves as a link between field notes and a dwc:Event. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "An identifier given to a dwc:Event in the field."@en ;
+    skos:definition "An identifier given to a dwc:Event in the field."@en ;
+    skos:prefLabel "Field Number"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/footprintSRS>
+    rdfs:label "Footprint SRS"@en ;
+    dcterms:description "Recommended best practice is to use the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use the value `not recorded`. It is also permitted to provide the SRS in Well-Known-Text, especially if no EPSG code provides the necessary values for the attributes of the SRS. Do not use this term to describe the SRS of the dwc:decimalLatitude and dwc:decimalLongitude, nor of any verbatim coordinates - use the dwc:geodeticDatum and dwc:verbatimSRS instead. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
+    skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
+    skos:prefLabel "Footprint SRS"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/footprintSpatialFit>
+    rdfs:label "Footprint Spatial Fit"@en ;
+    dcterms:description "Legal values are 0, greater than or equal to 1, or undefined. A value of 1 is an exact match or 100% overlap. A value of 0 should be used if the given footprint does not completely contain the original representation. A dwc:footprintSpatialFit is undefined (and should be left empty) if the original representation is any geometry without area (e.g., a point or polyline) and without uncertainty and the given georeference is not that same geometry (without uncertainty). If both the original and the given georeference are the same point, a dwc:footprintSpatialFit is 1. Detailed explanations with graphical examples can be found in the Georeferencing Best Practices, Chapman and Wieczorek, 2020 (https://doi.org/10.15468/doc-gg7h-s853)."@en ;
+    rdfs:comment "A ratio of the area of a footprint (dwc:footprintWKT) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
+    skos:definition "A ratio of the area of a footprint (dwc:footprintWKT) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
+    skos:prefLabel "Footprint Spatial Fit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/footprintWKT>
+    rdfs:label "Footprint WKT"@en ;
+    dcterms:description "A dcterms:Location may have both a point-radius representation (see dwc:decimalLatitude) and a footprint representation, and they may differ from each other."@en ;
+    rdfs:comment "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines a dcterms:Location."@en ;
+    skos:definition "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines a dcterms:Location."@en ;
+    skos:prefLabel "Footprint WKT"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/formation>
+    rdfs:label "Formation"@en ;
+    rdfs:comment "The full name of the lithostratigraphic formation from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the lithostratigraphic formation from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Formation"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/fundingAttributionID>
+    rdfs:label "Funding Attribution ID"@en ;
+    dcterms:description "Provide a unique identifier for the funding body, such as an identifier used in governmental or international databases. If no official identifier exists, use a persistent and unique identifier within your organization or dataset. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "An identifier for a dcterms:Agent that financially supported a project."@en ;
+    skos:definition "An identifier for a dcterms:Agent that financially supported a project."@en ;
+    skos:prefLabel "Funding Attribution ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/genericName>
+    rdfs:label "Generic Name"@en ;
+    dcterms:description "For synonyms the accepted genus and the genus part of the name may be different. The term dwc:genericName should be used together with dwc:specificEpithet to form a binomial and with dwc:infraspecificEpithet to form a trinomial. The term dwc:genericName should only be used for combinations. Uninomials of generic rank do not have a dwc:genericName."@en ;
+    rdfs:comment "The genus part of the dwc:scientificName without authorship."@en ;
+    skos:definition "The genus part of the dwc:scientificName without authorship."@en ;
+    skos:prefLabel "Generic Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/genus>
+    rdfs:label "Genus"@en ;
+    rdfs:comment "The full scientific name of the genus in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the genus in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Genus"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/geodeticDatum>
+    rdfs:label "Geodetic Datum"@en ;
+    dcterms:description "Recommended best practice is to use the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use the value `not recorded`. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for a string literal value."@en ;
+    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
+    skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
+    skos:prefLabel "Geodetic Datum"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/geologicalContextID>
+    rdfs:label "Geological Context ID"@en ;
+    rdfs:comment "An identifier for the set of information associated with a dwc:GeologicalContext (the location within a geological context, such as stratigraphy). May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the set of information associated with a dwc:GeologicalContext (the location within a geological context, such as stratigraphy). May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Geological Context ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/georeferenceProtocol>
+    rdfs:label "Georeference Protocol"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
+    skos:definition "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
+    skos:prefLabel "Georeference Protocol"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/georeferenceRemarks>
+    rdfs:label "Georeference Remarks"@en ;
+    rdfs:comment "Comments or notes about the spatial description determination, explaining assumptions made in addition or opposition to the those formalized in the method referred to in dwc:georeferenceProtocol."@en ;
+    skos:definition "Comments or notes about the spatial description determination, explaining assumptions made in addition or opposition to the those formalized in the method referred to in dwc:georeferenceProtocol."@en ;
+    skos:prefLabel "Georeference Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/georeferenceSources>
+    rdfs:label "Georeference Sources"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A list (concatenated and separated) of maps, gazetteers, or other resources used to georeference a dcterms:Location, described specifically enough to allow anyone in the future to use the same resources."@en ;
+    skos:definition "A list (concatenated and separated) of maps, gazetteers, or other resources used to georeference a dcterms:Location, described specifically enough to allow anyone in the future to use the same resources."@en ;
+    skos:prefLabel "Georeference Sources"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/georeferenceVerificationStatus>
+    rdfs:label "Georeference Verification Status"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
+    skos:definition "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
+    skos:prefLabel "Georeference Verification Status"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/georeferencedBy>
+    rdfs:label "Georeferenced By"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A name for a dcterms:Agent responsible for providing a georeference."@en ;
+    skos:definition "A name for a dcterms:Agent responsible for providing a georeference."@en ;
+    skos:prefLabel "Georeferenced By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/georeferencedDate>
+    rdfs:label "Georeferenced Date"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "The date on which the dcterms:Location was georeferenced."@en ;
+    skos:definition "The date on which the dcterms:Location was georeferenced."@en ;
+    skos:prefLabel "Georeferenced Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/group>
+    rdfs:label "Group"@en ;
+    rdfs:comment "The full name of the lithostratigraphic group from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the lithostratigraphic group from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Group"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/habitat>
+    rdfs:label "Habitat"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category or description of the habitat in which the dwc:Event occurred."@en ;
+    skos:definition "A category or description of the habitat in which the dwc:Event occurred."@en ;
+    skos:prefLabel "Habitat"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/higherClassification>
+    rdfs:label "Higher Classification"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `), with terms in order from the highest taxonomic rank to the lowest."@en ;
+    rdfs:comment "A list (concatenated and separated) of taxa names terminating at the rank immediately superior to the referenced dwc:Taxon."@en ;
+    skos:definition "A list (concatenated and separated) of taxa names terminating at the rank immediately superior to the referenced dwc:Taxon."@en ;
+    skos:prefLabel "Higher Classification"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/higherGeography>
+    rdfs:label "Higher Geography"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `), with terms in order from least specific to most specific."@en ;
+    rdfs:comment "A list (concatenated and separated) of geographic names less specific than the information captured in the dwc:locality term."@en ;
+    skos:definition "A list (concatenated and separated) of geographic names less specific than the information captured in the dwc:locality term."@en ;
+    skos:prefLabel "Higher Geography"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/higherGeographyID>
+    rdfs:label "Higher Geography ID"@en ;
+    dcterms:description "Recommended best practice is to use a persistent identifier from a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
+    rdfs:comment "An identifier for the geographic region within which the dcterms:Location occurred."@en ;
+    skos:definition "An identifier for the geographic region within which the dcterms:Location occurred."@en ;
+    skos:prefLabel "Higher Geography ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/higherTaxonName>
+    rdfs:label "Higher Taxon Name"@en ;
+    dcterms:description "Example: \"Animalia; Chordata; Vertebrata; Mammalia; Theria; Eutheria; Rodentia; Hystricognatha; Hystricognathi; Ctenomyidae; Ctenomyini; Ctenomys\""@en ;
+    rdfs:comment "A list (concatenated and separated) of the names for the taxonomic ranks less specific than that given in the scientificName."@en ;
+    skos:definition "A list (concatenated and separated) of the names for the taxonomic ranks less specific than that given in the scientificName."@en ;
+    skos:prefLabel "Higher Taxon Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/higherTaxonNameID>
+    rdfs:label "Higher Taxon Name ID"@en ;
+    rdfs:comment "A unique identifier for the name of the next higher rank than the scientificName in a taxonomic classification. See higherTaxonName."@en ;
+    skos:definition "A unique identifier for the name of the next higher rank than the scientificName in a taxonomic classification. See higherTaxonName."@en ;
+    skos:prefLabel "Higher Taxon Name ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/higherTaxonconceptID>
+    rdfs:label "Higher Taxon Concept ID"@en ;
+    rdfs:comment "A unique identifier for the taxon concept less specific than that given in the taxonConceptID."@en ;
+    skos:definition "A unique identifier for the taxon concept less specific than that given in the taxonConceptID."@en ;
+    skos:prefLabel "Higher Taxon Concept ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/highestBiostratigraphicZone>
+    rdfs:label "Highest Biostratigraphic Zone"@en ;
+    rdfs:comment "The full name of the highest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the highest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Highest Biostratigraphic Zone"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationAttributes>
+    rdfs:label "Identification Attributes"@en ;
+    dcterms:description "Example: \"natureOfID=expert identification; identificationEvidence=cytochrome B sequence\""@en ;
+    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Identification."@en ;
+    skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Identification."@en ;
+    skos:prefLabel "Identification Attributes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationID>
+    rdfs:label "Identification ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dwc:Identification."@en ;
+    skos:definition "An identifier for a dwc:Identification."@en ;
+    skos:prefLabel "Identification ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationQualifier>
+    rdfs:label "Identification Qualifier"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A brief phrase or a standard term (\"cf.\", \"aff.\") to express the determiner's doubts about the dwc:Identification."@en ;
+    skos:definition "A brief phrase or a standard term (\"cf.\", \"aff.\") to express the determiner's doubts about the dwc:Identification."@en ;
+    skos:prefLabel "Identification Qualifier"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationReferences>
+    rdfs:label "Identification References"@en ;
+    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Identification."@en ;
+    skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Identification."@en ;
+    skos:prefLabel "Identification References"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationRemarks>
+    rdfs:label "Identification Remarks"@en ;
+    rdfs:comment "Comments or notes about the dwc:Identification."@en ;
+    skos:definition "Comments or notes about the dwc:Identification."@en ;
+    skos:prefLabel "Identification Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationType>
+    rdfs:label "Identification Type"@en ;
+    dcterms:description "The evidentiary basis, analytical approach, or inferential method by which an identification was determined. Values describe the dominant source of information supporting the identification (e.g., morphology, geography, molecular data, functional attributes, relationships, or taxonomic revision), independent of confidence level or taxonomic outcome. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:Identification."@en ;
+    skos:definition "A category that best matches the nature of a dwc:Identification."@en ;
+    skos:prefLabel "Identification Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identificationVerificationStatus>
+    rdfs:label "Identification Verification Status"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as that used in HISPID and ABCD. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
+    skos:definition "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
+    skos:prefLabel "Identification Verification Status"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identifiedBy>
+    rdfs:label "Identified By"@en ;
+    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A name for a dcterms:Agent responsible for making a dwc:Identification."@en ;
+    skos:definition "A name for a dcterms:Agent responsible for making a dwc:Identification."@en ;
+    skos:prefLabel "Identified By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/identifiedByID>
+    rdfs:label "Identified By ID"@en ;
+    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Recommended best practice is to provide a single identifier that disambiguates the details of the identifying dcterms:Agent. If a list is used, the order of the identifiers on the list should not be assumed to convey any semantics. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "An identifier for a dcterms:Agent responsible for making a dwc:Identification."@en ;
+    skos:definition "An identifier for a dcterms:Agent responsible for making a dwc:Identification."@en ;
+    skos:prefLabel "Identified By ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/individualCount>
+    rdfs:label "Individual Count"@en ;
+    rdfs:comment "The number of individuals present at the time of the dwc:Occurrence."@en ;
+    skos:definition "The number of individuals present at the time of the dwc:Occurrence."@en ;
+    skos:prefLabel "Individual Count"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/individualID>
+    rdfs:label "Individual ID"@en ;
+    dcterms:description "Examples: \"U.amer. 44\", \"Smedley\", \"Orca J 23\""@en ;
+    rdfs:comment "An identifier for an individual or named group of individual organisms represented in the Occurrence. Meant to accommodate resampling of the same individual or group for monitoring purposes. May be a global unique identifier or an identifier specific to a data set."@en ;
+    skos:definition "An identifier for an individual or named group of individual organisms represented in the Occurrence. Meant to accommodate resampling of the same individual or group for monitoring purposes. May be a global unique identifier or an identifier specific to a data set."@en ;
+    skos:prefLabel "Individual ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/informationWithheld>
+    rdfs:label "Information Withheld"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:definition "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
+    skos:prefLabel "Information Withheld"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/infragenericEpithet>
+    rdfs:label "Infrageneric Epithet"@en ;
+    dcterms:description "The term dwc:infragenericEpithet should be used in conjunction with dwc:genericName, dwc:specificEpithet, dwc:infraspecificEpithet, dwc:taxonRank and dwc:scientificNameAuthorship to represent the individual elements of the complete dwc:scientificName. It can be used to indicate the subgenus placement of a species, which in zoology is often given in parentheses. Can also be used to share infrageneric names such as botanical sections (e.g., `Vicia sect. Cracca`)."@en ;
+    rdfs:comment "The infrageneric part of a binomial name at ranks above species but below genus."@en ;
+    skos:definition "The infrageneric part of a binomial name at ranks above species but below genus."@en ;
+    skos:prefLabel "Infrageneric Epithet"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/infraspecificEpithet>
+    rdfs:label "Infraspecific Epithet"@en ;
+    dcterms:description "In botany, name strings in literature and identifications may have multiple infraspecific ranks. According to the International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code Articles 6.7 & Art. 24.1), valid names only have two epithets, with the lowest rank being the dwc:infraspecificEpithet. For example: the dwc:infraspecificEpithet in the string `Indigofera charlieriana subsp. sessilis var. scaberrima` is `scaberrima` and the dwc:scientificName is `Indigofera charlieriana var. scaberrima`. Use dwc:verbatimIdentification for the full name string used in a dwc:Identification. "@en ;
+    rdfs:comment "The name of the lowest or terminal infraspecific of the dwc:scientificName."@en ;
+    skos:definition "The name of the lowest or terminal infraspecific of the dwc:scientificName."@en ;
+    skos:prefLabel "Infraspecific Epithet"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/institutionCode>
+    rdfs:label "Institution Code"@en ;
+    dcterms:description "The institution having ownership of a resource should be given in dwc:ownerInstitutionCode."@en ;
+    rdfs:comment "A name (or acronym) in use by an institution having custody of a resource."@en ;
+    skos:definition "A name (or acronym) in use by an institution having custody of a resource."@en ;
+    skos:prefLabel "Institution Code"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/institutionID>
+    rdfs:label "Institution ID"@en ;
+    dcterms:description "For physical specimens, the recommended best practice is to use a globally unique and resolvable identifier from a collections registry such as the Research Organization Registry (ROR) or the Global Registry of Scientific Collections (https://scientific-collections.gbif.org/)."@en ;
+    rdfs:comment "An identifier for an organization."@en ;
+    skos:definition "An identifier for an organization."@en ;
+    skos:prefLabel "Institution ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/isAcceptedIdentification>
+    rdfs:label "Is Accepted Identification"@en ;
+    dcterms:description "Recommended best practice is to follow the TDWG Boolean Controlled Vocabulary http://rs.tdwg.org/tag/doc/boolean/."@en ;
+    rdfs:comment "An indicator that a dwc:Identification of a dwc:Organism is a currently an accepted or preferred one."@en ;
+    skos:definition "An indicator that a dwc:Identification of a dwc:Organism is a currently an accepted or preferred one."@en ;
+    skos:prefLabel "Is Accepted Identification"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/island>
+    rdfs:label "Island"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
+    rdfs:comment "The name of the island on or near which the dcterms:Location occurs."@en ;
+    skos:definition "The name of the island on or near which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Island"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/islandGroup>
+    rdfs:label "Island Group"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
+    rdfs:comment "The name of the island group in which the dcterms:Location occurs."@en ;
+    skos:definition "The name of the island group in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Island Group"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/kingdom>
+    rdfs:label "Kingdom"@en ;
+    rdfs:comment "The full scientific name of the kingdom in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the kingdom in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Kingdom"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/latestAgeOrHighestStage>
+    rdfs:label "Latest Age Or Highest Stage"@en ;
+    rdfs:comment "The full name of the latest possible geochronologic age or highest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the latest possible geochronologic age or highest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Latest Age Or Highest Stage"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/latestEonOrHighestEonothem>
+    rdfs:label "Latest Eon Or Highest Eonothem"@en ;
+    rdfs:comment "The full name of the latest possible geochronologic eon or highest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the latest possible geochronologic eon or highest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Latest Eon Or Highest Eonothem"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/latestEpochOrHighestSeries>
+    rdfs:label "Latest Epoch Or Highest Series"@en ;
+    rdfs:comment "The full name of the latest possible geochronologic epoch or highest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the latest possible geochronologic epoch or highest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Latest Epoch Or Highest Series"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/latestEraOrHighestErathem>
+    rdfs:label "Latest Era Or Highest Erathem"@en ;
+    rdfs:comment "The full name of the latest possible geochronologic era or highest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the latest possible geochronologic era or highest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Latest Era Or Highest Erathem"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/latestPeriodOrHighestSystem>
+    rdfs:label "Latest Period Or Highest System"@en ;
+    rdfs:comment "The full name of the latest possible geochronologic period or highest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the latest possible geochronologic period or highest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Latest Period Or Highest System"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/lifeStage>
+    rdfs:label "Life Stage"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "An age class or life stage of a dwc:Organism."@en ;
+    skos:definition "An age class or life stage of a dwc:Organism."@en ;
+    skos:prefLabel "Life Stage"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/lithostratigraphicTerms>
+    rdfs:label "Lithostratigraphic Terms"@en ;
+    rdfs:comment "The combination of all lithostratigraphic names for the rock from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The combination of all lithostratigraphic names for the rock from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Lithostratigraphic Terms"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/locality>
+    rdfs:label "Locality"@en ;
+    dcterms:description "Less specific geographic information can be provided in other geographic terms (dwc:higherGeography, dwc:continent, dwc:country, dwc:stateProvince, dwc:county, dwc:municipality, dwc:waterBody, dwc:island, dwc:islandGroup). This term may contain information modified from the original to correct perceived errors or standardize the description."@en ;
+    rdfs:comment "The specific description of the place."@en ;
+    skos:definition "The specific description of the place."@en ;
+    skos:prefLabel "Locality"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/locationAccordingTo>
+    rdfs:label "Location According To"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
+    skos:definition "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
+    skos:prefLabel "Location According To"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/locationAttributes>
+    rdfs:label "Location Attributes"@en ;
+    dcterms:description "Example: \"aspectheading=277; slopeindegrees=6\""@en ;
+    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the location."@en ;
+    skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the location."@en ;
+    skos:prefLabel "Location Attributes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/locationID>
+    rdfs:label "Location ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dcterms:Location."@en ;
+    skos:definition "An identifier for a dcterms:Location."@en ;
+    skos:prefLabel "Location ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/locationRemarks>
+    rdfs:label "Location Remarks"@en ;
+    rdfs:comment "Comments or notes about the dcterms:Location."@en ;
+    skos:definition "Comments or notes about the dcterms:Location."@en ;
+    skos:prefLabel "Location Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/lowestBiostratigraphicZone>
+    rdfs:label "Lowest Biostratigraphic Zone"@en ;
+    rdfs:comment "The full name of the lowest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the lowest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Lowest Biostratigraphic Zone"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/materialEntityCategory>
+    rdfs:label "Material Entity Category"@en ;
+    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
+    skos:definition "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Material Entity Category"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/materialEntityID>
+    rdfs:label "Material Entity ID"@en ;
+    dcterms:description "Values of dwc:materialEntityID are intended to uniquely and persistently identify a particular dwc:MaterialEntity within some context. Examples of context include a particular sample collection, an organization, or the worldwide scale. Recommended best practice is to use a persistent, globally unique identifier. The identifier is bound to a physical object (the dwc:MaterialEntity) as opposed to a particular digital record (representation) of that physical object."@en ;
+    rdfs:comment "An identifier for a particular instance of a dwc:MaterialEntity."@en ;
+    skos:definition "An identifier for a particular instance of a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Material Entity ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/materialEntityRemarks>
+    rdfs:label "Material Entity Remarks"@en ;
+    rdfs:comment "Comments or notes about a dwc:MaterialEntity."@en ;
+    skos:definition "Comments or notes about a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Material Entity Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/materialEntityType>
+    rdfs:label "Material Entity Type"@en ;
+    dcterms:description "A more generic classification of a dwc:MaterialEntity than dwc:preparations. Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
+    skos:definition "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
+    skos:prefLabel "Material Entity Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/materialSampleID>
+    rdfs:label "Material Sample ID"@en ;
+    dcterms:description "Recommended best practice is to use a persistent, globally unique identifier."@en ;
+    rdfs:comment "An identifier for the dwc:MaterialSample (as opposed to a particular digital record of the dwc:MaterialSample). In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the dwc:materialSampleID globally unique."@en ;
+    skos:definition "An identifier for the dwc:MaterialSample (as opposed to a particular digital record of the dwc:MaterialSample). In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the dwc:materialSampleID globally unique."@en ;
+    skos:prefLabel "Material Sample ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/maximumDepthInMeters>
+    rdfs:label "Maximum Depth In Meters"@en ;
+    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
+    rdfs:comment "The greatest depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:definition "The greatest depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:prefLabel "Maximum Depth In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/maximumDistanceAboveSurfaceInMeters>
+    rdfs:label "Maximum Distance Above Surface In Meters"@en ;
+    rdfs:comment "The greater distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
+    skos:definition "The greater distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
+    skos:prefLabel "Maximum Distance Above Surface In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/maximumElevationInMeters>
+    rdfs:label "Maximum Elevation In Meters"@en ;
+    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
+    rdfs:comment "The greatest elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:definition "The greatest elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:prefLabel "Maximum Elevation In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementAccuracy>
+    rdfs:label "Measurement Accuracy"@en ;
+    rdfs:comment "The description of the potential error associated with the dwc:measurementValue."@en ;
+    skos:definition "The description of the potential error associated with the dwc:measurementValue."@en ;
+    skos:prefLabel "Measurement Accuracy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementDeterminedBy>
+    rdfs:label "Measurement Determined By"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A list (concatenated and separated) of names of people, groups, or organizations who determined the value of the dwc:MeasurementOrFact."@en ;
+    skos:definition "A list (concatenated and separated) of names of people, groups, or organizations who determined the value of the dwc:MeasurementOrFact."@en ;
+    skos:prefLabel "Measurement Determined By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementDeterminedDate>
+    rdfs:label "Measurement Determined Date"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "The date on which the dwc:MeasurementOrFact was made."@en ;
+    skos:definition "The date on which the dwc:MeasurementOrFact was made."@en ;
+    skos:prefLabel "Measurement Determined Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementID>
+    rdfs:label "Measurement ID"@en ;
+    rdfs:comment "An identifier for the dwc:MeasurementOrFact (information pertaining to measurements, facts, characteristics, or assertions). May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the dwc:MeasurementOrFact (information pertaining to measurements, facts, characteristics, or assertions). May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Measurement ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementMethod>
+    rdfs:label "Measurement Method"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A description of or reference to (publication, URI) the method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
+    skos:definition "A description of or reference to (publication, URI) the method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
+    skos:prefLabel "Measurement Method"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementRemarks>
+    rdfs:label "Measurement Remarks"@en ;
+    rdfs:comment "Comments or notes accompanying the dwc:MeasurementOrFact."@en ;
+    skos:definition "Comments or notes accompanying the dwc:MeasurementOrFact."@en ;
+    skos:prefLabel "Measurement Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementType>
+    rdfs:label "Measurement Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The nature of the measurement, fact, characteristic, or assertion."@en ;
+    skos:definition "The nature of the measurement, fact, characteristic, or assertion."@en ;
+    skos:prefLabel "Measurement Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementUnit>
+    rdfs:label "Measurement Unit"@en ;
+    dcterms:description "Recommended best practice is to use the International System of Units (SI). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The units associated with the dwc:measurementValue."@en ;
+    skos:definition "The units associated with the dwc:measurementValue."@en ;
+    skos:prefLabel "Measurement Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/measurementValue>
+    rdfs:label "Measurement Value"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The value of the measurement, fact, characteristic, or assertion."@en ;
+    skos:definition "The value of the measurement, fact, characteristic, or assertion."@en ;
+    skos:prefLabel "Measurement Value"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/member>
+    rdfs:label "Member"@en ;
+    rdfs:comment "The full name of the lithostratigraphic member from which the dwc:MaterialEntity was collected."@en ;
+    skos:definition "The full name of the lithostratigraphic member from which the dwc:MaterialEntity was collected."@en ;
+    skos:prefLabel "Member"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/minimumDepthInMeters>
+    rdfs:label "Minimum Depth In Meters"@en ;
+    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
+    rdfs:comment "The least depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:definition "The least depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:prefLabel "Minimum Depth In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/minimumDistanceAboveSurfaceInMeters>
+    rdfs:label "Minimum Distance Above Surface In Meters"@en ;
+    rdfs:comment "The lesser distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
+    skos:definition "The lesser distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
+    skos:prefLabel "Minimum Distance Above Surface In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/minimumElevationInMeters>
+    rdfs:label "Minimum Elevation In Meters"@en ;
+    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
+    rdfs:comment "The least elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:definition "The least elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
+    skos:prefLabel "Minimum Elevation In Meters"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/molecularProtocolID>
+    rdfs:label "Molecular Protocol ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dwc:MolecularProtocol."@en ;
+    skos:definition "An identifier for a dwc:MolecularProtocol."@en ;
+    skos:prefLabel "Molecular Protocol ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/month>
+    rdfs:label "Month"@en ;
+    rdfs:comment "The integer month in which the dwc:Event occurred."@en ;
+    skos:definition "The integer month in which the dwc:Event occurred."@en ;
+    skos:prefLabel "Month"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/municipality>
+    rdfs:label "Third Order Division"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
+    rdfs:comment "The full, unabbreviated name of the next smaller administrative region than county (city, municipality, etc.) in which the dcterms:Location occurs. Do not use this term for a nearby named place that does not contain the actual dcterms:Location."@en ;
+    skos:definition "The full, unabbreviated name of the next smaller administrative region than county (city, municipality, etc.) in which the dcterms:Location occurs. Do not use this term for a nearby named place that does not contain the actual dcterms:Location."@en ;
+    skos:prefLabel "Third Order Division"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/nameAccordingTo>
+    rdfs:label "Name According To"@en ;
+    dcterms:description "This term provides context to the dwc:scientificName. Together with the dwc:scientificName, separated by `sensu` or `sec.`, it forms the taxon concept label, which may be seen as having the same relationship to dwc:taxonConceptID as, for example, dwc:acceptedNameUsage has to dwc:acceptedNameUsageID. When not provided, in Taxon Core data sets the dwc:nameAccordingTo can be taken to be the data set. In this case the data set mostly provides sufficient context to infer the delimitation of the taxon and its relationship with other taxa. In Occurrence Core data sets, when not provided, dwc:nameAccordingTo can be an underlying taxonomy of the data set, e.g., Plants of the World Online (http://powo.science.kew.org/) for vascular plant records in iNaturalist (in which case it should be provided), or, which is the case for most dwc:PreservedSpecimen data sets, the dwc:Identification, in which case there is no further context."@en ;
+    rdfs:comment "The reference to the source in which the specific taxon concept circumscription is defined or implied - traditionally signified by the Latin \"sensu\" or \"sec.\" (from secundum, meaning \"according to\"). For taxa that result from identifications, a reference to the keys, monographs, experts and other sources should be given."@en ;
+    skos:definition "The reference to the source in which the specific taxon concept circumscription is defined or implied - traditionally signified by the Latin \"sensu\" or \"sec.\" (from secundum, meaning \"according to\"). For taxa that result from identifications, a reference to the keys, monographs, experts and other sources should be given."@en ;
+    skos:prefLabel "Name According To"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/nameAccordingToID>
+    rdfs:label "Name According To ID"@en ;
+    rdfs:comment "An identifier for the source in which the specific taxon concept circumscription is defined or implied. See dwc:nameAccordingTo."@en ;
+    skos:definition "An identifier for the source in which the specific taxon concept circumscription is defined or implied. See dwc:nameAccordingTo."@en ;
+    skos:prefLabel "Name According To ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/namePublicationID>
+    rdfs:label "Name Publication ID"@en ;
+    dcterms:description "Example: \"http://hdl.handle.net/10199/7\""@en ;
+    rdfs:comment "A resolvable globally unique identifier for the original publication of the scientificName."@en ;
+    skos:definition "A resolvable globally unique identifier for the original publication of the scientificName."@en ;
+    skos:prefLabel "Name Publication ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/namePublishedIn>
+    rdfs:label "Name Published In"@en ;
+    dcterms:description "A citation of the first publication of the name in its given combination, not the basionym / original name. Recombinations are often not published in zoology, in which case dwc:namePublishedIn should be empty."@en ;
+    rdfs:comment "A reference for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
+    skos:definition "A reference for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
+    skos:prefLabel "Name Published In"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/namePublishedInID>
+    rdfs:label "Name Published In ID"@en ;
+    dcterms:description "A citation of the first publication of the name in its given combination, not the basionym / original name. Recombinations are often not published in zoology, in which case dwc:namePublishedInID should be empty."@en ;
+    rdfs:comment "An identifier for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
+    skos:definition "An identifier for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
+    skos:prefLabel "Name Published In ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/namePublishedInYear>
+    rdfs:label "Name Published In Year"@en ;
+    rdfs:comment "The four-digit year in which the dwc:scientificName was published."@en ;
+    skos:definition "The four-digit year in which the dwc:scientificName was published."@en ;
+    skos:prefLabel "Name Published In Year"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/nomenclaturalCode>
+    rdfs:label "Nomenclatural Code"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
+    rdfs:comment "The nomenclatural code (or codes in the case of an ambiregnal name) under which the dwc:scientificName is constructed."@en ;
+    skos:definition "The nomenclatural code (or codes in the case of an ambiregnal name) under which the dwc:scientificName is constructed."@en ;
+    skos:prefLabel "Nomenclatural Code"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/nomenclaturalStatus>
+    rdfs:label "Nomenclatural Status"@en ;
+    rdfs:comment "The status related to the original publication of the name and its conformance to the relevant rules of nomenclature. It is based essentially on an algorithm according to the business rules of the code. It requires no taxonomic opinion."@en ;
+    skos:definition "The status related to the original publication of the name and its conformance to the relevant rules of nomenclature. It is based essentially on an algorithm according to the business rules of the code. It requires no taxonomic opinion."@en ;
+    skos:prefLabel "Nomenclatural Status"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/nucleotideSequenceRemarks>
+    rdfs:label "Nucleotide Sequence Remarks"@en ;
+    rdfs:comment "Comments or notes about a dwc:NucleotideSequence."@en ;
+    skos:definition "Comments or notes about a dwc:NucleotideSequence."@en ;
+    skos:prefLabel "Nucleotide Sequence Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/objectQuantity>
+    rdfs:label "Object Quantity"@en ;
+    dcterms:description "An dwc:objectQuantity must have a corresponding dwc:objectQuantityType."@en ;
+    rdfs:comment "A number or enumeration value for the quantity of differentiable dwc:MaterialEntities comprising this dwc:MaterialEntity."@en ;
+    skos:definition "A number or enumeration value for the quantity of differentiable dwc:MaterialEntities comprising this dwc:MaterialEntity."@en ;
+    skos:prefLabel "Object Quantity"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/objectQuantityType>
+    rdfs:label "Object Quantity Type"@en ;
+    dcterms:description "An dwc:objectQuantityType must have a corresponding dwc:objectQuantity. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
+    skos:definition "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
+    skos:prefLabel "Object Quantity Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceAttributes>
+    rdfs:label "Occurrence Attributes"@en ;
+    dcterms:description "Examples: \"Tragus length: 14mm; Weight: 120g\", \"Height: 1-1.5 meters tall; flowers yellow; uncommon\"."@en ;
+    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Occurrence."@en ;
+    skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Occurrence."@en ;
+    skos:prefLabel "Occurrence Attributes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceDetails>
+    rdfs:label "Occurrence Details"@en ;
+    dcterms:description "Example: \"http://mvzarctos.berkeley.edu/guid/MVZ:Mamm:165861\""@en ;
+    rdfs:comment "A reference (publication, URI) to the most detailed information available about the Occurrence."@en ;
+    skos:definition "A reference (publication, URI) to the most detailed information available about the Occurrence."@en ;
+    skos:prefLabel "Occurrence Details"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceID>
+    rdfs:label "Occurrence ID"@en ;
+    dcterms:description "In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the dwc:occurrenceID globally unique."@en ;
+    rdfs:comment "An identifier for a dwc:Occurrence (as opposed to a particular digital record of a dwc:Occurrence)."@en ;
+    skos:definition "An identifier for a dwc:Occurrence (as opposed to a particular digital record of a dwc:Occurrence)."@en ;
+    skos:prefLabel "Occurrence ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementAccuracy>
+    rdfs:label "Occurrence Measurement Accuracy"@en ;
+    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
+    rdfs:comment "The description of the error associated with the occurrenceAttributeValue."@en ;
+    skos:definition "The description of the error associated with the occurrenceAttributeValue."@en ;
+    skos:prefLabel "Occurrence Measurement Accuracy"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementDeterminedBy>
+    rdfs:label "Occurrence Measurement Determined By"@en ;
+    dcterms:description "Example: \"Javier de la Torre\""@en ;
+    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the occurrence."@en ;
+    skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the occurrence."@en ;
+    skos:prefLabel "Occurrence Measurement Determined By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementDeterminedDate>
+    rdfs:label "Occurrence Measurement Determined Date"@en ;
+    dcterms:description "Examples: \"1963-03-08T14:07-0600\" is 8 Mar 1963 2:07pm in the time zone six hours earlier than UTC, \"2009-02-20T08:40Z\" is 20 Feb 2009 8:40am UTC, \"1809-02-12\" is 12 Feb 1809, \"1906-06\" is Jun 1906, \"1971\" is just that year, \"2007-03-01T13:00:00Z/2008-05-11T15:30:00Z\" is the interval between 1 Mar 2007 1pm UTC and 11 May 2008 3:30pm UTC, \"2007-11-13/15\" is the interval between 13 Nov 2007 and 15 Nov 2007."@en ;
+    rdfs:comment "The date on which the the measurement or characteristic of the occurrence was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:definition "The date on which the the measurement or characteristic of the occurrence was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
+    skos:prefLabel "Occurrence Measurement Determined Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementID>
+    rdfs:label "Occurrence Measurement ID"@en ;
+    rdfs:comment "An identifier for the occurrence attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the occurrence attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Occurrence Measurement ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementRemarks>
+    rdfs:label "Occurrence Measurement Remarks"@en ;
+    dcterms:description "Example: \"tip of tail missing\""@en ;
+    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the occurrence."@en ;
+    skos:definition "Comments or notes accompanying the measurement or characteristic of the occurrence."@en ;
+    skos:prefLabel "Occurrence Measurement Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementType>
+    rdfs:label "Occurrence Measurement Type"@en ;
+    dcterms:description "Example: \"tail length\""@en ;
+    rdfs:comment "The nature of the measurement or characteristic of the occurrence. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:definition "The nature of the measurement or characteristic of the occurrence. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:prefLabel "Occurrence Measurement Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementUnit>
+    rdfs:label "Occurrence Measurement Unit"@en ;
+    dcterms:description "Example: \"mm\""@en ;
+    rdfs:comment "The units for the value of the measurement or characteristic of the occurrence. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:definition "The units for the value of the measurement or characteristic of the occurrence. Recommended best practice is to use International System of Units (SI) units."@en ;
+    skos:prefLabel "Occurrence Measurement Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceMeasurementValue>
+    rdfs:label "Occurrence Measurement Value"@en ;
+    dcterms:description "Example: \"45\""@en ;
+    rdfs:comment "The value of the measurement or characteristic of the occurrence."@en ;
+    skos:definition "The value of the measurement or characteristic of the occurrence."@en ;
+    skos:prefLabel "Occurrence Measurement Value"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceRemarks>
+    rdfs:label "Occurrence Remarks"@en ;
+    rdfs:comment "Comments or notes about the dwc:Occurrence."@en ;
+    skos:definition "Comments or notes about the dwc:Occurrence."@en ;
+    skos:prefLabel "Occurrence Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/occurrenceStatus>
+    rdfs:label "Occurrence Status"@en ;
+    dcterms:description "For dwc:Occurrences, the default vocabulary is recommended to consist of detected and notDetected, but can be extended by implementers with good justification. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
+    skos:definition "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
+    skos:prefLabel "Occurrence Status"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/order>
+    rdfs:label "Order"@en ;
+    rdfs:comment "The full scientific name of the order in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the order in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Order"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismID>
+    rdfs:label "Organism ID"@en ;
+    rdfs:comment "An identifier for the dwc:Organism instance (as opposed to a particular digital record of the dwc:Organism). May be a globally unique identifier or an identifier specific to the data set."@en ;
+    skos:definition "An identifier for the dwc:Organism instance (as opposed to a particular digital record of the dwc:Organism). May be a globally unique identifier or an identifier specific to the data set."@en ;
+    skos:prefLabel "Organism ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismInteractionDescription>
+    rdfs:label "Organism Interaction Description"@en ;
+    rdfs:comment "A verbatim description of a dwc:OrganismInteraction."@en ;
+    skos:definition "A verbatim description of a dwc:OrganismInteraction."@en ;
+    skos:prefLabel "Organism Interaction Description"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismInteractionID>
+    rdfs:label "Organism Interaction ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dwc:OrganismInteraction."@en ;
+    skos:definition "An identifier for a dwc:OrganismInteraction."@en ;
+    skos:prefLabel "Organism Interaction ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismInteractionType>
+    rdfs:label "Organism Interaction Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
+    skos:definition "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
+    skos:prefLabel "Organism Interaction Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismName>
+    rdfs:label "Organism Name"@en ;
+    rdfs:comment "A textual name or label assigned to a dwc:Organism instance."@en ;
+    skos:definition "A textual name or label assigned to a dwc:Organism instance."@en ;
+    skos:prefLabel "Organism Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismQuantity>
+    rdfs:label "Organism Quantity"@en ;
+    dcterms:description "A dwc:organismQuantity must have a corresponding dwc:organismQuantityType."@en ;
+    rdfs:comment "A number or enumeration value for the quantity of dwc:Organisms."@en ;
+    skos:definition "A number or enumeration value for the quantity of dwc:Organisms."@en ;
+    skos:prefLabel "Organism Quantity"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismQuantityType>
+    rdfs:label "Organism Quantity Type"@en ;
+    dcterms:description "A dwc:organismQuantityType must have a corresponding dwc:organismQuantity. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The type of quantification system used for the quantity of dwc:Organisms."@en ;
+    skos:definition "The type of quantification system used for the quantity of dwc:Organisms."@en ;
+    skos:prefLabel "Organism Quantity Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismRemarks>
+    rdfs:label "Organism Remarks"@en ;
+    rdfs:comment "Comments or notes about the dwc:Organism instance."@en ;
+    skos:definition "Comments or notes about the dwc:Organism instance."@en ;
+    skos:prefLabel "Organism Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/organismScope>
+    rdfs:label "Organism Scope"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term is not intended to be used to specify a type of dwc:Taxon. To describe the kind of dwc:Organism using a URI object in RDF, use rdf:type (http://www.w3.org/1999/02/22-rdf-syntax-ns#type) instead."@en ;
+    rdfs:comment "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
+    skos:definition "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
+    skos:prefLabel "Organism Scope"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/originalNameUsage>
+    rdfs:label "Original Name Usage"@en ;
+    dcterms:description "The full scientific name, with authorship and date information if known, of the name usage in which the terminal element of the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode. For example, for names governed by the ICNafp, this term would indicate the basionym of a record representing a subsequent combination. Unlike basionyms, however, this term can apply to scientific names at all ranks."@en ;
+    rdfs:comment "The taxon name, with authorship and date information if known, as it originally appeared when first established under the rules of the associated dwc:nomenclaturalCode. The basionym (botany) or basonym (bacteriology) of the dwc:scientificName or the senior/earlier homonym for replaced names."@en ;
+    skos:definition "The taxon name, with authorship and date information if known, as it originally appeared when first established under the rules of the associated dwc:nomenclaturalCode. The basionym (botany) or basonym (bacteriology) of the dwc:scientificName or the senior/earlier homonym for replaced names."@en ;
+    skos:prefLabel "Original Name Usage"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/originalNameUsageID>
+    rdfs:label "Original Name Usage ID"@en ;
+    dcterms:description "This term should be used to refer to the dwc:taxonID of a dwc:Taxon record that represents the usage of the terminal element of the dwc:scientificName as originally established under the rules of the associated dwc:nomenclaturalCode. For example, for names governed by the ICNafp, this term would establish the relationship between a record representing a subsequent combination and the record for its corresponding basionym. Unlike basionyms, however, this term can apply to scientific names at all ranks. For Darwin Core Archives the related record should be present locally in the same archive."@en ;
+    rdfs:comment "An identifier for the name usage (documented meaning of the name according to a source) in which the terminal element of the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
+    skos:definition "An identifier for the name usage (documented meaning of the name according to a source) in which the terminal element of the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
+    skos:prefLabel "Original Name Usage ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/otherCatalogNumbers>
+    rdfs:label "Other Catalog Numbers"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of previous or alternate fully qualified catalog numbers or other human-used identifiers for the same dwc:MaterialEntity, whether in the current or any other data set or collection."@en ;
+    skos:definition "A list (concatenated and separated) of previous or alternate fully qualified catalog numbers or other human-used identifiers for the same dwc:MaterialEntity, whether in the current or any other data set or collection."@en ;
+    skos:prefLabel "Other Catalog Numbers"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/ownerInstitutionCode>
+    rdfs:label "Owner Institution Code"@en ;
+    rdfs:comment "A name (or acronym) in use by an institution having ownership of a resource."@en ;
+    skos:definition "A name (or acronym) in use by an institution having ownership of a resource."@en ;
+    skos:prefLabel "Owner Institution Code"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/parentEventID>
+    rdfs:label "Parent Event ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a broader dwc:Event that contains this and potentially other dwc:Events."@en ;
+    skos:definition "An identifier for a broader dwc:Event that contains this and potentially other dwc:Events."@en ;
+    skos:prefLabel "Parent Event ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/parentMeasurementID>
+    rdfs:label "Parent Measurement ID"@en ;
+    dcterms:description "May be a globally unique identifier or an identifier specific to the data set."@en ;
+    rdfs:comment "An identifier for a broader dwc:MeasurementOrFact that groups this and potentially other dwc:MeasurementOrFacts."@en ;
+    skos:definition "An identifier for a broader dwc:MeasurementOrFact that groups this and potentially other dwc:MeasurementOrFacts."@en ;
+    skos:prefLabel "Parent Measurement ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/parentNameUsage>
+    rdfs:label "Parent Name Usage"@en ;
+    rdfs:comment "The full name, with authorship and date information if known, of the direct, most proximate higher-rank parent dwc:Taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
+    skos:definition "The full name, with authorship and date information if known, of the direct, most proximate higher-rank parent dwc:Taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
+    skos:prefLabel "Parent Name Usage"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/parentNameUsageID>
+    rdfs:label "Parent Name Usage ID"@en ;
+    dcterms:description "This term should be used for accepted names to refer to the dwc:taxonID of a dwc:Taxon record that represents the next higher taxon rank in the same taxonomic classification. For Darwin Core Archives the related record should be present locally in the same archive."@en ;
+    rdfs:comment "An identifier for the name usage (documented meaning of the name according to a source) of the direct, most proximate higher-rank parent taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
+    skos:definition "An identifier for the name usage (documented meaning of the name according to a source) of the direct, most proximate higher-rank parent taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
+    skos:prefLabel "Parent Name Usage ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/pathway>
+    rdfs:label "Pathway"@en ;
+    dcterms:description "Recommended best practice is to use controlled value strings from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/pw/. For details, refer to https://doi.org/10.3897/biss.3.38084. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
+    skos:definition "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
+    skos:prefLabel "Pathway"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/phylum>
+    rdfs:label "Phylum"@en ;
+    rdfs:comment "The full scientific name of the phylum or division in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the phylum or division in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Phylum"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/pointRadiusSpatialFit>
+    rdfs:label "Point Radius Spatial Fit"@en ;
+    dcterms:description "Legal values are 0, greater than or equal to 1, or undefined. A value of 1 is an exact match or 100% overlap. A value of 0 should be used if the given point-radius does not completely contain the original representation. The pointRadiusSpatialFit is undefined (and should be left empty) if the original representation is any geometry without area (e.g., a point or polyline) and without uncertainty and the given georeference is not that same geometry (without uncertainty). If both the original and the given georeference are the same point, the pointRadiusSpatialFit is 1. Detailed explanations with graphical examples can be found in the Georeferencing Best Practices, Chapman and Wieczorek, 2020 (https://doi.org/10.15468/doc-gg7h-s853)."@en ;
+    rdfs:comment "A ratio of the area of a point-radius (dwc:decimalLatitude, dwc:decimalLongitude, dwc:coordinateUncertaintyInMeters) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
+    skos:definition "A ratio of the area of a point-radius (dwc:decimalLatitude, dwc:decimalLongitude, dwc:coordinateUncertaintyInMeters) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
+    skos:prefLabel "Point Radius Spatial Fit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/preferredSpatialRepresentation>
+    rdfs:label "Preferred Spatial Representation"@en ;
+    rdfs:comment "An indication of which spatial representation best represents the dcterms:Location."@en ;
+    skos:definition "An indication of which spatial representation best represents the dcterms:Location."@en ;
+    skos:prefLabel "Preferred Spatial Representation"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/preparations>
+    rdfs:label "Preparations"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A list (concatenated and separated) of preparations and preservation methods for a dwc:MaterialEntity."@en ;
+    skos:definition "A list (concatenated and separated) of preparations and preservation methods for a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Preparations"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/previousIdentifications>
+    rdfs:label "Previous Identifications"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of previous assignments of names to the dwc:Organism."@en ;
+    skos:definition "A list (concatenated and separated) of previous assignments of names to the dwc:Organism."@en ;
+    skos:prefLabel "Previous Identifications"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/processedTotalReadCount>
+    rdfs:label "Processed Total Read Count"@en ;
+    rdfs:comment "The total number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
+    skos:definition "The total number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
+    skos:prefLabel "Processed Total Read Count"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/projectID>
+    rdfs:label "Project ID"@en ;
+    dcterms:description "A projectID may be shared in multiple distinct datasets. The nature of the association can be described in the metadata project description element. This term should be used to provide a globally unique identifier (GUID) for a project, if available. This could be a DOI, URI, or any other persistent identifier that ensures a project can be uniquely distinguished from others. The Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of identifiers for projects that contributed to a dwc:Event."@en ;
+    skos:definition "A list (concatenated and separated) of identifiers for projects that contributed to a dwc:Event."@en ;
+    skos:prefLabel "Project ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/projectTitle>
+    rdfs:label "Project Title"@en ;
+    dcterms:description "Use this term to provide the official name or title of a project as it is commonly known and cited. Avoid abbreviations unless they are widely understood. The recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of titles or names for projects that contributed to a dwc:Event."@en ;
+    skos:definition "A list (concatenated and separated) of titles or names for projects that contributed to a dwc:Event."@en ;
+    skos:prefLabel "Project Title"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/protocolDescription>
+    rdfs:label "Protocol Description"@en ;
+    rdfs:comment "A detailed description of a dwc:Protocol."@en ;
+    skos:definition "A detailed description of a dwc:Protocol."@en ;
+    skos:prefLabel "Protocol Description"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/protocolID>
+    rdfs:label "Protocol ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dwc:Protocol."@en ;
+    skos:definition "An identifier for a dwc:Protocol."@en ;
+    skos:prefLabel "Protocol ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/protocolReferences>
+    rdfs:label "Protocol References"@en ;
+    dcterms:description "Recommended best practice is to separate multiple values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Protocol."@en ;
+    skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Protocol."@en ;
+    skos:prefLabel "Protocol References"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/protocolRemarks>
+    rdfs:label "Protocol Remarks"@en ;
+    rdfs:comment "Comments or notes about a dwc:Protocol."@en ;
+    skos:definition "Comments or notes about a dwc:Protocol."@en ;
+    skos:prefLabel "Protocol Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/protocolType>
+    rdfs:label "Protocol Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category that best matches the nature of a dwc:Protocol."@en ;
+    skos:definition "A category that best matches the nature of a dwc:Protocol."@en ;
+    skos:prefLabel "Protocol Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/readCount>
+    rdfs:label "Read Count"@en ;
+    rdfs:comment "The number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
+    skos:definition "The number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
+    skos:prefLabel "Read Count"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/recordNumber>
+    rdfs:label "Record Number"@en ;
+    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
+    skos:definition "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
+    skos:prefLabel "Record Number"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/recordedBy>
+    rdfs:label "Recorded By"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A name for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
+    skos:definition "A name for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
+    skos:prefLabel "Recorded By"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/recordedByID>
+    rdfs:label "Recorded By ID"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
+    rdfs:comment "An identifier for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
+    skos:definition "An identifier for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
+    skos:prefLabel "Recorded By ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/referenceID>
+    rdfs:label "Reference ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dcterms:BibliographicResource."@en ;
+    skos:definition "An identifier for a dcterms:BibliographicResource."@en ;
+    skos:prefLabel "Reference ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/referenceRemarks>
+    rdfs:label "Reference Remarks"@en ;
+    rdfs:comment "Comments or notes about a dcterms:BibliographicResource."@en ;
+    skos:definition "Comments or notes about a dcterms:BibliographicResource."@en ;
+    skos:prefLabel "Reference Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/referenceType>
+    rdfs:label "Reference Type"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
+    rdfs:comment "A category that best matches the nature of a dcterms:BibliographicResource."@en ;
+    skos:definition "A category that best matches the nature of a dcterms:BibliographicResource."@en ;
+    skos:prefLabel "Reference Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relatedResourceID>
+    rdfs:label "Related Resource ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for the related resource (the object) of a dwc:ResourceRelationship."@en ;
+    skos:definition "An identifier for the related resource (the object) of a dwc:ResourceRelationship."@en ;
+    skos:prefLabel "Related Resource ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relatedResourceType>
+    rdfs:label "Related Resource Type"@en ;
+    dcterms:description "Examples: \"StillImage\", \"MovingImage\", \"Sound\", PhysicalObject\", \"PreservedSpecimen\", FossilSpecimen\", LivingSpecimen\", \"HumanObservation\", \"MachineObservation\", \"Location\", \"Taxonomy\", \"NomeclaturalChecklist\", \"Publication\""@en ;
+    rdfs:comment "The type of the related resource. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:definition "The type of the related resource. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:prefLabel "Related Resource Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relationshipAccordingTo>
+    rdfs:label "Relationship According To"@en ;
+    rdfs:comment "The source (person, organization, publication, reference) establishing the relationship between the two resources."@en ;
+    skos:definition "The source (person, organization, publication, reference) establishing the relationship between the two resources."@en ;
+    skos:prefLabel "Relationship According To"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relationshipEstablishedDate>
+    rdfs:label "Relationship Established Date"@en ;
+    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
+    rdfs:comment "The date-time on which the relationship between the two resources was established."@en ;
+    skos:definition "The date-time on which the relationship between the two resources was established."@en ;
+    skos:prefLabel "Relationship Established Date"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relationshipOfResource>
+    rdfs:label "Relationship Of Resource"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
+    rdfs:comment "The relationship of the subject (identified by dwc:resourceID) to the object (identified by dwc:relatedResourceID)."@en ;
+    skos:definition "The relationship of the subject (identified by dwc:resourceID) to the object (identified by dwc:relatedResourceID)."@en ;
+    skos:prefLabel "Relationship Of Resource"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relationshipOfResourceID>
+    rdfs:label "Relationship Of Resource ID"@en ;
+    dcterms:description "Recommended best practice is to use the identifiers of the terms in a controlled vocabulary, such as the OBO Relation Ontology."@en ;
+    rdfs:comment "An identifier for the relationship type (predicate) that connects the subject identified by dwc:resourceID to its object identified by dwc:relatedResourceID."@en ;
+    skos:definition "An identifier for the relationship type (predicate) that connects the subject identified by dwc:resourceID to its object identified by dwc:relatedResourceID."@en ;
+    skos:prefLabel "Relationship Of Resource ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/relationshipRemarks>
+    rdfs:label "Relationship Remarks"@en ;
+    rdfs:comment "Comments or notes about the relationship between the two resources."@en ;
+    skos:definition "Comments or notes about the relationship between the two resources."@en ;
+    skos:prefLabel "Relationship Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/reproductiveCondition>
+    rdfs:label "Reproductive Condition"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A reproductive condition of a dwc:Organism."@en ;
+    skos:definition "A reproductive condition of a dwc:Organism."@en ;
+    skos:prefLabel "Reproductive Condition"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/resourceID>
+    rdfs:label "Resource ID"@en ;
+    rdfs:comment "An identifier for the resource that is the subject of the relationship."@en ;
+    skos:definition "An identifier for the resource that is the subject of the relationship."@en ;
+    skos:prefLabel "Resource ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/resourceRelationshipID>
+    rdfs:label "Resource Relationship ID"@en ;
+    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
+    rdfs:comment "An identifier for a dwc:ResourceRelationship."@en ;
+    skos:definition "An identifier for a dwc:ResourceRelationship."@en ;
+    skos:prefLabel "Resource Relationship ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/sampleSizeUnit>
+    rdfs:label "Sample Size Unit"@en ;
+    dcterms:description "A dwc:sampleSizeUnit must have a corresponding dwc:sampleSizeValue, e.g., `5` for dwc:sampleSizeValue with `m` for dwc:sampleSizeUnit. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
+    skos:definition "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
+    skos:prefLabel "Sample Size Unit"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/sampleSizeValue>
+    rdfs:label "Sample Size Value"@en ;
+    dcterms:description "A dwc:sampleSizeValue must have a corresponding dwc:sampleSizeUnit."@en ;
+    rdfs:comment "A numeric value for a measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
+    skos:definition "A numeric value for a measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
+    skos:prefLabel "Sample Size Value"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/sampledSubstrateCategory>
+    rdfs:label "Sampled Substrate Category"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary and separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category or type of substrate sampled during a dwc:Event."@en ;
+    skos:definition "A category or type of substrate sampled during a dwc:Event."@en ;
+    skos:prefLabel "Sampled Substrate Category"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/sampledSubstrateLayer>
+    rdfs:label "Sampled Substrate Layer"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary and separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A list (concatenated and separated) of substrate layers sampled during a dwc:Event."@en ;
+    skos:definition "A list (concatenated and separated) of substrate layers sampled during a dwc:Event."@en ;
+    skos:prefLabel "Sampled Substrate Layer"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/samplingEffort>
+    rdfs:label "Sampling Effort"@en ;
+    rdfs:comment "The amount of effort expended during a dwc:Event."@en ;
+    skos:definition "The amount of effort expended during a dwc:Event."@en ;
+    skos:prefLabel "Sampling Effort"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/samplingProtocol>
+    rdfs:label "Sampling Protocol"@en ;
+    dcterms:description "Recommended best practice is to describe a dwc:Event with no more than one sampling protocol. In the case of a summary Event with multiple protocols, in which a specific protocol can not be attributed to specific dwc:Occurrences, the recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The names of, references to, or descriptions of the methods or protocols used during a dwc:Event."@en ;
+    skos:definition "The names of, references to, or descriptions of the methods or protocols used during a dwc:Event."@en ;
+    skos:prefLabel "Sampling Protocol"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/scientificName>
+    rdfs:label "Scientific Name"@en ;
+    dcterms:description "This term should not contain identification qualifications, which should instead be supplied in the IdentificationQualifier term. When applied to an Organism or Occurrence, this term should be used to represent the scientific name that was applied to the associated Organism in accordance with the Taxon to which it was or is currently identified. Names should be compliant to the most recent nomenclatural code. For example, names of hybrids for algae, fungi and plants should follow the rules of the International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code Articles H.1, H.2 and H.3). Thus, use the multiplication sign `×` (Unicode `U+00D7`, HTML `&times;`) to identify a hybrid, not `x` or `X`, if possible."@en ;
+    rdfs:comment "The full scientific name, with authorship and date information if known. When forming part of a dwc:Identification, this should be the name in lowest level taxonomic rank that can be determined."@en ;
+    skos:definition "The full scientific name, with authorship and date information if known. When forming part of a dwc:Identification, this should be the name in lowest level taxonomic rank that can be determined."@en ;
+    skos:prefLabel "Scientific Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/scientificNameAuthorship>
+    rdfs:label "Scientific Name Authorship"@en ;
+    rdfs:comment "The authorship information for the dwc:scientificName formatted according to the conventions of the applicable dwc:nomenclaturalCode."@en ;
+    skos:definition "The authorship information for the dwc:scientificName formatted according to the conventions of the applicable dwc:nomenclaturalCode."@en ;
+    skos:prefLabel "Scientific Name Authorship"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/scientificNameID>
+    rdfs:label "Scientific Name ID"@en ;
+    rdfs:comment "An identifier for the nomenclatural (not taxonomic) details of a scientific name."@en ;
+    skos:definition "An identifier for the nomenclatural (not taxonomic) details of a scientific name."@en ;
+    skos:prefLabel "Scientific Name ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/scientificNameRank>
+    rdfs:label "Scientific Name Rank"@en ;
+    dcterms:description "Examples: \"subsp.\", \"var.\", \"forma\", \"species\", \"genus\""@en ;
+    rdfs:comment "The taxonomic rank of the most specific name in the scientificName. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:definition "The taxonomic rank of the most specific name in the scientificName. Recommended best practice is to use a controlled vocabulary."@en ;
+    skos:prefLabel "Scientific Name Rank"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/sequence>
+    rdfs:label "Sequence"@en ;
+    dcterms:description "Recommended best practice is to use IUPAC single character symbols (https://www.bioinformatics.org/sms/iupac.html). Use \"N\" for an unknown or missing nucleotide, and avoid using \"?\". The sequence should be written in the 5' to 3' direction."@en ;
+    rdfs:comment "A string representing nucleotide base pairs."@en ;
+    skos:definition "A string representing nucleotide base pairs."@en ;
+    skos:prefLabel "Sequence"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/sex>
+    rdfs:label "Sex"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A sex of a dwc:Organism."@en ;
+    skos:definition "A sex of a dwc:Organism."@en ;
+    skos:prefLabel "Sex"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/siteNumber>
+    rdfs:label "Site Number"@en ;
+    dcterms:description "Usually an institutional identifier for a specific named place as opposed to dwc:locationID, which is an identifier for the entire set of distinct information for an instance of dcterms:Location. This term differs from dwc:fieldNumber in that dwc:siteNumber is not related strictly to one dwc:Event. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "An identifier for a named site."@en ;
+    skos:definition "An identifier for a named site."@en ;
+    skos:prefLabel "Site Number"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/specificEpithet>
+    rdfs:label "Specific Epithet"@en ;
+    rdfs:comment "The name of the first or species epithet of the dwc:scientificName."@en ;
+    skos:definition "The name of the first or species epithet of the dwc:scientificName."@en ;
+    skos:prefLabel "Specific Epithet"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/startDayOfYear>
+    rdfs:label "Start Day Of Year"@en ;
+    dcterms:description "The value is 1 for January 1 and 365 for December 31, except in a leap year, in which case it is 366."@en ;
+    rdfs:comment "The earliest integer day of the year on which a dwc:Event occurred."@en ;
+    skos:definition "The earliest integer day of the year on which a dwc:Event occurred."@en ;
+    skos:prefLabel "Start Day Of Year"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/stateProvince>
+    rdfs:label "First Order Division"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
+    rdfs:comment "The name of the next smaller administrative region than country (state, province, canton, department, region, etc.) in which the dcterms:Location occurs."@en ;
+    skos:definition "The name of the next smaller administrative region than country (state, province, canton, department, region, etc.) in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "First Order Division"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/subfamily>
+    rdfs:label "Subfamily"@en ;
+    rdfs:comment "The full scientific name of the subfamily in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the subfamily in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Subfamily"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/subgenus>
+    rdfs:label "Subgenus"@en ;
+    dcterms:description "A value for this term should be a complete subgenus name as required by the appropriate nomenclatural code."@en ;
+    rdfs:comment "The full scientific name of the subgenus in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the subgenus in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Subgenus"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/subtribe>
+    rdfs:label "Subtribe"@en ;
+    rdfs:comment "The full scientific name of the subtribe in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the subtribe in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Subtribe"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/superfamily>
+    rdfs:label "Superfamily"@en ;
+    dcterms:description "A taxonomic category subordinate to an order and superior to a family. According to ICZN article 29.2, the suffix `-oidea` is used for a superfamily name."@en ;
+    rdfs:comment "The full scientific name of the superfamily in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the superfamily in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Superfamily"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonAccordingTo>
+    rdfs:label "Taxon According To"@en ;
+    rdfs:comment "Information about the authorship of this taxon concept which uses the scientificName in their sense (secundum, sensu). Could be a publication (identification key), institution or team of individuals."@en ;
+    skos:definition "Information about the authorship of this taxon concept which uses the scientificName in their sense (secundum, sensu). Could be a publication (identification key), institution or team of individuals."@en ;
+    skos:prefLabel "Taxon According To"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonAttributes>
+    rdfs:label "Taxon Attributes"@en ;
+    dcterms:description "Example: \"iucnstatus=vulnerable; distribution=Neuquen, Argentina\""@en ;
+    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the taxon."@en ;
+    skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the taxon."@en ;
+    skos:prefLabel "Taxon Attributes"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonConceptID>
+    rdfs:label "Taxon Concept ID"@en ;
+    rdfs:comment "An identifier for the taxonomic concept to which the record refers - not for the nomenclatural details of a dwc:Taxon."@en ;
+    skos:definition "An identifier for the taxonomic concept to which the record refers - not for the nomenclatural details of a dwc:Taxon."@en ;
+    skos:prefLabel "Taxon Concept ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonFormula>
+    rdfs:label "Taxon Formula"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
+    rdfs:comment "A string representing the pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
+    skos:definition "A string representing the pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
+    skos:prefLabel "Taxon Formula"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonID>
+    rdfs:label "Taxon ID"@en ;
+    rdfs:comment "An identifier for a dwc:Taxon."@en ;
+    skos:definition "An identifier for a dwc:Taxon."@en ;
+    skos:prefLabel "Taxon ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonNameID>
+    rdfs:label "Taxon Name ID"@en ;
+    rdfs:comment "A unique identifier for the scientificName."@en ;
+    skos:definition "A unique identifier for the scientificName."@en ;
+    skos:prefLabel "Taxon Name ID"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonRank>
+    rdfs:label "Taxon Rank"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. The taxon ranks of algae, fungi and plants are defined in the International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code Articles H3.2, H4.4 and H.3.1)."@en ;
+    rdfs:comment "The taxonomic rank of the most specific name in the dwc:scientificName."@en ;
+    skos:definition "The taxonomic rank of the most specific name in the dwc:scientificName."@en ;
+    skos:prefLabel "Taxon Rank"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonRemarks>
+    rdfs:label "Taxon Remarks"@en ;
+    rdfs:comment "Comments or notes about the taxon or name."@en ;
+    skos:definition "Comments or notes about the taxon or name."@en ;
+    skos:prefLabel "Taxon Remarks"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/taxonomicStatus>
+    rdfs:label "Taxonomic Status"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
+    rdfs:comment "The status of the use of the dwc:scientificName as a label for a taxon. Requires taxonomic opinion to define the scope of a dwc:Taxon. Rules of priority then are used to define the taxonomic status of the nomenclature contained in that scope, combined with the experts opinion. It must be linked to a specific taxonomic reference that defines the concept."@en ;
+    skos:definition "The status of the use of the dwc:scientificName as a label for a taxon. Requires taxonomic opinion to define the scope of a dwc:Taxon. Rules of priority then are used to define the taxonomic status of the nomenclature contained in that scope, combined with the experts opinion. It must be linked to a specific taxonomic reference that defines the concept."@en ;
+    skos:prefLabel "Taxonomic Status"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/tribe>
+    rdfs:label "Tribe"@en ;
+    rdfs:comment "The full scientific name of the tribe in which the dwc:Taxon is classified."@en ;
+    skos:definition "The full scientific name of the tribe in which the dwc:Taxon is classified."@en ;
+    skos:prefLabel "Tribe"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/typeOfType>
+    rdfs:label "Type Of Type"@en ;
+    dcterms:description "The term dwc:typeOfType must be used in combination with dwc:typifiedName. Together they make up the type status of a specimen. Note that relatively very few specimens are nomenclatural types (types of names), so in most cases this term will have no value. Unlike dwc:typeStatus, dwc:typeOfType can only have a single value. Recommended best practice is to use a controlled vocabulary such as the GBIF Nomenclatural Type Status Vocabulary. This term has an equivalent in the tcs: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A category of nomenclatural type of a dwc:MaterialEntity."@en ;
+    skos:definition "A category of nomenclatural type of a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Type Of Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/typeStatus>
+    rdfs:label "Type Status"@en ;
+    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A list (concatenated and separated) of nomenclatural types (type status, typified scientific name, publication) applied to the subject."@en ;
+    skos:definition "A list (concatenated and separated) of nomenclatural types (type status, typified scientific name, publication) applied to the subject."@en ;
+    skos:prefLabel "Type Status"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/typifiedName>
+    rdfs:label "Typified Name"@en ;
+    dcterms:description "The term dwc:typifiedName must be used in combination with dwc:typeOfType. Together they make up the type status of a specimen. Note that relatively very few specimens are nomenclatural types (types of names), so in most cases this term will have no value. Unlike dwc:typeStatus, dwc:typifiedName can only have a single value, so a dwc:MaterialEntity can only have a single dwc:typifiedName."@en ;
+    rdfs:comment "A scientific name for which a specimen or other name is the type."@en ;
+    skos:definition "A scientific name for which a specimen or other name is the type."@en ;
+    skos:prefLabel "Typified Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimAssertionType>
+    rdfs:label "Verbatim Assertion Type"@en ;
+    dcterms:description "This term is meant to allow the capture of an unaltered original name for a dwc:assertionType. This term is meant to be used in addition to dwc:assertionType, not instead of it."@en ;
+    rdfs:comment "A string representing the type of dwc:Assertion as it appeared in an original record."@en ;
+    skos:definition "A string representing the type of dwc:Assertion as it appeared in an original record."@en ;
+    skos:prefLabel "Verbatim Assertion Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimCoordinateSystem>
+    rdfs:label "Verbatim Coordinate System"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
+    skos:definition "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
+    skos:prefLabel "Verbatim Coordinate System"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimCoordinates>
+    rdfs:label "Verbatim Coordinates"@en ;
+    dcterms:description "The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in dwc:verbatimSRS and the coordinate system should be stored in dwc:verbatimCoordinateSystem."@en ;
+    rdfs:comment "Verbatim original spatial coordinates of a dcterms:Location."@en ;
+    skos:definition "Verbatim original spatial coordinates of a dcterms:Location."@en ;
+    skos:prefLabel "Verbatim Coordinates"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimDepth>
+    rdfs:label "Verbatim Depth"@en ;
+    rdfs:comment "The original description of the depth below the local surface."@en ;
+    skos:definition "The original description of the depth below the local surface."@en ;
+    skos:prefLabel "Verbatim Depth"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimElevation>
+    rdfs:label "Verbatim Elevation"@en ;
+    rdfs:comment "An original description of the elevation of a dcterms:Location."@en ;
+    skos:definition "An original description of the elevation of a dcterms:Location."@en ;
+    skos:prefLabel "Verbatim Elevation"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimEventDate>
+    rdfs:label "Verbatim EventDate"@en ;
+    rdfs:comment "The verbatim original representation of the date and time information for a dwc:Event."@en ;
+    skos:definition "The verbatim original representation of the date and time information for a dwc:Event."@en ;
+    skos:prefLabel "Verbatim EventDate"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimIdentification>
+    rdfs:label "Verbatim Identification"@en ;
+    dcterms:description "This term is meant to allow the capture of an unaltered original identification/determination, including identification qualifiers, hybrid formulas, uncertainties, etc. This term is meant to be used in addition to dwc:scientificName (and dwc:identificationQualifier etc.), not instead of it."@en ;
+    rdfs:comment "A string representing the taxonomic identification as it appeared in the original record."@en ;
+    skos:definition "A string representing the taxonomic identification as it appeared in the original record."@en ;
+    skos:prefLabel "Verbatim Identification"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimLabel>
+    rdfs:label "Verbatim Label"@en ;
+    dcterms:description "The content of this term should include no embellishments, prefixes, headers or other additions made to the text. Abbreviations must not be expanded and supposed misspellings must not be corrected. Lines or breakpoints between blocks of text that could be verified by seeing the original labels or images of them may be used. Examples of material entities include preserved specimens, fossil specimens, and material samples. Best practice is to use UTF-8 for all characters. Best practice is to add comment “verbatimLabel derived from human transcription” in dwc:materialEntityRemarks. Examples can be found at https://dwc.tdwg.org/examples/verbatimLabel."@en ;
+    rdfs:comment "A verbatim original representation of the written information affixed or related to a dwc:MaterialEntity."@en ;
+    skos:definition "A verbatim original representation of the written information affixed or related to a dwc:MaterialEntity."@en ;
+    skos:prefLabel "Verbatim Label"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimLatitude>
+    rdfs:label "Verbatim Latitude"@en ;
+    dcterms:description "The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in dwc:verbatimSRS and the coordinate system should be stored in dwc:verbatimCoordinateSystem."@en ;
+    rdfs:comment "A verbatim original latitude of a dcterms:Location."@en ;
+    skos:definition "A verbatim original latitude of a dcterms:Location."@en ;
+    skos:prefLabel "Verbatim Latitude"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimLocality>
+    rdfs:label "Verbatim Locality"@en ;
+    rdfs:comment "An original textual description of a dcterms:Location."@en ;
+    skos:definition "An original textual description of a dcterms:Location."@en ;
+    skos:prefLabel "Verbatim Locality"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimLongitude>
+    rdfs:label "Verbatim Longitude"@en ;
+    dcterms:description "The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in dwc:verbatimSRS and the coordinate system should be stored in dwc:verbatimCoordinateSystem."@en ;
+    rdfs:comment "A verbatim original longitude of a dcterms:Location."@en ;
+    skos:definition "A verbatim original longitude of a dcterms:Location."@en ;
+    skos:prefLabel "Verbatim Longitude"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimMeasurementType>
+    rdfs:label "Verbatim Measurement Type"@en ;
+    dcterms:description "This term is meant to allow the capture of an unaltered original name for a measurement or fact type. This term is meant to be used in addition to dwc:measurementType, not instead of it."@en ;
+    rdfs:comment "A string representing the type of measurement or fact as it appeared in the original record."@en ;
+    skos:definition "A string representing the type of measurement or fact as it appeared in the original record."@en ;
+    skos:prefLabel "Verbatim Measurement Type"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimSRS>
+    rdfs:label "Verbatim SRS"@en ;
+    dcterms:description "Recommended best practice is to use the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use the value `not recorded`. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
+    skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
+    skos:prefLabel "Verbatim SRS"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimScientificNameRank>
+    rdfs:label "Verbatim Scientific Name Rank"@en ;
+    dcterms:description "Examples: \"Agamospecies\", \"sub-lesus\", \"prole\", \"apomict\", \"nothogrex\"."@en ;
+    rdfs:comment "The taxonomic rank of the most specific name in the scientificName as it appears in the original record."@en ;
+    skos:definition "The taxonomic rank of the most specific name in the scientificName as it appears in the original record."@en ;
+    skos:prefLabel "Verbatim Scientific Name Rank"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verbatimTaxonRank>
+    rdfs:label "Verbatim Taxon Rank"@en ;
+    rdfs:comment "The taxonomic rank of the most specific name in the dwc:scientificName as it appears in the original record."@en ;
+    skos:definition "The taxonomic rank of the most specific name in the dwc:scientificName as it appears in the original record."@en ;
+    skos:prefLabel "Verbatim Taxon Rank"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/vernacularName>
+    rdfs:label "Vernacular Name"@en ;
+    rdfs:comment "A common or vernacular name."@en ;
+    skos:definition "A common or vernacular name."@en ;
+    skos:prefLabel "Vernacular Name"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/verticalDatum>
+    rdfs:label "Vertical Datum"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
+    skos:definition "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
+    skos:prefLabel "Vertical Datum"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/vitality>
+    rdfs:label "Vitality"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
+    rdfs:comment "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
+    skos:definition "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
+    skos:prefLabel "Vitality"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/waterBody>
+    rdfs:label "Water Body"@en ;
+    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
+    rdfs:comment "The name of the water body in which the dcterms:Location occurs."@en ;
+    skos:definition "The name of the water body in which the dcterms:Location occurs."@en ;
+    skos:prefLabel "Water Body"@en ;
+.
+
+<http://rs.tdwg.org/dwc/terms/year>
+    rdfs:label "Year"@en ;
+    rdfs:comment "The four-digit year in which the dwc:Event occurred, according to the Common Era Calendar."@en ;
+    skos:definition "The four-digit year in which the dwc:Event occurred, according to the Common Era Calendar."@en ;
+    skos:prefLabel "Year"@en ;
 .

--- a/prez/reference_data/annotations/dwc-annotations.ttl
+++ b/prez/reference_data/annotations/dwc-annotations.ttl
@@ -3,3371 +3,2190 @@
 # Retrieved: 2026-07-20
 # Source content: CC BY 4.0, https://creativecommons.org/licenses/by/4.0/
 #
-PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 <http://rs.tdwg.org/dwc/iri/>
     rdfs:label "Darwin Core IRI-value Term Analogs"@en ;
-    dcterms:description "The terms on this list are intended to be used with IRI values."@en ;
-    skos:prefLabel "Darwin Core IRI-value Term Analogs"@en ;
+    skos:definition "The terms on this list are intended to be used with IRI values"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/assayType>
     rdfs:label "Assay Type (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
     skos:definition "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Assay Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/assertionBy>
     rdfs:label "Assertion By (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An IRI identifying a dcterms:Agent responsible for making a dwc:Assertion."@en ;
     skos:definition "An IRI identifying a dcterms:Agent responsible for making a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion By (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/assertionType>
     rdfs:label "Assertion Type (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:Assertion."@en ;
     skos:definition "A category that best matches the nature of a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/assertionUnit>
     rdfs:label "Assertion Unit (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.ontology-of-units-of-measure.org for SI units, derived units, or other non-SI units accepted for use within the SI. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A unit associated with the value in dwc:assertionValue."@en ;
     skos:definition "A unit associated with the value in dwc:assertionValue."@en ;
-    skos:prefLabel "Assertion Unit (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/assertionValue>
     rdfs:label "Assertion Value (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An asserted value."@en ;
     skos:definition "An asserted value."@en ;
-    skos:prefLabel "Assertion Value (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/behavior>
     rdfs:label "Behavior (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A behavior shown by a dwc:Organism."@en ;
     skos:definition "A behavior shown by a dwc:Organism."@en ;
-    skos:prefLabel "Behavior (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/caste>
     rdfs:label "Caste (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary that aligns best with a dwc:Taxon. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A social caste of a dwc:Organism."@en ;
     skos:definition "A social caste of a dwc:Organism."@en ;
-    skos:prefLabel "Caste (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/dataGeneralizations>
     rdfs:label "Data Generalizations (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
     skos:definition "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
-    skos:prefLabel "Data Generalizations (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/degreeOfEstablishment>
     rdfs:label "Degree of Establishment (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use IRIs from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/doe/. For details, refer to https://doi.org/10.3897/biss.3.38084 . Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
     skos:definition "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
-    skos:prefLabel "Degree of Establishment (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/discipline>
     rdfs:label "Discipline (IRI)"@en ;
-    dcterms:description "This term can be used to classify records according to branches of knowledge. Recommended best practice is to use a controlled vocabulary. Terms in the dwciri namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The primary branch or branches of knowledge represented by the record."@en ;
     skos:definition "The primary branch or branches of knowledge represented by the record."@en ;
-    skos:prefLabel "Discipline (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/disposition>
     rdfs:label "Disposition (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
     skos:definition "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
-    skos:prefLabel "Disposition (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/earliestGeochronologicalEra>
     rdfs:label "Earliest Geochronological Era"@en ;
-    dcterms:description "Recommended best practice is to use an IRI from a controlled vocabulary. A \"convenience property\" that replaces Darwin Core literal-value terms related to geological context. See Section 2.7.6 of the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the earliest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the earliest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Earliest Geochronological Era"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/establishmentMeans>
     rdfs:label "Establishment Means (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use IRIs from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/em/. For details, refer to https://doi.org/10.3897/biss.3.38084 . Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
     skos:definition "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
-    skos:prefLabel "Establishment Means (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/eventCategory>
     rdfs:label "Event Category (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A broad category that best matches the nature of a dwc:Event."@en ;
     skos:definition "A broad category that best matches the nature of a dwc:Event."@en ;
-    skos:prefLabel "Event Category (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/eventType>
     rdfs:label "Event Type (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A narrow category that best matches the nature of a dwc:Event."@en ;
     skos:definition "A narrow category that best matches the nature of a dwc:Event."@en ;
-    skos:prefLabel "Event Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/fieldNotes>
     rdfs:label "Field Notes (IRI)"@en ;
-    dcterms:description "The subject is a dwc:Event instance and the object is a (possibly IRI-identified) resource that is the field notes."@en ;
-    rdfs:comment "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
     skos:definition "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
-    skos:prefLabel "Field Notes (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/fieldNumber>
     rdfs:label "Field Number (IRI)"@en ;
-    dcterms:description "Often serves as a link between field notes and a dwc:Event. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An identifier given to a dwc:Event in the field."@en ;
     skos:definition "An identifier given to a dwc:Event in the field."@en ;
-    skos:prefLabel "Field Number (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/footprintSRS>
     rdfs:label "Footprint SRS (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use an IRI for the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary IRI for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary IRI for the name or code of the ellipsoid, if known. Otherwise use an IRI for the value corresponding to `not recorded`."@en ;
-    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
     skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
-    skos:prefLabel "Footprint SRS (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/footprintWKT>
     rdfs:label "Footprint WKT (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines the dcterms:Location. A dcterms:Location may have both a point-radius representation (see dwc:decimalLatitude) and a footprint representation, and they may differ from each other."@en ;
     skos:definition "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines the dcterms:Location. A dcterms:Location may have both a point-radius representation (see dwc:decimalLatitude) and a footprint representation, and they may differ from each other."@en ;
-    skos:prefLabel "Footprint WKT (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/fromLithostratigraphicUnit>
     rdfs:label "From Lithostratigraphic Unit"@en ;
-    dcterms:description "Recommended best practice is to use an IRI from a controlled vocabulary. A \"convenience property\" that replaces Darwin Core literal-value terms related to geological context. See Section 2.7.7 of the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link a dwc:GeologicalContext instance to an IRI-identified lithostratigraphic unit at the lowest possible level in a hierarchy."@en ;
     skos:definition "Use to link a dwc:GeologicalContext instance to an IRI-identified lithostratigraphic unit at the lowest possible level in a hierarchy."@en ;
-    skos:prefLabel "From Lithostratigraphic Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/fundingAttribution>
     rdfs:label "Funding Attribution (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An organization or agency that provided funding for a project."@en ;
     skos:definition "An organization or agency that provided funding for a project."@en ;
-    skos:prefLabel "Funding Attribution (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/geodeticDatum>
     rdfs:label "Geodetic Datum (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use an IRI for the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use an IRI corresponding to the value `not recorded`."@en ;
-    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
     skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
-    skos:prefLabel "Geodetic Datum (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/georeferenceProtocol>
     rdfs:label "Georeference Protocol (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
     skos:definition "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
-    skos:prefLabel "Georeference Protocol (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/georeferenceSources>
     rdfs:label "Georeference Sources (IRI)"@en ;
-    dcterms:description "Recommended best practice is describe a georeference with no more than one sampled georeference source. In the case of a georeference that cannot be attributed to a specific source, the recommended best practice is to repeat the property for each IRI that denotes a different source that applies to the georeference. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An IRI for a map, gazetteer, or other resource used to georeference a dcterms:Location."@en ;
     skos:definition "An IRI for a map, gazetteer, or other resource used to georeference a dcterms:Location."@en ;
-    skos:prefLabel "Georeference Sources (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/georeferenceVerificationStatus>
     rdfs:label "Georeference Verification Status (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
     skos:definition "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
-    skos:prefLabel "Georeference Verification Status (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/georeferencedBy>
     rdfs:label "Georeferenced By (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An IRI identifying a dcterms:Agent responsible for providing a georeference."@en ;
     skos:definition "An IRI identifying a dcterms:Agent responsible for providing a georeference."@en ;
-    skos:prefLabel "Georeferenced By (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/habitat>
     rdfs:label "Habitat (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A category or description of the habitat in which the dwc:Event occurred."@en ;
     skos:definition "A category or description of the habitat in which the dwc:Event occurred."@en ;
-    skos:prefLabel "Habitat (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/identificationQualifier>
     rdfs:label "Identification Qualifier (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A controlled value to express the determiner's doubts about the dwc:Identification."@en ;
     skos:definition "A controlled value to express the determiner's doubts about the dwc:Identification."@en ;
-    skos:prefLabel "Identification Qualifier (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/identificationType>
     rdfs:label "Identification Type (IRI)"@en ;
-    dcterms:description "The evidentiary basis, analytical approach, or inferential method by which an identification was determined. Values describe the dominant source of information supporting the identification (e.g., morphology, geography, molecular data, functional attributes, relationships, or taxonomic revision), independent of confidence level or taxonomic outcome. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:Identification."@en ;
     skos:definition "A category that best matches the nature of a dwc:Identification."@en ;
-    skos:prefLabel "Identification Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/identificationVerificationStatus>
     rdfs:label "Identification Verification Status (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as that used in HISPID and ABCD. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
     skos:definition "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
-    skos:prefLabel "Identification Verification Status (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/identifiedBy>
     rdfs:label "Identified By (IRI)"@en ;
-    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An IRI identifying a dcterms:Agent responsible for making a dwc:Identification."@en ;
     skos:definition "An IRI identifying a dcterms:Agent responsible for making a dwc:Identification."@en ;
-    skos:prefLabel "Identified By (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/inCollection>
     rdfs:label "In Collection"@en ;
-    dcterms:description "Recommended best practice is to use an IRI from a controlled registry. A \"convenience property\" that replaces literal-value terms related to collections and institutions. See Section 2.7.3 of the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link any subject resource that is part of a collection to the collection containing the resource."@en ;
     skos:definition "Use to link any subject resource that is part of a collection to the collection containing the resource."@en ;
-    skos:prefLabel "In Collection"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/inDataset>
     rdfs:label "In Dataset"@en ;
-    dcterms:description "A string literal name of the dataset can be provided using the term dwc:datasetName. See the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link a subject dataset record to the dataset which contains it."@en ;
     skos:definition "Use to link a subject dataset record to the dataset which contains it."@en ;
-    skos:prefLabel "In Dataset"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/inDescribedPlace>
     rdfs:label "In Described Place"@en ;
-    dcterms:description "Recommended best practice is to use an IRI from a controlled registry. A \"convenience property\" that replaces Darwin Core literal-value terms related to locations. See Section 2.7.5 of the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link a dcterms:Location instance subject to the lowest level standardized hierarchically-described resource."@en ;
     skos:definition "Use to link a dcterms:Location instance subject to the lowest level standardized hierarchically-described resource."@en ;
-    skos:prefLabel "In Described Place"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/informationWithheld>
     rdfs:label "Information Withheld (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
     skos:definition "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
-    skos:prefLabel "Information Withheld (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/latestGeochronologicalEra>
     rdfs:label "Latest Geochronological Era"@en ;
-    dcterms:description "Recommended best practice is to use an IRI from a controlled vocabulary. A \"convenience property\" that replaces Darwin Core literal-value terms related to geological context. See Section 2.7.6 of the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the latest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "Use to link a dwc:GeologicalContext instance to chronostratigraphic time periods at the lowest possible level in a standardized hierarchy. Use this property to point to the latest possible geological time period from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Latest Geochronological Era"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/lifeStage>
     rdfs:label "Life Stage (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An age class or life stage of a dwc:Organism."@en ;
     skos:definition "An age class or life stage of a dwc:Organism."@en ;
-    skos:prefLabel "Life Stage (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/locationAccordingTo>
     rdfs:label "Location According To (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
     skos:definition "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
-    skos:prefLabel "Location According To (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/materialEntityCategory>
     rdfs:label "Material Entity Category (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
     skos:definition "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Material Entity Category (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/materialEntityType>
     rdfs:label "Material Entity Type (IRI)"@en ;
-    dcterms:description "A more generic classification of a dwc:MaterialEntity than dwc:preparations. Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
     skos:definition "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
-    skos:prefLabel "Material Entity Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/measurementDeterminedBy>
     rdfs:label "Measurement Determined By (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A person, group, or organization who determined the value of the dwc:MeasurementOrFact."@en ;
     skos:definition "A person, group, or organization who determined the value of the dwc:MeasurementOrFact."@en ;
-    skos:prefLabel "Measurement Determined By (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/measurementMethod>
     rdfs:label "Measurement Method (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
     skos:definition "The method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
-    skos:prefLabel "Measurement Method (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/measurementType>
     rdfs:label "Measurement Type (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The nature of the measurement, fact, characteristic, or assertion."@en ;
     skos:definition "The nature of the measurement, fact, characteristic, or assertion."@en ;
-    skos:prefLabel "Measurement Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/measurementUnit>
     rdfs:label "Measurement Unit (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.wurvoc.org/vocabularies/om-1.8/ of SI units, derived units, or other non-SI units accepted for use within the SI."@en ;
-    rdfs:comment "The units associated with the dwc:measurementValue."@en ;
     skos:definition "The units associated with the dwc:measurementValue."@en ;
-    skos:prefLabel "Measurement Unit (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/measurementValue>
     rdfs:label "Measurement Value (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The value of the measurement, fact, characteristic, or assertion."@en ;
     skos:definition "The value of the measurement, fact, characteristic, or assertion."@en ;
-    skos:prefLabel "Measurement Value (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/objectQuantityType>
     rdfs:label "Object Quantity Type (IRI)"@en ;
-    dcterms:description "An dwc:objectQuantityType must have a corresponding dwc:objectQuantity. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
     skos:definition "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
-    skos:prefLabel "Object Quantity Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/occurrenceStatus>
     rdfs:label "Occurrence Status (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
     skos:definition "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
-    skos:prefLabel "Occurrence Status (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/organismInteractionType>
     rdfs:label "Organism Interaction Type (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
     skos:definition "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
-    skos:prefLabel "Organism Interaction Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/organismQuantityType>
     rdfs:label "Organism Quantity Type (IRI)"@en ;
-    dcterms:description "A dwc:organismQuantityType must have a corresponding dwc:organismQuantity."@en ;
-    rdfs:comment "The type of quantification system used for the quantity of organisms."@en ;
     skos:definition "The type of quantification system used for the quantity of organisms."@en ;
-    skos:prefLabel "Organism Quantity Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/organismScope>
     rdfs:label "Organism Scope (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term is not intended to be used to specify a type of dwc:Taxon. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
     skos:definition "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
-    skos:prefLabel "Organism Scope (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/pathway>
     rdfs:label "Pathway (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use IRIs from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/pw/. For details, refer to https://doi.org/10.3897/biss.3.38084 . Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
     skos:definition "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
-    skos:prefLabel "Pathway (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/preferredSpatialRepresentation>
     rdfs:label "Preferred Spatial Representation (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An indication of which spatial representation best represents the dcterms:Location."@en ;
     skos:definition "An indication of which spatial representation best represents the dcterms:Location."@en ;
-    skos:prefLabel "Preferred Spatial Representation (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/preparations>
     rdfs:label "Preparations (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A preparation or preservation method for a specimen."@en ;
     skos:definition "A preparation or preservation method for a specimen."@en ;
-    skos:prefLabel "Preparations (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/protocolType>
     rdfs:label "Protocol Type (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:Protocol."@en ;
     skos:definition "A category that best matches the nature of a dwc:Protocol."@en ;
-    skos:prefLabel "Protocol Type (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/recordNumber>
     rdfs:label "Record Number (IRI)"@en ;
-    dcterms:description "The subject is a dwc:Occurrence and the object is a (possibly IRI-identified) resource that is the field notes."@en ;
-    rdfs:comment "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
     skos:definition "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
-    skos:prefLabel "Record Number (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/recordedBy>
     rdfs:label "Recorded By (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An IRI identifying a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
     skos:definition "An IRI identifying a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
-    skos:prefLabel "Recorded By (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/reproductiveCondition>
     rdfs:label "Reproductive Condition (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A reproductive condition of a dwc:Organism."@en ;
     skos:definition "A reproductive condition of a dwc:Organism."@en ;
-    skos:prefLabel "Reproductive Condition (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/sampleSizeUnit>
     rdfs:label "Sampling Size Unit (IRI)"@en ;
-    dcterms:description "A dwciri:sampleSizeUnit must have a corresponding dwc:sampleSizeValue. Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.wurvoc.org/vocabularies/om-1.8/ of SI units, derived units, or other non-SI units accepted for use within the SI."@en ;
-    rdfs:comment "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
     skos:definition "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
-    skos:prefLabel "Sampling Size Unit (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/sampledSubstrateCategory>
     rdfs:label "Sampled Substrate Category (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A category or type of substrate sampled during a dwc:Event."@en ;
     skos:definition "A category or type of substrate sampled during a dwc:Event."@en ;
-    skos:prefLabel "Sampled Substrate Category (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/sampledSubstrateLayer>
     rdfs:label "Sampled Substrate Layer (IRI)"@en ;
-    dcterms:description "Recommended best practice is describe a dwc:Event with no more than one sampled substrate layer. In the case of a dwc:Event that cannot be attributed to a specific layer, the recommended best practice is to repeat the property for each IRI that denotes a different layer that applies to the dwc:Event. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An IRI identifying a substrate layer sampled during a dwc:Event."@en ;
     skos:definition "An IRI identifying a substrate layer sampled during a dwc:Event."@en ;
-    skos:prefLabel "Sampled Substrate Layer (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/samplingProtocol>
     rdfs:label "Sampling Protocol (IRI)"@en ;
-    dcterms:description "Recommended best practice is to describe a dwc:Event with no more than one sampling protocol. In the case of a summary dwc:Event in which a specific protocol can not be attributed to specific dwc:Occurrences, the recommended best practice is to repeat the property for each IRI that denotes a different sampling protocol that applies to the dwc:Occurrence."@en ;
-    rdfs:comment "The methods or protocols used during a dwc:Event, denoted by an IRI."@en ;
     skos:definition "The methods or protocols used during a dwc:Event, denoted by an IRI."@en ;
-    skos:prefLabel "Sampling Protocol (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/sex>
     rdfs:label "Sex (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A sex of a dwc:Organism."@en ;
     skos:definition "A sex of a dwc:Organism."@en ;
-    skos:prefLabel "Sex (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/siteNumber>
     rdfs:label "Site Number (IRI)"@en ;
-    dcterms:description "Usually an institutional identifier for a specific named place as opposed to dwc:locationID, which is an identifier for the entire set of distinct information for an instance of dcterms:Location. This term differs from dwciri:fieldNumber in that dwciri:siteNumber is not related strictly to one dwc:Event. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An identifier for a named site."@en ;
     skos:definition "An identifier for a named site."@en ;
-    skos:prefLabel "Site Number (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/taxonFormula>
     rdfs:label "Taxon Formula (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
     skos:definition "A pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
-    skos:prefLabel "Taxon Formula (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/toDigitalSpecimen>
     rdfs:label "To Digital Specimen"@en ;
-    dcterms:description "Use to link a dwc:MaterialEntity instance subject to a Digital Specimem entity."@en ;
-    rdfs:comment "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
     skos:definition "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
-    skos:prefLabel "To Digital Specimen"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/toTaxon>
     rdfs:label "To Taxon"@en ;
-    dcterms:description "A \"convenience property\" that replaces Darwin Core literal-value terms related to taxonomic entities. See Section 2.7.4 of the Darwin Core RDF Guide for details."@en ;
-    rdfs:comment "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
     skos:definition "Use to link a dwc:Identification instance subject to a taxonomic entity such as a taxon, taxon concept, or taxon name use."@en ;
-    skos:prefLabel "To Taxon"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/typeStatus>
     rdfs:label "Type Status (IRI)"@en ;
-    dcterms:description "Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A nomenclatural type (type status, typified scientific name, publication) applied to the subject."@en ;
     skos:definition "A nomenclatural type (type status, typified scientific name, publication) applied to the subject."@en ;
-    skos:prefLabel "Type Status (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/verbatimCoordinateSystem>
     rdfs:label "Verbatim Coordinate System (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
     skos:definition "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
-    skos:prefLabel "Verbatim Coordinate System (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/verbatimSRS>
     rdfs:label "Verbatim SRS (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use an IRI for the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary IRI for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary IRI for the name or code of the ellipsoid, if known. Otherwise use an IRI for the value corresponding to `not recorded`."@en ;
-    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
     skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
-    skos:prefLabel "Verbatim SRS (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/verticalDatum>
     rdfs:label "Vertical Datum (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
     skos:definition "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
-    skos:prefLabel "Vertical Datum (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/iri/vitality>
     rdfs:label "Vitality (IRI)"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. Terms in the dwciri: namespace are intended to be used in RDF with non-literal objects."@en ;
-    rdfs:comment "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
     skos:definition "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
-    skos:prefLabel "Vitality (IRI)"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/>
     rdfs:label "Core terms defined by Darwin Core"@en ;
-    dcterms:description "This term list includes all currently valid terms that have been defined in the core Darwin Core namespace dwc:."@en ;
-    skos:prefLabel "Core terms defined by Darwin Core"@en ;
+    skos:definition "This term list includes all currently valid terms that have been defined in the core Darwin Core namespace dwc:.  To comment on this schema, please create a new issue in https://github.com/tdwg/dwc/issues"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/AcceptedTaxon>
     rdfs:label "Accepted Taxon"@en ;
-    rdfs:comment "The currently valid (zoological) or accepted (botanical) name for the ScientificName."@en ;
     skos:definition "The currently valid (zoological) or accepted (botanical) name for the ScientificName."@en ;
-    skos:prefLabel "Accepted Taxon"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/AcceptedTaxonID>
     rdfs:label "Accepted Taxon ID"@en ;
-    rdfs:comment "A global unique identifier for the parent to the AcceptedTaxon."@en ;
     skos:definition "A global unique identifier for the parent to the AcceptedTaxon."@en ;
-    skos:prefLabel "Accepted Taxon ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/AccessConstraints>
     rdfs:label "Access Constraints"@en ;
-    dcterms:description "Example: \"not-for-profit use only\"."@en ;
-    rdfs:comment "A description of constraints on the use of the data as shared or access to further data that is not shared."@en ;
     skos:definition "A description of constraints on the use of the data as shared or access to further data that is not shared."@en ;
-    skos:prefLabel "Access Constraints"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Assertion>
     rdfs:label "Assertion"@en ;
-    dcterms:description "Resources can be thought of as identifiable records or instances of classes and may include, but need not be limited to instances of dwc:Occurrence, dwc:Organism, dwc:MaterialEntity, dwc:Event, dcterms:Location, dwc:GeologicalContext, dwc:Identification, or dwc:Taxon."@en ;
-    rdfs:comment "A statement about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
     skos:definition "A statement about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
-    skos:prefLabel "Assertion"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/CatalogNumberNumeric>
     rdfs:label "Catalog Number Numeric"@en ;
-    rdfs:comment "The numeric value of the catalogNumber, used to facilitate numerical sorting and searching by ranges."@en ;
     skos:definition "The numeric value of the catalogNumber, used to facilitate numerical sorting and searching by ranges."@en ;
-    skos:prefLabel "Catalog Number Numeric"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Dataset>
     rdfs:label "Dataset"@en ;
-    rdfs:comment "The category of information pertaining to a logical set of records."@en ;
     skos:definition "The category of information pertaining to a logical set of records."@en ;
-    skos:prefLabel "Dataset"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/DwCType>
     rdfs:label "Darwin Core Type"@en ;
-    rdfs:comment "The set of classes specified by the Darwin Core Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
     skos:definition "The set of classes specified by the Darwin Core Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
-    skos:prefLabel "Darwin Core Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EarliestDateCollected>
     rdfs:label "Earliest Date Collected"@en ;
-    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-    rdfs:comment "The earliest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
     skos:definition "The earliest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
-    skos:prefLabel "Earliest Date Collected"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EndTimeOfDay>
     rdfs:label "End Time of Day"@en ;
-    dcterms:description "Examples: \"12.0\" (= noon), \"13.5\" (= 1:30pm)"@en ;
-    rdfs:comment "The time of day when the event ended, expressed as decimal hours from midnight, local time."@en ;
     skos:definition "The time of day when the event ended, expressed as decimal hours from midnight, local time."@en ;
-    skos:prefLabel "End Time of Day"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Event>
     rdfs:label "Event"@en ;
-    rdfs:comment "An action, process, or set of circumstances occurring at a dcterms:Location during a period of time."@en ;
     skos:definition "An action, process, or set of circumstances occurring at a dcterms:Location during a period of time."@en ;
-    skos:prefLabel "Event"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttribute>
     rdfs:label "Event Attribute"@en ;
-    rdfs:comment "Container class for information about attributes related to a given sampling event."@en ;
     skos:definition "Container class for information about attributes related to a given sampling event."@en ;
-    skos:prefLabel "Event Attribute"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeAccuracy>
     rdfs:label "Event Attribute Accuracy"@en ;
-    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
-    rdfs:comment "The description of the error associated with the EventAttributeValue."@en ;
     skos:definition "The description of the error associated with the EventAttributeValue."@en ;
-    skos:prefLabel "Event Attribute Accuracy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeDeterminedBy>
     rdfs:label "Event Attribute Determined By"@en ;
-    dcterms:description "Example: \"Robert Hijmans\""@en ;
-    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the sampling event."@en ;
     skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the sampling event."@en ;
-    skos:prefLabel "Event Attribute Determined By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeDeterminedDate>
     rdfs:label "Event Attribute Determined Date"@en ;
-    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-    rdfs:comment "The date on which the the measurement or characteristic of the sampling event was made."@en ;
     skos:definition "The date on which the the measurement or characteristic of the sampling event was made."@en ;
-    skos:prefLabel "Event Attribute Determined Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeID>
     rdfs:label "Event Attribute ID"@en ;
-    rdfs:comment "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Event Attribute ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeRemarks>
     rdfs:label "Event Attribute Remarks"@en ;
-    dcterms:description "Example: \"temperature taken at 15:00\""@en ;
-    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the sampling event."@en ;
     skos:definition "Comments or notes accompanying the measurement or characteristic of the sampling event."@en ;
-    skos:prefLabel "Event Attribute Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeType>
     rdfs:label "Event Attribute Type"@en ;
-    dcterms:description "Example: \"Temperature\""@en ;
-    rdfs:comment "The nature of the measurement or characteristic of the sampling event. Recommended best practice is to use a controlled vocabulary."@en ;
     skos:definition "The nature of the measurement or characteristic of the sampling event. Recommended best practice is to use a controlled vocabulary."@en ;
-    skos:prefLabel "Event Attribute Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeUnit>
     rdfs:label "Event Attribute Unit"@en ;
-    dcterms:description "Example: \"C\""@en ;
-    rdfs:comment "The units for the value of the measurement or characteristic of the sampling event. Recommended best practice is to use International System of Units (SI) units."@en ;
     skos:definition "The units for the value of the measurement or characteristic of the sampling event. Recommended best practice is to use International System of Units (SI) units."@en ;
-    skos:prefLabel "Event Attribute Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventAttributeValue>
     rdfs:label "Event Attribute"@en ;
-    dcterms:description "Example: \"22\""@en ;
-    rdfs:comment "The value of the measurement or characteristic of the sampling event."@en ;
     skos:definition "The value of the measurement or characteristic of the sampling event."@en ;
-    skos:prefLabel "Event Attribute"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/EventMeasurement>
     rdfs:label "Event Measurement"@en ;
-    rdfs:comment "The category of information pertaining to measurements associated with an event."@en ;
     skos:definition "The category of information pertaining to measurements associated with an event."@en ;
-    skos:prefLabel "Event Measurement"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/FossilSpecimen>
     rdfs:label "Fossil Specimen"@en ;
-    rdfs:comment "A preserved specimen that is a fossil."@en ;
     skos:definition "A preserved specimen that is a fossil."@en ;
-    skos:prefLabel "Fossil Specimen"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Generalizations>
     rdfs:label "Generalizations"@en ;
-    dcterms:description "Examples: \"Coordinates generalized from original GPS coordinates to the nearest half degree grid cell\", \"locality information given only to nearest county\"."@en ;
-    rdfs:comment "Actions taken to make the data as shared less specific or complete than in its original form. Suggests that alternative data of highly quality may be available on request."@en ;
     skos:definition "Actions taken to make the data as shared less specific or complete than in its original form. Suggests that alternative data of highly quality may be available on request."@en ;
-    skos:prefLabel "Generalizations"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/GeologicalContext>
     rdfs:label "Geological Context"@en ;
-    rdfs:comment "A set of geological designations, such as stratigraphy, that qualifies a dcterms:Location or source of a dwc:MaterialEntity."@en ;
     skos:definition "A set of geological designations, such as stratigraphy, that qualifies a dcterms:Location or source of a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Geological Context"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/HigherTaxon>
     rdfs:label "Higher Taxon"@en ;
-    dcterms:description "Example: \"Animalia, Chordata, Vertebrata, Mammalia, Theria, Eutheria, Rodentia, Hystricognatha, Hystricognathi, Ctenomyidae, Ctenomyini, Ctenomys\"."@en ;
-    rdfs:comment "A list (concatenated and separated) of the names for the taxonomic ranks less specific than the ScientificName."@en ;
     skos:definition "A list (concatenated and separated) of the names for the taxonomic ranks less specific than the ScientificName."@en ;
-    skos:prefLabel "Higher Taxon"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/HigherTaxonID>
     rdfs:label "Higher Taxon ID"@en ;
-    rdfs:comment "A global unique identifier for the parent to the taxon."@en ;
     skos:definition "A global unique identifier for the parent to the taxon."@en ;
-    skos:prefLabel "Higher Taxon ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/HumanObservation>
     rdfs:label "Human Observation"@en ;
-    rdfs:comment "An output of a human observation process."@en ;
     skos:definition "An output of a human observation process."@en ;
-    skos:prefLabel "Human Observation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Identification>
     rdfs:label "Identification"@en ;
-    dcterms:description "For biology, the assignment of a scientific name or taxon concept to a dwc:Organism."@en ;
-    rdfs:comment "A classification of a resource according to a classification scheme."@en ;
     skos:definition "A classification of a resource according to a classification scheme."@en ;
-    skos:prefLabel "Identification"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/LatestDateCollected>
     rdfs:label "Latest Date Collected"@en ;
-    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-    rdfs:comment "The latest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
     skos:definition "The latest date-time in a period during which a event occurred. If the event is recorded as occurring at a single date-time, populate both EarliestDateCollected and LatestDateCollected with the same value. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
-    skos:prefLabel "Latest Date Collected"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/LivingSpecimen>
     rdfs:label "Living Specimen"@en ;
-    rdfs:comment "A specimen that is alive."@en ;
     skos:definition "A specimen that is alive."@en ;
-    skos:prefLabel "Living Specimen"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/MachineObservation>
     rdfs:label "Machine Observation"@en ;
-    rdfs:comment "An output of a machine observation process."@en ;
     skos:definition "An output of a machine observation process."@en ;
-    skos:prefLabel "Machine Observation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/MaterialCitation>
     rdfs:label "Material Citation"@en ;
-    dcterms:description "This class constitutes a new value for the controlled vocabulary in the recommendations for basisOfRecord. When importing Darwin Core Archives of literature-based datasets to GBIF, the basisOfRecord should be changed from \"Occurrence\", \"PreservedSpecimen\" or \"Literature\" to \"MaterialCitation\"."@en ;
-    rdfs:comment "A reference to or citation of one, a part of, or multiple specimens in scholarly publications."@en ;
     skos:definition "A reference to or citation of one, a part of, or multiple specimens in scholarly publications."@en ;
-    skos:prefLabel "Material Citation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/MaterialEntity>
     rdfs:label "Material Entity"@en ;
-    dcterms:description "The term is defined at the most general level to admit descriptions of any subtype of material entity within the scope of Darwin Core. In particular, any kind of material sample, preserved specimen, fossil, or exemplar from living collections is intended to be subsumed under this term. In Darwin Core, dwc:Organism, dwc:Occurrence, and dwc:MaterialEntity are related, but distinct concepts. A dwc:Organism is a biological individual or group with an identity and life history that persists independently of the particular dwc:MaterialEntities through which it is manifested. A dwc:Occurrence is a dwc:Event that represents the presence or state of a dwc:Organism at a place during an interval of time, with no explicit dependency on any dwc:MaterialEntity. A dwc:MaterialEntity represents physical matter, including whole bodies, parts, or derivatives of dwc:Organisms, that may directly or indirectly serve as evidence of a dwc:Occurrence."@en ;
-    rdfs:comment "An entity that can be identified, exists for some period of time, and consists in whole or in part of physical matter while it exists."@en ;
     skos:definition "An entity that can be identified, exists for some period of time, and consists in whole or in part of physical matter while it exists."@en ;
-    skos:prefLabel "Material Entity"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/MaterialSample>
     rdfs:label "Material Sample"@en ;
-    rdfs:comment "A material entity that represents an entity of interest in whole or in part."@en ;
     skos:definition "A material entity that represents an entity of interest in whole or in part."@en ;
-    skos:prefLabel "Material Sample"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/MeasurementOrFact>
     rdfs:label "Measurement Or Fact"@en ;
-    dcterms:description "Resources can be thought of as identifiable records or instances of classes and may include, but need not be limited to instances of dwc:Occurrence, dwc:Organism, dwc:MaterialEntity, dwc:Event, dcterms:Location, dwc:GeologicalContext, dwc:Identification, or dwc:Taxon."@en ;
-    rdfs:comment "A measurement of or fact about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
     skos:definition "A measurement of or fact about an rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource)."@en ;
-    skos:prefLabel "Measurement Or Fact"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/MolecularProtocol>
     rdfs:label "Molecular Protocol"@en ;
-    rdfs:comment "A protocol used to perform a dwc:NucleotideAnalysis and potentially derive a dwc:NucleotideSequence from a dwc:MaterialEntity."@en ;
     skos:definition "A protocol used to perform a dwc:NucleotideAnalysis and potentially derive a dwc:NucleotideSequence from a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Molecular Protocol"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/NucleotideAnalysis>
     rdfs:label "Nucleotide Analysis"@en ;
-    rdfs:comment "A link between a dwc:NucleotideSequence or a dwc:Identification and a dwc:Event and a dwc:MaterialEntity from which it was derived, using a specified dwc:Protocol."@en ;
     skos:definition "A link between a dwc:NucleotideSequence or a dwc:Identification and a dwc:Event and a dwc:MaterialEntity from which it was derived, using a specified dwc:Protocol."@en ;
-    skos:prefLabel "Nucleotide Analysis"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/NucleotideSequence>
     rdfs:label "Nucleotide Sequence"@en ;
-    rdfs:comment "A digital representation of a nucleotide sequence."@en ;
     skos:definition "A digital representation of a nucleotide sequence."@en ;
-    skos:prefLabel "Nucleotide Sequence"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Occurrence>
     rdfs:label "Occurrence"@en ;
-    dcterms:description "In Darwin Core, dwc:Organism, dwc:Occurrence, and dwc:MaterialEntity are related, but distinct concepts. A dwc:Organism is a biological individual or group with an identity and life history that persists independently of the particular dwc:MaterialEntities through which it is manifested. A dwc:Occurrence is a dwc:Event that represents the presence or state of a dwc:Organism at a place during an interval of time, with no explicit dependency on any dwc:MaterialEntity. A dwc:MaterialEntity represents physical matter, including whole bodies, parts, or derivatives of dwc:Organisms, that may directly or indirectly serve as evidence of a dwc:Occurrence."@en ;
-    rdfs:comment "A dwc:Event that establishes the state of a dwc:Organism at a particular place and time."@en ;
     skos:definition "A dwc:Event that establishes the state of a dwc:Organism at a particular place and time."@en ;
-    skos:prefLabel "Occurrence"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/OccurrenceMeasurement>
     rdfs:label "Occurrence Measurement"@en ;
-    rdfs:comment "The category of information pertaining to measurements accociated with an occurrence."@en ;
     skos:definition "The category of information pertaining to measurements accociated with an occurrence."@en ;
-    skos:prefLabel "Occurrence Measurement"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Organism>
     rdfs:label "Organism"@en ;
-    dcterms:description "Instances of the dwc:Organism class are intended to facilitate linking one or more dwc:Identification instances to one or more dwc:Occurrence instances. Therefore, things that are typically assigned scientific names (such as viruses, hybrids, and lichens) and aggregates whose dwc:Occurrences are typically recorded (such as packs, clones, and colonies) are included in the scope of this class. In Darwin Core, dwc:Organism, dwc:Occurrence, and dwc:MaterialEntity are related, but distinct concepts. A dwc:Organism is a biological individual or group with an identity and life history that persists independently of the particular dwc:MaterialEntities through which it is manifested. A dwc:Occurrence is a dwc:Event that represents the presence or state of a dwc:Organism at a place during an interval of time, with no explicit dependency on any dwc:MaterialEntity. A dwc:MaterialEntity represents physical matter, including whole bodies, parts, or derivatives of dwc:Organisms, that may directly or indirectly serve as evidence of a dwc:Occurrence."@en ;
-    rdfs:comment "A particular organism or defined group of organisms considered to be taxonomically homogeneous."@en ;
     skos:definition "A particular organism or defined group of organisms considered to be taxonomically homogeneous."@en ;
-    skos:prefLabel "Organism"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/OrganismInteraction>
     rdfs:label "Organism Interaction"@en ;
-    dcterms:description "Supports only primary observed interactions, not habitual or derived taxon-level interactions. Pairwise interactions must be used to represent multi-organism interactions. When possible, typify the action rather than the state from which an action is inferred, with the actor as the subject dwc:Occurrence and the acted-upon as the related dwc:Occurrence. Only one direction of a two-way interaction is necessary, though both are permissible as distinct OrganismInteractions with distinct subject dwc:Occurrences."@en ;
-    rdfs:comment "An interaction between two dwc:Organisms during a dwc:Event."@en ;
     skos:definition "An interaction between two dwc:Organisms during a dwc:Event."@en ;
-    skos:prefLabel "Organism Interaction"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/PreservedSpecimen>
     rdfs:label "Preserved Specimen"@en ;
-    rdfs:comment "A specimen that has been preserved."@en ;
     skos:definition "A specimen that has been preserved."@en ;
-    skos:prefLabel "Preserved Specimen"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/PreviousIdentifications>
     rdfs:label "Previous Identifications"@en ;
-    dcterms:description "Example: \"Anthus correndera\"."@en ;
-    rdfs:comment "A list (concatenated and separated) of previous ScientificNames to which the sample was identified."@en ;
     skos:definition "A list (concatenated and separated) of previous ScientificNames to which the sample was identified."@en ;
-    skos:prefLabel "Previous Identifications"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Protocol>
     rdfs:label "Protocol"@en ;
-    rdfs:comment "A method used during an action."@en ;
     skos:definition "A method used during an action."@en ;
-    skos:prefLabel "Protocol"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Provenance>
     rdfs:label "Provenance"@en ;
-    dcterms:description "This is a convenience class to group related properties."@en ;
-    rdfs:comment "Information about an entity’s origins."@en ;
     skos:definition "Information about an entity’s origins."@en ;
-    skos:prefLabel "Provenance"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/RelatedBasisOfRecord>
     rdfs:label "Related Basis of Record"@en ;
-    dcterms:description "Example: \"PreservedSpecimen\""@en ;
-    rdfs:comment "The nature of the related resource. Recommended best practice is to use the same controlled vocabulary as for basisOfRecord."@en ;
     skos:definition "The nature of the related resource. Recommended best practice is to use the same controlled vocabulary as for basisOfRecord."@en ;
-    skos:prefLabel "Related Basis of Record"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/ResourceRelationship>
     rdfs:label "Resource Relationship"@en ;
-    dcterms:description "Resources can be thought of as identifiable records or instances of classes and may include, but need not be limited to instances of dwc:Occurrence, dwc:Organism, dwc:MaterialEntity, dwc:Event, dcterms:Location, dwc:GeologicalContext, dwc:Identification, or dwc:Taxon."@en ;
-    rdfs:comment "A relationship of one rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource) to another."@en ;
     skos:definition "A relationship of one rdfs:Resource (http://www.w3.org/2000/01/rdf-schema#Resource) to another."@en ;
-    skos:prefLabel "Resource Relationship"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Sample>
     rdfs:label "Sample"@en ;
-    rdfs:comment "Container class for information about the results of a sampling event (specimen, observation, etc.)"@en ;
     skos:definition "Container class for information about the results of a sampling event (specimen, observation, etc.)"@en ;
-    skos:prefLabel "Sample"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttribute>
     rdfs:label "Sample Attribute"@en ;
-    rdfs:comment "Container class for information about attributes related to a given sample."@en ;
     skos:definition "Container class for information about attributes related to a given sample."@en ;
-    skos:prefLabel "Sample Attribute"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttributeAccuracy>
     rdfs:label "Sample Attribute Accuracy"@en ;
-    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
-    rdfs:comment "The description of the error associated with the SampleAttributeValue."@en ;
     skos:definition "The description of the error associated with the SampleAttributeValue."@en ;
-    skos:prefLabel "Sample Attribute Accuracy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttributeDeterminedBy>
     rdfs:label "Sample Attribute Determined By"@en ;
-    dcterms:description "Example: \"Javier de la Torre\""@en ;
-    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the sample."@en ;
     skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the sample."@en ;
-    skos:prefLabel "Sample Attribute Determined By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttributeDeterminedDate>
     rdfs:label "Sample Attribute Determined Date"@en ;
-    dcterms:description "Date may be used to express temporal information at any level of granularity. Recommended best practice is to use an encoding scheme, such as the W3CDTF profile of ISO 8601 [W3CDTF]."@en ;
-    rdfs:comment "The date on which the the measurement or characteristic of the sample was made."@en ;
     skos:definition "The date on which the the measurement or characteristic of the sample was made."@en ;
-    skos:prefLabel "Sample Attribute Determined Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttributeRemarks>
     rdfs:label "Sample Attribute Remarks"@en ;
-    dcterms:description "Example: \"tip of tail missing\""@en ;
-    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the sample."@en ;
     skos:definition "Comments or notes accompanying the measurement or characteristic of the sample."@en ;
-    skos:prefLabel "Sample Attribute Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttributeUnit>
     rdfs:label "Sample Attribute Unit"@en ;
-    dcterms:description "Example: \"mm\""@en ;
-    rdfs:comment "The units for the value of the measurement or characteristic of the sample. Recommended best practice is to use International System of Units (SI) units."@en ;
     skos:definition "The units for the value of the measurement or characteristic of the sample. Recommended best practice is to use International System of Units (SI) units."@en ;
-    skos:prefLabel "Sample Attribute Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleAttributeValue>
     rdfs:label "Sample Attribute Value"@en ;
-    dcterms:description "Example: \"45\""@en ;
-    rdfs:comment "The value of the measurement or characteristic of the sample."@en ;
     skos:definition "The value of the measurement or characteristic of the sample."@en ;
-    skos:prefLabel "Sample Attribute Value"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SampleRemarks>
     rdfs:label "Sample Remarks"@en ;
-    dcterms:description "Example: \"found dead on road\""@en ;
-    rdfs:comment "Comments or notes about the sample or record."@en ;
     skos:definition "Comments or notes about the sample or record."@en ;
-    skos:prefLabel "Sample Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingAttributeID>
     rdfs:label "Sample Attribute ID"@en ;
-    rdfs:comment "An identifier for the sampling attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the sampling attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Sample Attribute ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingAttributeType>
     rdfs:label "Sample Attribute Type"@en ;
-    dcterms:description "Example: \"tail length\""@en ;
-    rdfs:comment "The nature of the measurement or characteristic of the sample. Recommended best practice is to use a controlled vocabulary."@en ;
     skos:definition "The nature of the measurement or characteristic of the sample. Recommended best practice is to use a controlled vocabulary."@en ;
-    skos:prefLabel "Sample Attribute Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingEvent>
     rdfs:label "Sampling Event"@en ;
-    rdfs:comment "Container class for information about the conditions and methods of acquisition of samples."@en ;
     skos:definition "Container class for information about the conditions and methods of acquisition of samples."@en ;
-    skos:prefLabel "Sampling Event"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingEventAttributes>
     rdfs:label "Sampling Event Attributes"@en ;
-    dcterms:description "Example: \"Relative humidity: 28 %; Temperature: 22 C; Sample size: 10 kg\""@en ;
-    rdfs:comment "A list (concatenated and separated) of additional measurements or characteristics of the sampling event."@en ;
     skos:definition "A list (concatenated and separated) of additional measurements or characteristics of the sampling event."@en ;
-    skos:prefLabel "Sampling Event Attributes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingEventID>
     rdfs:label "Sampling Event ID"@en ;
-    rdfs:comment "An identifier for the sampling event. May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the sampling event. May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Sampling Event ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingEventRemarks>
     rdfs:label "Sampling Event Remarks"@en ;
-    dcterms:description "Example: \"found dead on road\""@en ;
-    rdfs:comment "Comments or notes about the sampling event."@en ;
     skos:definition "Comments or notes about the sampling event."@en ;
-    skos:prefLabel "Sampling Event Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingLocation>
     rdfs:label "Sampling Location"@en ;
-    rdfs:comment "Container class for information about the location where a sampling event occurred."@en ;
     skos:definition "Container class for information about the location where a sampling event occurred."@en ;
-    skos:prefLabel "Sampling Location"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingLocationID>
     rdfs:label "Sampling Location ID"@en ;
-    dcterms:description "Example: \"MVZ:LocID:12345\""@en ;
-    rdfs:comment "An identifier for the sampling location. May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the sampling location. May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Sampling Location ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/SamplingLocationRemarks>
     rdfs:label "Sampling Location Remarks"@en ;
-    dcterms:description "Example: \"under water since 2005\""@en ;
-    rdfs:comment "Comments or notes about the sampling location."@en ;
     skos:definition "Comments or notes about the sampling location."@en ;
-    skos:prefLabel "Sampling Location Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/StartTimeOfDay>
     rdfs:label "Start Time of Day"@en ;
-    dcterms:description "Examples: \"12.0\" (= noon), \"13.5\" (= 1:30pm)"@en ;
-    rdfs:comment "The time of day when the event began, expressed as decimal hours from midnight, local time."@en ;
     skos:definition "The time of day when the event began, expressed as decimal hours from midnight, local time."@en ;
-    skos:prefLabel "Start Time of Day"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/Taxon>
     rdfs:label "Taxon"@en ;
-    rdfs:comment "A group of organisms (sensu http://purl.obolibrary.org/obo/OBI_0100026) considered by taxonomists to form a homogeneous unit."@en ;
     skos:definition "A group of organisms (sensu http://purl.obolibrary.org/obo/OBI_0100026) considered by taxonomists to form a homogeneous unit."@en ;
-    skos:prefLabel "Taxon"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/TaxonID>
     rdfs:label "Taxon ID"@en ;
-    rdfs:comment "A global unique identifier for the taxon (name in a classification)."@en ;
     skos:definition "A global unique identifier for the taxon (name in a classification)."@en ;
-    skos:prefLabel "Taxon ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/UsagePolicy>
     rdfs:label "Usage Policy"@en ;
-    dcterms:description "This is a convenience class to group related properties."@en ;
-    rdfs:comment "Information about rights, usage, and attribution statements applicable to an entity."@en ;
     skos:definition "Information about rights, usage, and attribution statements applicable to an entity."@en ;
-    skos:prefLabel "Usage Policy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedNameUsage>
     rdfs:label "Accepted Name Usage"@en ;
-    dcterms:description "The full scientific name, with authorship and date information if known, of the accepted (botanical) or valid (zoological) name in cases where the provided dwc:scientificName is considered by the reference indicated in the dwc:nameAccordingTo property, or of the content provider, to be a synonym or misapplied name. When applied to a dwc:Organism or dwc:Occurrence, this term should be used in cases where a content provider regards the provided dwc:scientificName to be inconsistent with the taxonomic perspective of the content provider. For example, there are many discrepancies within specimen collections and observation datasets between the recorded name (e.g., the most recent identification from an expert who examined a specimen, or a field identification for an observed dwc:Organism), and the name asserted by the content provider to be taxonomically accepted."@en ;
-    rdfs:comment "The full name, with authorship and date information if known, of the currently valid (zoological) or accepted (botanical) dwc:Taxon."@en ;
     skos:definition "The full name, with authorship and date information if known, of the currently valid (zoological) or accepted (botanical) dwc:Taxon."@en ;
-    skos:prefLabel "Accepted Name Usage"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedNameUsageID>
     rdfs:label "Accepted Name Usage ID"@en ;
-    dcterms:description "This term should be used for synonyms or misapplied names to refer to the dwc:taxonID of a dwc:Taxon record that represents the accepted (botanical) or valid (zoological) name. For Darwin Core Archives the related record should be present locally in the same archive."@en ;
-    rdfs:comment "An identifier for the name usage (documented meaning of the name according to a source) of the currently valid (zoological) or accepted (botanical) taxon."@en ;
     skos:definition "An identifier for the name usage (documented meaning of the name according to a source) of the currently valid (zoological) or accepted (botanical) taxon."@en ;
-    skos:prefLabel "Accepted Name Usage ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedScientificName>
     rdfs:label "Accepted Scientific Name"@en ;
-    dcterms:description "Example: \"Tamias minimus\" valid name for \"Eutamias minimus\""@en ;
-    rdfs:comment "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
     skos:definition "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
-    skos:prefLabel "Accepted Scientific Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedScientificNameID>
     rdfs:label "Accepted Scientific Name ID"@en ;
-    rdfs:comment "A unique identifier for the acceptedScientificName."@en ;
     skos:definition "A unique identifier for the acceptedScientificName."@en ;
-    skos:prefLabel "Accepted Scientific Name ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedTaxonID>
     rdfs:label "Accepted Taxon ID"@en ;
-    dcterms:description "Example: \"8fa58e08-08de-4ac1-b69c-1235340b7001\""@en ;
-    rdfs:comment "An identifier for the name of the currently valid (zoological) or accepted (botanical) taxon. See acceptedTaxon."@en ;
     skos:definition "An identifier for the name of the currently valid (zoological) or accepted (botanical) taxon. See acceptedTaxon."@en ;
-    skos:prefLabel "Accepted Taxon ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedTaxonName>
     rdfs:label "Accepted Taxon Name"@en ;
-    dcterms:description "Example: \"Tamias minimus\" valid name for \"Eutamias minimus\""@en ;
-    rdfs:comment "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
     skos:definition "The currently valid (zoological) or accepted (botanical) name for the scientificName."@en ;
-    skos:prefLabel "Accepted Taxon Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/acceptedTaxonNameID>
     rdfs:label "Accepted Taxon Name ID"@en ;
-    rdfs:comment "A unique identifier for the acceptedTaxonName."@en ;
     skos:definition "A unique identifier for the acceptedTaxonName."@en ;
-    skos:prefLabel "Accepted Taxon Name ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/accordingTo>
     rdfs:label "According To"@en ;
-    rdfs:comment "Abstract term to attribute information to a source."@en ;
     skos:definition "Abstract term to attribute information to a source."@en ;
-    skos:prefLabel "According To"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/accuracy>
     rdfs:label "Accuracy"@en ;
-    rdfs:comment "Abstract term to capture error information about a measurement or fact."@en ;
     skos:definition "Abstract term to capture error information about a measurement or fact."@en ;
-    skos:prefLabel "Accuracy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/agentID>
     rdfs:label "Agent ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dcterms:Agent."@en ;
     skos:definition "An identifier for a dcterms:Agent."@en ;
-    skos:prefLabel "Agent ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/agentRemarks>
     rdfs:label "Agent Remarks"@en ;
-    rdfs:comment "Comments or notes about a dcterms:Agent."@en ;
     skos:definition "Comments or notes about a dcterms:Agent."@en ;
-    skos:prefLabel "Agent Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/agentRoleOrder>
     rdfs:label "Agent Role Order"@en ;
-    dcterms:description "One could use dwc:agentRoleOrder to create an ordered list of collectors (agentRole = 'collector') for a dwc:MaterialEntity in a Darwin Core Data Package, for example. The first would have dwc:agentRoleOrder=1, the second would have dwc:agentRoleOrder=2."@en ;
-    rdfs:comment "A numerical position of an AgentRole in a set of AgentRoles."@en ;
     skos:definition "A numerical position of an AgentRole in a set of AgentRoles."@en ;
-    skos:prefLabel "Agent Role Order"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/agentType>
     rdfs:label "Agent Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
-    rdfs:comment "A category that best matches the nature of a dcterms:Agent."@en ;
     skos:definition "A category that best matches the nature of a dcterms:Agent."@en ;
-    skos:prefLabel "Agent Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assayType>
     rdfs:label "Assay Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
     skos:definition "A type of method used in a study to detect taxon/taxa of interest in a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Assay Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionBy>
     rdfs:label "Assertion By"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A name for a dcterms:Agent responsible for making a dwc:Assertion."@en ;
     skos:definition "A name for a dcterms:Agent responsible for making a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionEffectiveDate>
     rdfs:label "Assertion Effective Date"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "A date on which a state or measurement of a dwc:Assertion was deemed to first be in effect."@en ;
     skos:definition "A date on which a state or measurement of a dwc:Assertion was deemed to first be in effect."@en ;
-    skos:prefLabel "Assertion Effective Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionError>
     rdfs:label "Assertion Error"@en ;
-    rdfs:comment "A description of the potential error associated with a dwc:assertionValue."@en ;
     skos:definition "A description of the potential error associated with a dwc:assertionValue."@en ;
-    skos:prefLabel "Assertion Error"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionID>
     rdfs:label "Assertion ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dwc:Assertion."@en ;
     skos:definition "An identifier for a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionMadeDate>
     rdfs:label "Assertion Made Date"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "A date on which a dwc:Assertion was created."@en ;
     skos:definition "A date on which a dwc:Assertion was created."@en ;
-    skos:prefLabel "Assertion Made Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionProtocols>
     rdfs:label "Assertion Protocols"@en ;
-    rdfs:comment "Names of, references to, or descriptions of dwc:Protocols used in making a dwc:Assertion."@en ;
     skos:definition "Names of, references to, or descriptions of dwc:Protocols used in making a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion Protocols"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionReferences>
     rdfs:label "Assertion References"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources associated with a dwc:Assertion."@en ;
     skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources associated with a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion References"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionRemarks>
     rdfs:label "Assertion Remarks"@en ;
-    rdfs:comment "Comments or notes about a dwc:Assertion."@en ;
     skos:definition "Comments or notes about a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionType>
     rdfs:label "Assertion Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:Assertion."@en ;
     skos:definition "A category that best matches the nature of a dwc:Assertion."@en ;
-    skos:prefLabel "Assertion Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionUnit>
     rdfs:label "Assertion Unit"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Ontology of Units of Measure http://www.ontology-of-units-of-measure.org for SI units, derived units, or other non-SI units accepted for use within the SI. For units that are composed of multiple parts, use the patterns as given in \"A Primer for Communicating Mathematics via Plain Text\" (https://cse.sc.edu/~fenner/latex-ASCII.pdf) by Stephen Fenner (e.g., `g/cm^3` for grams per cubic centimeter). For other units, provide the value as a recognizable standard (e.g., '%') or written out in full and in the plural (e.g., `individuals`). It is fine to provide non-SI units in the original language of the dataset. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A unit associated with the value in dwc:assertionValue."@en ;
     skos:definition "A unit associated with the value in dwc:assertionValue."@en ;
-    skos:prefLabel "Assertion Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/assertionValue>
     rdfs:label "Assertion Value"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "An asserted value."@en ;
     skos:definition "An asserted value."@en ;
-    skos:prefLabel "Assertion Value"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/associatedMedia>
     rdfs:label "Associated Media"@en ;
-    rdfs:comment "A list (concatenated and separated) of identifiers (publication, global unique identifier, URI) of media associated with the dwc:Occurrence."@en ;
     skos:definition "A list (concatenated and separated) of identifiers (publication, global unique identifier, URI) of media associated with the dwc:Occurrence."@en ;
-    skos:prefLabel "Associated Media"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/associatedOccurrences>
     rdfs:label "Associated Occurrences"@en ;
-    dcterms:description "This term can be used to provide a list of associations to other dwc:Occurrences. Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of identifiers of other dwc:Occurrence records and their associations to this dwc:Occurrence."@en ;
     skos:definition "A list (concatenated and separated) of identifiers of other dwc:Occurrence records and their associations to this dwc:Occurrence."@en ;
-    skos:prefLabel "Associated Occurrences"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/associatedOrganisms>
     rdfs:label "Associated Organisms"@en ;
-    dcterms:description "This term can be used to provide a list of associations to other dwc:Organisms. Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of identifiers of other dwc:Organisms and the associations of this dwc:Organism to each of them."@en ;
     skos:definition "A list (concatenated and separated) of identifiers of other dwc:Organisms and the associations of this dwc:Organism to each of them."@en ;
-    skos:prefLabel "Associated Organisms"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/associatedReferences>
     rdfs:label "Associated References"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. Note also that the intended usage of the term dcterms:references in Darwin Core when applied to a dwc:Occurrence is to point to the definitive source representation of that dwc:Occurrence if one is available. Note also that the intended usage of dcterms:bibliographicCitation in Darwin Core when applied to a dwc:Occurrence is to provide the preferred way to cite the dwc:Occurrence itself."@en ;
-    rdfs:comment "A list (concatenated and separated) of identifiers (publication, bibliographic reference, global unique identifier, URI) of literature associated with the dwc:Occurrence."@en ;
     skos:definition "A list (concatenated and separated) of identifiers (publication, bibliographic reference, global unique identifier, URI) of literature associated with the dwc:Occurrence."@en ;
-    skos:prefLabel "Associated References"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/associatedSequences>
     rdfs:label "Associated Sequences"@en ;
-    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources for dwc:NucleotideSequences associated with a dwc:MaterialEntity."@en ;
     skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources for dwc:NucleotideSequences associated with a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Associated Sequences"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/associatedTaxa>
     rdfs:label "Associated Taxa"@en ;
-    dcterms:description "This term can be used to provide a list of associations to dwc:Taxon records other than the one defined in the dwc:Occurrence. Note that the dwc:ResourceRelationship class is an alternative means of representing associations, and with more detail. This term is not apt for establishing relationships between dwc:Taxon records, only between specific dwc:Occurrences of a dwc:Organism with other dwc:Taxon records. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of identifiers or names of dwc:Taxon records and the associations of this dwc:Occurrence to each of them."@en ;
     skos:definition "A list (concatenated and separated) of identifiers or names of dwc:Taxon records and the associations of this dwc:Occurrence to each of them."@en ;
-    skos:prefLabel "Associated Taxa"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/basionym>
     rdfs:label "Basionym"@en ;
-    dcterms:description "Example: \"Pinus abies\""@en ;
-    rdfs:comment "The basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
     skos:definition "The basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
-    skos:prefLabel "Basionym"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/basionymID>
     rdfs:label "Basionym ID"@en ;
-    rdfs:comment "A unique identifier for the basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
     skos:definition "A unique identifier for the basionym (botany) or basonym (bacteriology) of the scientificName."@en ;
-    skos:prefLabel "Basionym ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/basisOfRecord>
     rdfs:label "Basis Of Record"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the set of local names of the identifiers for classes in Darwin Core."@en ;
-    rdfs:comment "The specific nature of the data record."@en ;
     skos:definition "The specific nature of the data record."@en ;
-    skos:prefLabel "Basis Of Record"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/bed>
     rdfs:label "Bed"@en ;
-    rdfs:comment "The full name of the lithostratigraphic bed from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the lithostratigraphic bed from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Bed"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/behavior>
     rdfs:label "Behavior"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A behavior shown by a dwc:Organism."@en ;
     skos:definition "A behavior shown by a dwc:Organism."@en ;
-    skos:prefLabel "Behavior"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/binomial>
     rdfs:label "Binomial"@en ;
-    dcterms:description "Example: \"Ctenomys sociabilis\""@en ;
-    rdfs:comment "The combination of genus and first (species) epithet of the scientificName."@en ;
     skos:definition "The combination of genus and first (species) epithet of the scientificName."@en ;
-    skos:prefLabel "Binomial"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/caste>
     rdfs:label "Caste"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary that aligns best with a dwc:Taxon. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A social caste of a dwc:Organism."@en ;
     skos:definition "A social caste of a dwc:Organism."@en ;
-    skos:prefLabel "Caste"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/catalogNumber>
     rdfs:label "Catalog Number"@en ;
-    rdfs:comment "An identifier (preferably unique) for a resource within a collection."@en ;
     skos:definition "An identifier (preferably unique) for a resource within a collection."@en ;
-    skos:prefLabel "Catalog Number"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/causeOfDeath>
     rdfs:label "Cause Of Death"@en ;
-    dcterms:description "The cause may be due to natural causes (e.g., disease, predation), human-related activities (e.g., roadkill, pollution), or other environmental factors (e.g., extreme weather events)."@en ;
-    rdfs:comment "An indication of the known or suspected cause of death of a dwc:Organism."@en ;
     skos:definition "An indication of the known or suspected cause of death of a dwc:Organism."@en ;
-    skos:prefLabel "Cause Of Death"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/class>
     rdfs:label "Class"@en ;
-    rdfs:comment "The full scientific name of the class in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the class in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Class"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/collectionCode>
     rdfs:label "Collection Code"@en ;
-    rdfs:comment "A name, acronym, coden, or initialism identifying a collection."@en ;
     skos:definition "A name, acronym, coden, or initialism identifying a collection."@en ;
-    skos:prefLabel "Collection Code"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/collectionID>
     rdfs:label "Collection ID"@en ;
-    dcterms:description "For physical specimens, the recommended best practice is to use a globally unique and resolvable identifier from a collections registry such as the Global Registry of Scientific Collections (https://scientific-collections.gbif.org/)."@en ;
-    rdfs:comment "An identifier for a collection."@en ;
     skos:definition "An identifier for a collection."@en ;
-    skos:prefLabel "Collection ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/continent>
     rdfs:label "Continent"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
-    rdfs:comment "The name of the continent in which the dcterms:Location occurs."@en ;
     skos:definition "The name of the continent in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Continent"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/coordinatePrecision>
     rdfs:label "Coordinate Precision"@en ;
-    rdfs:comment "A decimal representation of the precision of the coordinates given in the dwc:decimalLatitude and dwc:decimalLongitude."@en ;
     skos:definition "A decimal representation of the precision of the coordinates given in the dwc:decimalLatitude and dwc:decimalLongitude."@en ;
-    skos:prefLabel "Coordinate Precision"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/coordinateUncertaintyInMeters>
     rdfs:label "Coordinate Uncertainty In Meters"@en ;
-    dcterms:description "Leave the value empty if the uncertainty is unknown, cannot be estimated, or is not applicable (because there are no coordinates). Zero is not a valid value for this term."@en ;
-    rdfs:comment "A horizontal distance (in meters) from a given dwc:decimalLatitude and dwc:decimalLongitude describing the smallest circle containing the whole of the dcterms:Location. Zero is not a valid value for this term."@en ;
     skos:definition "A horizontal distance (in meters) from a given dwc:decimalLatitude and dwc:decimalLongitude describing the smallest circle containing the whole of the dcterms:Location. Zero is not a valid value for this term."@en ;
-    skos:prefLabel "Coordinate Uncertainty In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/country>
     rdfs:label "Country"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
-    rdfs:comment "The name of the country or major administrative unit in which the dcterms:Location occurs."@en ;
     skos:definition "The name of the country or major administrative unit in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Country"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/countryCode>
     rdfs:label "Country Code"@en ;
-    dcterms:description "Recommended best practice is to use an ISO 3166-1-alpha-2 country code, or 'ZZ' (for an unknown location or a location unassignable to a single country code), or 'XZ' (for the high seas beyond national jurisdictions). Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
-    rdfs:comment "The standard code for the country in which the dcterms:Location occurs."@en ;
     skos:definition "The standard code for the country in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Country Code"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/county>
     rdfs:label "Second Order Division"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
-    rdfs:comment "The full, unabbreviated name of the next smaller administrative region than stateProvince (county, shire, department, etc.) in which the dcterms:Location occurs."@en ;
     skos:definition "The full, unabbreviated name of the next smaller administrative region than stateProvince (county, shire, department, etc.) in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Second Order Division"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/cultivarEpithet>
     rdfs:label "Cultivar Epithet"@en ;
-    dcterms:description "According to the Rules of the Cultivated Plant Code, a cultivar name consists of a botanical name followed by a cultivar epithet. The value given as the dwc:cultivarEpithet should exclude any quotes. The term dwc:taxonRank should be used to indicate which type of cultivated plant name (e.g., cultivar, cultivar group, grex) is concerned. This epithet, including any enclosing apostrophes or suffix, should be provided in dwc:scientificName as well."@en ;
-    rdfs:comment "Part of the name of a cultivar, cultivar group or grex that follows the dwc:scientificName."@en ;
     skos:definition "Part of the name of a cultivar, cultivar group or grex that follows the dwc:scientificName."@en ;
-    skos:prefLabel "Cultivar Epithet"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/dataGeneralizations>
     rdfs:label "Data Generalizations"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
     skos:definition "Actions taken to make the shared data less specific or complete than in its original form. Suggests that alternative data of higher quality may be available on request."@en ;
-    skos:prefLabel "Data Generalizations"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/datasetID>
     rdfs:label "Dataset ID"@en ;
-    rdfs:comment "An identifier for the set of data. May be a global unique identifier or an identifier specific to a collection or institution."@en ;
     skos:definition "An identifier for the set of data. May be a global unique identifier or an identifier specific to a collection or institution."@en ;
-    skos:prefLabel "Dataset ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/datasetName>
     rdfs:label "Dataset Name"@en ;
-    rdfs:comment "A name of a source dataset."@en ;
     skos:definition "A name of a source dataset."@en ;
-    skos:prefLabel "Dataset Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/dateIdentified>
     rdfs:label "Date Identified"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "The date on which the subject was determined as representing the dwc:Taxon."@en ;
     skos:definition "The date on which the subject was determined as representing the dwc:Taxon."@en ;
-    skos:prefLabel "Date Identified"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/day>
     rdfs:label "Day"@en ;
-    rdfs:comment "The integer day of the month on which the dwc:Event occurred."@en ;
     skos:definition "The integer day of the month on which the dwc:Event occurred."@en ;
-    skos:prefLabel "Day"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/decimalLatitude>
     rdfs:label "Decimal Latitude"@en ;
-    dcterms:description "Positive values are north of the Equator, negative values are south of it. Valid values lie between -90 and 90, inclusive."@en ;
-    rdfs:comment "A geographic latitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
     skos:definition "A geographic latitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
-    skos:prefLabel "Decimal Latitude"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/decimalLongitude>
     rdfs:label "Decimal Longitude"@en ;
-    dcterms:description "Positive values are east of the Greenwich Meridian, negative values are west of it. Valid values lie between -180 and 180, inclusive."@en ;
-    rdfs:comment "A geographic longitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
     skos:definition "A geographic longitude (in decimal degrees, using the spatial reference system given in dwc:geodeticDatum) of a dcterms:Location."@en ;
-    skos:prefLabel "Decimal Longitude"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/degreeOfEstablishment>
     rdfs:label "Degree of Establishment"@en ;
-    dcterms:description "Recommended best practice is to use controlled value strings from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/doe/. For details, refer to https://doi.org/10.3897/biss.3.38084. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
     skos:definition "The degree to which a dwc:Organism survives, reproduces, and expands its range at the given place and time."@en ;
-    skos:prefLabel "Degree of Establishment"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/digitalSpecimenID>
     rdfs:label "Digital Specimen ID"@en ;
-    dcterms:description "A Digital Specimen is defined in https://doi.org/10.3897/rio.7.e67379. A dwc:digitalSpecimenID is intended to uniquely and persistently identify a Digital Specimen. Recommended best practice is to use a DOI with machine readable metadata in the DOI record that uses a community agreed metadata profile (also known as FDO profile) for a Digital Specimen. For an example see: https://doi.org/10.3535/N75-CR4-0SM?noredirect. The identifier is for a digital information artifact (the Digital Specimen) as opposed to an identifier for a specific instance of a dwc:MaterialEntity."@en ;
-    rdfs:comment "An identifier for a Digital Specimen resource."@en ;
     skos:definition "An identifier for a Digital Specimen resource."@en ;
-    skos:prefLabel "Digital Specimen ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/discipline>
     rdfs:label "Discipline"@en ;
-    dcterms:description "This term can be used to classify records according to branches of knowledge. Recommended best practice is to use a controlled vocabulary and to separate the values in a list with space vertical bar space (` | `). It is also recommended to use this field to describe specimenType in MIDS. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The primary branch or branches of knowledge represented by a dwc:MaterialEntity."@en ;
     skos:definition "The primary branch or branches of knowledge represented by a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Discipline"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/disposition>
     rdfs:label "Disposition"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
     skos:definition "A current state of a dwc:MaterialEntity with respect to where it can be found."@en ;
-    skos:prefLabel "Disposition"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/dynamicProperties>
     rdfs:label "Dynamic Properties"@en ;
-    dcterms:description "Recommended best practice is to use a key:value encoding schema for a data interchange format such as JSON."@en ;
-    rdfs:comment "A list of additional measurements, facts, characteristics, or assertions about the record. Meant to provide a mechanism for structured content."@en ;
     skos:definition "A list of additional measurements, facts, characteristics, or assertions about the record. Meant to provide a mechanism for structured content."@en ;
-    skos:prefLabel "Dynamic Properties"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/earliestAgeOrLowestStage>
     rdfs:label "Earliest Age Or Lowest Stage"@en ;
-    rdfs:comment "The full name of the earliest possible geochronologic age or lowest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the earliest possible geochronologic age or lowest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Earliest Age Or Lowest Stage"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/earliestEonOrLowestEonothem>
     rdfs:label "Earliest Eon Or Lowest Eonothem"@en ;
-    rdfs:comment "The full name of the earliest possible geochronologic eon or lowest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the earliest possible geochronologic eon or lowest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Earliest Eon Or Lowest Eonothem"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/earliestEpochOrLowestSeries>
     rdfs:label "Earliest Epoch Or Lowest Series"@en ;
-    rdfs:comment "The full name of the earliest possible geochronologic epoch or lowest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the earliest possible geochronologic epoch or lowest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Earliest Epoch Or Lowest Series"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/earliestEraOrLowestErathem>
     rdfs:label "Earliest Era Or Lowest Erathem"@en ;
-    rdfs:comment "The full name of the earliest possible geochronologic era or lowest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the earliest possible geochronologic era or lowest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Earliest Era Or Lowest Erathem"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/earliestPeriodOrLowestSystem>
     rdfs:label "Earliest Period Or Lowest System"@en ;
-    rdfs:comment "The full name of the earliest possible geochronologic period or lowest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the earliest possible geochronologic period or lowest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Earliest Period Or Lowest System"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/endDayOfYear>
     rdfs:label "End Day Of Year"@en ;
-    dcterms:description "The value is 1 for January 1 and 365 for December 31, except in a leap year, in which case it is 366."@en ;
-    rdfs:comment "The latest integer day of the year on which a dwc:Event occurred."@en ;
     skos:definition "The latest integer day of the year on which a dwc:Event occurred."@en ;
-    skos:prefLabel "End Day Of Year"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/establishmentMeans>
     rdfs:label "Establishment Means"@en ;
-    dcterms:description "Recommended best practice is to use controlled value strings from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/em/. For details, refer to https://doi.org/10.3897/biss.3.38084. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
     skos:definition "Statement about whether a dwc:Organism has been introduced to a given place and time through the direct or indirect activity of modern humans."@en ;
-    skos:prefLabel "Establishment Means"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventAttributes>
     rdfs:label "Event Attributes"@en ;
-    dcterms:description "Example: \"Relative humidity: 28 %; Temperature: 22 C; Sample size: 10 kg\""@en ;
-    rdfs:comment "A list (concatenated and separated) of additional measurements or characteristics of the Event."@en ;
     skos:definition "A list (concatenated and separated) of additional measurements or characteristics of the Event."@en ;
-    skos:prefLabel "Event Attributes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventCategory>
     rdfs:label "Event Category"@en ;
-    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. Recommended best practice is to use one of the following controlled values: `Event`, `MaterialGathering`, `Occurrence`, `OrganismInteraction`, or `Survey`. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A broad category that best matches the nature of a dwc:Event."@en ;
     skos:definition "A broad category that best matches the nature of a dwc:Event."@en ;
-    skos:prefLabel "Event Category"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventDate>
     rdfs:label "Event Date"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019. Not suitable for a time in a geological context."@en ;
-    rdfs:comment "A date-time or time interval during which a dwc:Event occurred."@en ;
     skos:definition "A date-time or time interval during which a dwc:Event occurred."@en ;
-    skos:prefLabel "Event Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventID>
     rdfs:label "Event ID"@en ;
-    rdfs:comment "An identifier for the set of information associated with a dwc:Event (something that occurs at a place and time). May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the set of information associated with a dwc:Event (something that occurs at a place and time). May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Event ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementAccuracy>
     rdfs:label "Event Measurement Accuracy"@en ;
-    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
-    rdfs:comment "The description of the error associated with the EventAttributeValue."@en ;
     skos:definition "The description of the error associated with the EventAttributeValue."@en ;
-    skos:prefLabel "Event Measurement Accuracy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementDeterminedBy>
     rdfs:label "Event Measurement Determined By"@en ;
-    dcterms:description "Example: \"Robert Hijmans\""@en ;
-    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the event."@en ;
     skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the event."@en ;
-    skos:prefLabel "Event Measurement Determined By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementDeterminedDate>
     rdfs:label "Event Measurement Determined Date"@en ;
-    dcterms:description "Examples: \"1963-03-08T14:07-0600\" is 8 Mar 1963 2:07pm in the time zone six hours earlier than UTC, \"2009-02-20T08:40Z\" is 20 Feb 2009 8:40am UTC, \"1809-02-12\" is 12 Feb 1809, \"1906-06\" is Jun 1906, \"1971\" is just that year, \"2007-03-01T13:00:00Z/2008-05-11T15:30:00Z\" is the interval between 1 Mar 2007 1pm UTC and 11 May 2008 3:30pm UTC, \"2007-11-13/15\" is the interval between 13 Nov 2007 and 15 Nov 2007."@en ;
-    rdfs:comment "The date on which the the measurement or characteristic of the event was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
     skos:definition "The date on which the the measurement or characteristic of the event was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
-    skos:prefLabel "Event Measurement Determined Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementID>
     rdfs:label "Event Measurement ID"@en ;
-    rdfs:comment "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the event attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Event Measurement ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementRemarks>
     rdfs:label "Event Measurement Remarks"@en ;
-    dcterms:description "Example: \"temperature taken at 15:00\""@en ;
-    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the event."@en ;
     skos:definition "Comments or notes accompanying the measurement or characteristic of the event."@en ;
-    skos:prefLabel "Event Measurement Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementType>
     rdfs:label "Event Measurement Type"@en ;
-    dcterms:description "Example: \"temperature\""@en ;
-    rdfs:comment "The nature of the measurement or characteristic of the event. Recommended best practice is to use a controlled vocabulary."@en ;
     skos:definition "The nature of the measurement or characteristic of the event. Recommended best practice is to use a controlled vocabulary."@en ;
-    skos:prefLabel "Event Measurement Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementUnit>
     rdfs:label "Event Measurement Unit"@en ;
-    dcterms:description "Example: \"C\""@en ;
-    rdfs:comment "The units for the value of the measurement or characteristic of the event. Recommended best practice is to use International System of Units (SI) units."@en ;
     skos:definition "The units for the value of the measurement or characteristic of the event. Recommended best practice is to use International System of Units (SI) units."@en ;
-    skos:prefLabel "Event Measurement Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventMeasurementValue>
     rdfs:label "Event Measurement Value"@en ;
-    dcterms:description "Example: \"22\""@en ;
-    rdfs:comment "The value of the measurement or characteristic of the event."@en ;
     skos:definition "The value of the measurement or characteristic of the event."@en ;
-    skos:prefLabel "Event Measurement Value"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventRemarks>
     rdfs:label "Event Remarks"@en ;
-    rdfs:comment "Comments or notes about the dwc:Event."@en ;
     skos:definition "Comments or notes about the dwc:Event."@en ;
-    skos:prefLabel "Event Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventTime>
     rdfs:label "Event Time"@en ;
-    dcterms:description "Recommended best practice is to use a time of day that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "The time or interval during which a dwc:Event occurred."@en ;
     skos:definition "The time or interval during which a dwc:Event occurred."@en ;
-    skos:prefLabel "Event Time"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/eventType>
     rdfs:label "Event Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A narrow category that best matches the nature of a dwc:Event."@en ;
     skos:definition "A narrow category that best matches the nature of a dwc:Event."@en ;
-    skos:prefLabel "Event Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/family>
     rdfs:label "Family"@en ;
-    rdfs:comment "The full scientific name of the family in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the family in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Family"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/feedbackURL>
     rdfs:label "Feedback URL"@en ;
-    dcterms:description "Recommended best practice is to optionally include query strings that act to pre-populate web page form elements and communicate the context."@en ;
-    rdfs:comment "A uniform resource locator (URL) that points to a webpage on which a form may be submitted to gather feedback about the record."@en ;
     skos:definition "A uniform resource locator (URL) that points to a webpage on which a form may be submitted to gather feedback about the record."@en ;
-    skos:prefLabel "Feedback URL"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/fieldNotes>
     rdfs:label "Field Notes"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
     skos:definition "One of a) an indicator of the existence of, b) a reference to (publication, URI), or c) the text of notes taken in the field about the dwc:Event."@en ;
-    skos:prefLabel "Field Notes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/fieldNumber>
     rdfs:label "Field Number"@en ;
-    dcterms:description "Often serves as a link between field notes and a dwc:Event. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "An identifier given to a dwc:Event in the field."@en ;
     skos:definition "An identifier given to a dwc:Event in the field."@en ;
-    skos:prefLabel "Field Number"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/footprintSRS>
     rdfs:label "Footprint SRS"@en ;
-    dcterms:description "Recommended best practice is to use the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use the value `not recorded`. It is also permitted to provide the SRS in Well-Known-Text, especially if no EPSG code provides the necessary values for the attributes of the SRS. Do not use this term to describe the SRS of the dwc:decimalLatitude and dwc:decimalLongitude, nor of any verbatim coordinates - use the dwc:geodeticDatum and dwc:verbatimSRS instead. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
     skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geometry given in dwc:footprintWKT is based."@en ;
-    skos:prefLabel "Footprint SRS"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/footprintSpatialFit>
     rdfs:label "Footprint Spatial Fit"@en ;
-    dcterms:description "Legal values are 0, greater than or equal to 1, or undefined. A value of 1 is an exact match or 100% overlap. A value of 0 should be used if the given footprint does not completely contain the original representation. A dwc:footprintSpatialFit is undefined (and should be left empty) if the original representation is any geometry without area (e.g., a point or polyline) and without uncertainty and the given georeference is not that same geometry (without uncertainty). If both the original and the given georeference are the same point, a dwc:footprintSpatialFit is 1. Detailed explanations with graphical examples can be found in the Georeferencing Best Practices, Chapman and Wieczorek, 2020 (https://doi.org/10.15468/doc-gg7h-s853)."@en ;
-    rdfs:comment "A ratio of the area of a footprint (dwc:footprintWKT) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
     skos:definition "A ratio of the area of a footprint (dwc:footprintWKT) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
-    skos:prefLabel "Footprint Spatial Fit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/footprintWKT>
     rdfs:label "Footprint WKT"@en ;
-    dcterms:description "A dcterms:Location may have both a point-radius representation (see dwc:decimalLatitude) and a footprint representation, and they may differ from each other."@en ;
-    rdfs:comment "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines a dcterms:Location."@en ;
     skos:definition "A Well-Known Text (WKT) representation of the shape (footprint, geometry) that defines a dcterms:Location."@en ;
-    skos:prefLabel "Footprint WKT"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/formation>
     rdfs:label "Formation"@en ;
-    rdfs:comment "The full name of the lithostratigraphic formation from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the lithostratigraphic formation from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Formation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/fundingAttributionID>
     rdfs:label "Funding Attribution ID"@en ;
-    dcterms:description "Provide a unique identifier for the funding body, such as an identifier used in governmental or international databases. If no official identifier exists, use a persistent and unique identifier within your organization or dataset. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "An identifier for a dcterms:Agent that financially supported a project."@en ;
     skos:definition "An identifier for a dcterms:Agent that financially supported a project."@en ;
-    skos:prefLabel "Funding Attribution ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/genericName>
     rdfs:label "Generic Name"@en ;
-    dcterms:description "For synonyms the accepted genus and the genus part of the name may be different. The term dwc:genericName should be used together with dwc:specificEpithet to form a binomial and with dwc:infraspecificEpithet to form a trinomial. The term dwc:genericName should only be used for combinations. Uninomials of generic rank do not have a dwc:genericName."@en ;
-    rdfs:comment "The genus part of the dwc:scientificName without authorship."@en ;
     skos:definition "The genus part of the dwc:scientificName without authorship."@en ;
-    skos:prefLabel "Generic Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/genus>
     rdfs:label "Genus"@en ;
-    rdfs:comment "The full scientific name of the genus in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the genus in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Genus"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/geodeticDatum>
     rdfs:label "Geodetic Datum"@en ;
-    dcterms:description "Recommended best practice is to use the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use the value `not recorded`. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for a string literal value."@en ;
-    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
     skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which the geographic coordinates given in dwc:decimalLatitude and dwc:decimalLongitude are based."@en ;
-    skos:prefLabel "Geodetic Datum"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/geologicalContextID>
     rdfs:label "Geological Context ID"@en ;
-    rdfs:comment "An identifier for the set of information associated with a dwc:GeologicalContext (the location within a geological context, such as stratigraphy). May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the set of information associated with a dwc:GeologicalContext (the location within a geological context, such as stratigraphy). May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Geological Context ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/georeferenceProtocol>
     rdfs:label "Georeference Protocol"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
     skos:definition "A description or reference to a dwc:Protocol used to determine a spatial footprint, coordinates, and uncertainties."@en ;
-    skos:prefLabel "Georeference Protocol"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/georeferenceRemarks>
     rdfs:label "Georeference Remarks"@en ;
-    rdfs:comment "Comments or notes about the spatial description determination, explaining assumptions made in addition or opposition to the those formalized in the method referred to in dwc:georeferenceProtocol."@en ;
     skos:definition "Comments or notes about the spatial description determination, explaining assumptions made in addition or opposition to the those formalized in the method referred to in dwc:georeferenceProtocol."@en ;
-    skos:prefLabel "Georeference Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/georeferenceSources>
     rdfs:label "Georeference Sources"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A list (concatenated and separated) of maps, gazetteers, or other resources used to georeference a dcterms:Location, described specifically enough to allow anyone in the future to use the same resources."@en ;
     skos:definition "A list (concatenated and separated) of maps, gazetteers, or other resources used to georeference a dcterms:Location, described specifically enough to allow anyone in the future to use the same resources."@en ;
-    skos:prefLabel "Georeference Sources"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/georeferenceVerificationStatus>
     rdfs:label "Georeference Verification Status"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
     skos:definition "A categorical description of the extent to which the georeference has been verified to represent the best possible spatial description for the dcterms:Location of the dwc:Occurrence."@en ;
-    skos:prefLabel "Georeference Verification Status"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/georeferencedBy>
     rdfs:label "Georeferenced By"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A name for a dcterms:Agent responsible for providing a georeference."@en ;
     skos:definition "A name for a dcterms:Agent responsible for providing a georeference."@en ;
-    skos:prefLabel "Georeferenced By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/georeferencedDate>
     rdfs:label "Georeferenced Date"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "The date on which the dcterms:Location was georeferenced."@en ;
     skos:definition "The date on which the dcterms:Location was georeferenced."@en ;
-    skos:prefLabel "Georeferenced Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/group>
     rdfs:label "Group"@en ;
-    rdfs:comment "The full name of the lithostratigraphic group from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the lithostratigraphic group from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Group"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/habitat>
     rdfs:label "Habitat"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category or description of the habitat in which the dwc:Event occurred."@en ;
     skos:definition "A category or description of the habitat in which the dwc:Event occurred."@en ;
-    skos:prefLabel "Habitat"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/higherClassification>
     rdfs:label "Higher Classification"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `), with terms in order from the highest taxonomic rank to the lowest."@en ;
-    rdfs:comment "A list (concatenated and separated) of taxa names terminating at the rank immediately superior to the referenced dwc:Taxon."@en ;
     skos:definition "A list (concatenated and separated) of taxa names terminating at the rank immediately superior to the referenced dwc:Taxon."@en ;
-    skos:prefLabel "Higher Classification"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/higherGeography>
     rdfs:label "Higher Geography"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `), with terms in order from least specific to most specific."@en ;
-    rdfs:comment "A list (concatenated and separated) of geographic names less specific than the information captured in the dwc:locality term."@en ;
     skos:definition "A list (concatenated and separated) of geographic names less specific than the information captured in the dwc:locality term."@en ;
-    skos:prefLabel "Higher Geography"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/higherGeographyID>
     rdfs:label "Higher Geography ID"@en ;
-    dcterms:description "Recommended best practice is to use a persistent identifier from a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
-    rdfs:comment "An identifier for the geographic region within which the dcterms:Location occurred."@en ;
     skos:definition "An identifier for the geographic region within which the dcterms:Location occurred."@en ;
-    skos:prefLabel "Higher Geography ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/higherTaxonName>
     rdfs:label "Higher Taxon Name"@en ;
-    dcterms:description "Example: \"Animalia; Chordata; Vertebrata; Mammalia; Theria; Eutheria; Rodentia; Hystricognatha; Hystricognathi; Ctenomyidae; Ctenomyini; Ctenomys\""@en ;
-    rdfs:comment "A list (concatenated and separated) of the names for the taxonomic ranks less specific than that given in the scientificName."@en ;
     skos:definition "A list (concatenated and separated) of the names for the taxonomic ranks less specific than that given in the scientificName."@en ;
-    skos:prefLabel "Higher Taxon Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/higherTaxonNameID>
     rdfs:label "Higher Taxon Name ID"@en ;
-    rdfs:comment "A unique identifier for the name of the next higher rank than the scientificName in a taxonomic classification. See higherTaxonName."@en ;
     skos:definition "A unique identifier for the name of the next higher rank than the scientificName in a taxonomic classification. See higherTaxonName."@en ;
-    skos:prefLabel "Higher Taxon Name ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/higherTaxonconceptID>
     rdfs:label "Higher Taxon Concept ID"@en ;
-    rdfs:comment "A unique identifier for the taxon concept less specific than that given in the taxonConceptID."@en ;
     skos:definition "A unique identifier for the taxon concept less specific than that given in the taxonConceptID."@en ;
-    skos:prefLabel "Higher Taxon Concept ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/highestBiostratigraphicZone>
     rdfs:label "Highest Biostratigraphic Zone"@en ;
-    rdfs:comment "The full name of the highest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the highest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Highest Biostratigraphic Zone"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationAttributes>
     rdfs:label "Identification Attributes"@en ;
-    dcterms:description "Example: \"natureOfID=expert identification; identificationEvidence=cytochrome B sequence\""@en ;
-    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Identification."@en ;
     skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Identification."@en ;
-    skos:prefLabel "Identification Attributes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationID>
     rdfs:label "Identification ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dwc:Identification."@en ;
     skos:definition "An identifier for a dwc:Identification."@en ;
-    skos:prefLabel "Identification ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationQualifier>
     rdfs:label "Identification Qualifier"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A brief phrase or a standard term (\"cf.\", \"aff.\") to express the determiner's doubts about the dwc:Identification."@en ;
     skos:definition "A brief phrase or a standard term (\"cf.\", \"aff.\") to express the determiner's doubts about the dwc:Identification."@en ;
-    skos:prefLabel "Identification Qualifier"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationReferences>
     rdfs:label "Identification References"@en ;
-    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Identification."@en ;
     skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Identification."@en ;
-    skos:prefLabel "Identification References"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationRemarks>
     rdfs:label "Identification Remarks"@en ;
-    rdfs:comment "Comments or notes about the dwc:Identification."@en ;
     skos:definition "Comments or notes about the dwc:Identification."@en ;
-    skos:prefLabel "Identification Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationType>
     rdfs:label "Identification Type"@en ;
-    dcterms:description "The evidentiary basis, analytical approach, or inferential method by which an identification was determined. Values describe the dominant source of information supporting the identification (e.g., morphology, geography, molecular data, functional attributes, relationships, or taxonomic revision), independent of confidence level or taxonomic outcome. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:Identification."@en ;
     skos:definition "A category that best matches the nature of a dwc:Identification."@en ;
-    skos:prefLabel "Identification Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identificationVerificationStatus>
     rdfs:label "Identification Verification Status"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as that used in HISPID and ABCD. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
     skos:definition "A categorical indicator of the extent to which a taxonomic determination has been verified to be correct."@en ;
-    skos:prefLabel "Identification Verification Status"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identifiedBy>
     rdfs:label "Identified By"@en ;
-    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A name for a dcterms:Agent responsible for making a dwc:Identification."@en ;
     skos:definition "A name for a dcterms:Agent responsible for making a dwc:Identification."@en ;
-    skos:prefLabel "Identified By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/identifiedByID>
     rdfs:label "Identified By ID"@en ;
-    dcterms:description "When used in the context of an eco:Survey, the subject consists of all of the dwc:Identifications related to the eco:Survey. Recommended best practice is to provide a single identifier that disambiguates the details of the identifying dcterms:Agent. If a list is used, the order of the identifiers on the list should not be assumed to convey any semantics. Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "An identifier for a dcterms:Agent responsible for making a dwc:Identification."@en ;
     skos:definition "An identifier for a dcterms:Agent responsible for making a dwc:Identification."@en ;
-    skos:prefLabel "Identified By ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/individualCount>
     rdfs:label "Individual Count"@en ;
-    rdfs:comment "The number of individuals present at the time of the dwc:Occurrence."@en ;
     skos:definition "The number of individuals present at the time of the dwc:Occurrence."@en ;
-    skos:prefLabel "Individual Count"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/individualID>
     rdfs:label "Individual ID"@en ;
-    dcterms:description "Examples: \"U.amer. 44\", \"Smedley\", \"Orca J 23\""@en ;
-    rdfs:comment "An identifier for an individual or named group of individual organisms represented in the Occurrence. Meant to accommodate resampling of the same individual or group for monitoring purposes. May be a global unique identifier or an identifier specific to a data set."@en ;
     skos:definition "An identifier for an individual or named group of individual organisms represented in the Occurrence. Meant to accommodate resampling of the same individual or group for monitoring purposes. May be a global unique identifier or an identifier specific to a data set."@en ;
-    skos:prefLabel "Individual ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/informationWithheld>
     rdfs:label "Information Withheld"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
     skos:definition "Additional information that exists about a resource, but that is not shared publicly. Suggests that alternative data of higher quality may be available on request."@en ;
-    skos:prefLabel "Information Withheld"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/infragenericEpithet>
     rdfs:label "Infrageneric Epithet"@en ;
-    dcterms:description "The term dwc:infragenericEpithet should be used in conjunction with dwc:genericName, dwc:specificEpithet, dwc:infraspecificEpithet, dwc:taxonRank and dwc:scientificNameAuthorship to represent the individual elements of the complete dwc:scientificName. It can be used to indicate the subgenus placement of a species, which in zoology is often given in parentheses. Can also be used to share infrageneric names such as botanical sections (e.g., `Vicia sect. Cracca`)."@en ;
-    rdfs:comment "The infrageneric part of a binomial name at ranks above species but below genus."@en ;
     skos:definition "The infrageneric part of a binomial name at ranks above species but below genus."@en ;
-    skos:prefLabel "Infrageneric Epithet"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/infraspecificEpithet>
     rdfs:label "Infraspecific Epithet"@en ;
-    dcterms:description "In botany, name strings in literature and identifications may have multiple infraspecific ranks. According to the International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code Articles 6.7 & Art. 24.1), valid names only have two epithets, with the lowest rank being the dwc:infraspecificEpithet. For example: the dwc:infraspecificEpithet in the string `Indigofera charlieriana subsp. sessilis var. scaberrima` is `scaberrima` and the dwc:scientificName is `Indigofera charlieriana var. scaberrima`. Use dwc:verbatimIdentification for the full name string used in a dwc:Identification. "@en ;
-    rdfs:comment "The name of the lowest or terminal infraspecific of the dwc:scientificName."@en ;
     skos:definition "The name of the lowest or terminal infraspecific of the dwc:scientificName."@en ;
-    skos:prefLabel "Infraspecific Epithet"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/institutionCode>
     rdfs:label "Institution Code"@en ;
-    dcterms:description "The institution having ownership of a resource should be given in dwc:ownerInstitutionCode."@en ;
-    rdfs:comment "A name (or acronym) in use by an institution having custody of a resource."@en ;
     skos:definition "A name (or acronym) in use by an institution having custody of a resource."@en ;
-    skos:prefLabel "Institution Code"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/institutionID>
     rdfs:label "Institution ID"@en ;
-    dcterms:description "For physical specimens, the recommended best practice is to use a globally unique and resolvable identifier from a collections registry such as the Research Organization Registry (ROR) or the Global Registry of Scientific Collections (https://scientific-collections.gbif.org/)."@en ;
-    rdfs:comment "An identifier for an organization."@en ;
     skos:definition "An identifier for an organization."@en ;
-    skos:prefLabel "Institution ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/isAcceptedIdentification>
     rdfs:label "Is Accepted Identification"@en ;
-    dcterms:description "Recommended best practice is to follow the TDWG Boolean Controlled Vocabulary http://rs.tdwg.org/tag/doc/boolean/."@en ;
-    rdfs:comment "An indicator that a dwc:Identification of a dwc:Organism is a currently an accepted or preferred one."@en ;
     skos:definition "An indicator that a dwc:Identification of a dwc:Organism is a currently an accepted or preferred one."@en ;
-    skos:prefLabel "Is Accepted Identification"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/island>
     rdfs:label "Island"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
-    rdfs:comment "The name of the island on or near which the dcterms:Location occurs."@en ;
     skos:definition "The name of the island on or near which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Island"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/islandGroup>
     rdfs:label "Island Group"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
-    rdfs:comment "The name of the island group in which the dcterms:Location occurs."@en ;
     skos:definition "The name of the island group in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Island Group"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/kingdom>
     rdfs:label "Kingdom"@en ;
-    rdfs:comment "The full scientific name of the kingdom in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the kingdom in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Kingdom"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/latestAgeOrHighestStage>
     rdfs:label "Latest Age Or Highest Stage"@en ;
-    rdfs:comment "The full name of the latest possible geochronologic age or highest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the latest possible geochronologic age or highest chronostratigraphic stage attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Latest Age Or Highest Stage"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/latestEonOrHighestEonothem>
     rdfs:label "Latest Eon Or Highest Eonothem"@en ;
-    rdfs:comment "The full name of the latest possible geochronologic eon or highest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the latest possible geochronologic eon or highest chronostratigraphic eonothem or the informal name attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Latest Eon Or Highest Eonothem"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/latestEpochOrHighestSeries>
     rdfs:label "Latest Epoch Or Highest Series"@en ;
-    rdfs:comment "The full name of the latest possible geochronologic epoch or highest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the latest possible geochronologic epoch or highest chronostratigraphic series attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Latest Epoch Or Highest Series"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/latestEraOrHighestErathem>
     rdfs:label "Latest Era Or Highest Erathem"@en ;
-    rdfs:comment "The full name of the latest possible geochronologic era or highest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the latest possible geochronologic era or highest chronostratigraphic erathem attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Latest Era Or Highest Erathem"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/latestPeriodOrHighestSystem>
     rdfs:label "Latest Period Or Highest System"@en ;
-    rdfs:comment "The full name of the latest possible geochronologic period or highest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the latest possible geochronologic period or highest chronostratigraphic system attributable to the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Latest Period Or Highest System"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/lifeStage>
     rdfs:label "Life Stage"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "An age class or life stage of a dwc:Organism."@en ;
     skos:definition "An age class or life stage of a dwc:Organism."@en ;
-    skos:prefLabel "Life Stage"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/lithostratigraphicTerms>
     rdfs:label "Lithostratigraphic Terms"@en ;
-    rdfs:comment "The combination of all lithostratigraphic names for the rock from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The combination of all lithostratigraphic names for the rock from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Lithostratigraphic Terms"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/locality>
     rdfs:label "Locality"@en ;
-    dcterms:description "Less specific geographic information can be provided in other geographic terms (dwc:higherGeography, dwc:continent, dwc:country, dwc:stateProvince, dwc:county, dwc:municipality, dwc:waterBody, dwc:island, dwc:islandGroup). This term may contain information modified from the original to correct perceived errors or standardize the description."@en ;
-    rdfs:comment "The specific description of the place."@en ;
     skos:definition "The specific description of the place."@en ;
-    skos:prefLabel "Locality"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/locationAccordingTo>
     rdfs:label "Location According To"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
     skos:definition "Information about the source of this dcterms:Location information. Could be a publication (gazetteer), institution, or team of individuals."@en ;
-    skos:prefLabel "Location According To"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/locationAttributes>
     rdfs:label "Location Attributes"@en ;
-    dcterms:description "Example: \"aspectheading=277; slopeindegrees=6\""@en ;
-    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the location."@en ;
     skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the location."@en ;
-    skos:prefLabel "Location Attributes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/locationID>
     rdfs:label "Location ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dcterms:Location."@en ;
     skos:definition "An identifier for a dcterms:Location."@en ;
-    skos:prefLabel "Location ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/locationRemarks>
     rdfs:label "Location Remarks"@en ;
-    rdfs:comment "Comments or notes about the dcterms:Location."@en ;
     skos:definition "Comments or notes about the dcterms:Location."@en ;
-    skos:prefLabel "Location Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/lowestBiostratigraphicZone>
     rdfs:label "Lowest Biostratigraphic Zone"@en ;
-    rdfs:comment "The full name of the lowest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the lowest possible geological biostratigraphic zone of the stratigraphic horizon from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Lowest Biostratigraphic Zone"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/materialEntityCategory>
     rdfs:label "Material Entity Category"@en ;
-    dcterms:description "Recommended best practice is to use a limited, tightly controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
     skos:definition "A high-level, mutually exclusive classification describing the fundamental substance and origin of a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Material Entity Category"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/materialEntityID>
     rdfs:label "Material Entity ID"@en ;
-    dcterms:description "Values of dwc:materialEntityID are intended to uniquely and persistently identify a particular dwc:MaterialEntity within some context. Examples of context include a particular sample collection, an organization, or the worldwide scale. Recommended best practice is to use a persistent, globally unique identifier. The identifier is bound to a physical object (the dwc:MaterialEntity) as opposed to a particular digital record (representation) of that physical object."@en ;
-    rdfs:comment "An identifier for a particular instance of a dwc:MaterialEntity."@en ;
     skos:definition "An identifier for a particular instance of a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Material Entity ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/materialEntityRemarks>
     rdfs:label "Material Entity Remarks"@en ;
-    rdfs:comment "Comments or notes about a dwc:MaterialEntity."@en ;
     skos:definition "Comments or notes about a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Material Entity Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/materialEntityType>
     rdfs:label "Material Entity Type"@en ;
-    dcterms:description "A more generic classification of a dwc:MaterialEntity than dwc:preparations. Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
     skos:definition "A more generic classification of a dwc:MaterialEntity than dwc:preparations but less broad than dwc:materialCategory."@en ;
-    skos:prefLabel "Material Entity Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/materialSampleID>
     rdfs:label "Material Sample ID"@en ;
-    dcterms:description "Recommended best practice is to use a persistent, globally unique identifier."@en ;
-    rdfs:comment "An identifier for the dwc:MaterialSample (as opposed to a particular digital record of the dwc:MaterialSample). In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the dwc:materialSampleID globally unique."@en ;
     skos:definition "An identifier for the dwc:MaterialSample (as opposed to a particular digital record of the dwc:MaterialSample). In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the dwc:materialSampleID globally unique."@en ;
-    skos:prefLabel "Material Sample ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/maximumDepthInMeters>
     rdfs:label "Maximum Depth In Meters"@en ;
-    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
-    rdfs:comment "The greatest depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
     skos:definition "The greatest depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
-    skos:prefLabel "Maximum Depth In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/maximumDistanceAboveSurfaceInMeters>
     rdfs:label "Maximum Distance Above Surface In Meters"@en ;
-    rdfs:comment "The greater distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
     skos:definition "The greater distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
-    skos:prefLabel "Maximum Distance Above Surface In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/maximumElevationInMeters>
     rdfs:label "Maximum Elevation In Meters"@en ;
-    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
-    rdfs:comment "The greatest elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
     skos:definition "The greatest elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
-    skos:prefLabel "Maximum Elevation In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementAccuracy>
     rdfs:label "Measurement Accuracy"@en ;
-    rdfs:comment "The description of the potential error associated with the dwc:measurementValue."@en ;
     skos:definition "The description of the potential error associated with the dwc:measurementValue."@en ;
-    skos:prefLabel "Measurement Accuracy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementDeterminedBy>
     rdfs:label "Measurement Determined By"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A list (concatenated and separated) of names of people, groups, or organizations who determined the value of the dwc:MeasurementOrFact."@en ;
     skos:definition "A list (concatenated and separated) of names of people, groups, or organizations who determined the value of the dwc:MeasurementOrFact."@en ;
-    skos:prefLabel "Measurement Determined By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementDeterminedDate>
     rdfs:label "Measurement Determined Date"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "The date on which the dwc:MeasurementOrFact was made."@en ;
     skos:definition "The date on which the dwc:MeasurementOrFact was made."@en ;
-    skos:prefLabel "Measurement Determined Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementID>
     rdfs:label "Measurement ID"@en ;
-    rdfs:comment "An identifier for the dwc:MeasurementOrFact (information pertaining to measurements, facts, characteristics, or assertions). May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the dwc:MeasurementOrFact (information pertaining to measurements, facts, characteristics, or assertions). May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Measurement ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementMethod>
     rdfs:label "Measurement Method"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A description of or reference to (publication, URI) the method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
     skos:definition "A description of or reference to (publication, URI) the method or protocol used to determine the measurement, fact, characteristic, or assertion."@en ;
-    skos:prefLabel "Measurement Method"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementRemarks>
     rdfs:label "Measurement Remarks"@en ;
-    rdfs:comment "Comments or notes accompanying the dwc:MeasurementOrFact."@en ;
     skos:definition "Comments or notes accompanying the dwc:MeasurementOrFact."@en ;
-    skos:prefLabel "Measurement Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementType>
     rdfs:label "Measurement Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The nature of the measurement, fact, characteristic, or assertion."@en ;
     skos:definition "The nature of the measurement, fact, characteristic, or assertion."@en ;
-    skos:prefLabel "Measurement Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementUnit>
     rdfs:label "Measurement Unit"@en ;
-    dcterms:description "Recommended best practice is to use the International System of Units (SI). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The units associated with the dwc:measurementValue."@en ;
     skos:definition "The units associated with the dwc:measurementValue."@en ;
-    skos:prefLabel "Measurement Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/measurementValue>
     rdfs:label "Measurement Value"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The value of the measurement, fact, characteristic, or assertion."@en ;
     skos:definition "The value of the measurement, fact, characteristic, or assertion."@en ;
-    skos:prefLabel "Measurement Value"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/member>
     rdfs:label "Member"@en ;
-    rdfs:comment "The full name of the lithostratigraphic member from which the dwc:MaterialEntity was collected."@en ;
     skos:definition "The full name of the lithostratigraphic member from which the dwc:MaterialEntity was collected."@en ;
-    skos:prefLabel "Member"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/minimumDepthInMeters>
     rdfs:label "Minimum Depth In Meters"@en ;
-    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
-    rdfs:comment "The least depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
     skos:definition "The least depth within a range of depths, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
-    skos:prefLabel "Minimum Depth In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/minimumDistanceAboveSurfaceInMeters>
     rdfs:label "Minimum Distance Above Surface In Meters"@en ;
-    rdfs:comment "The lesser distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
     skos:definition "The lesser distance in a range of distance from a reference surface in the vertical direction, in meters. Use positive values for locations above the surface, negative values for locations below. If depth measures are given, the reference surface is the location given by the depth, otherwise the reference surface is the location given by the elevation."@en ;
-    skos:prefLabel "Minimum Distance Above Surface In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/minimumElevationInMeters>
     rdfs:label "Minimum Elevation In Meters"@en ;
-    dcterms:description "See https://docs.gbif.org/georeferencing-best-practices/1.0/en/#img-depth-elevation-distance-above-surface."@en ;
-    rdfs:comment "The least elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
     skos:definition "The least elevation within a range of elevations, measured relative to the vertical reference surface indicated by the value of dwc:verticalDatum."@en ;
-    skos:prefLabel "Minimum Elevation In Meters"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/molecularProtocolID>
     rdfs:label "Molecular Protocol ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dwc:MolecularProtocol."@en ;
     skos:definition "An identifier for a dwc:MolecularProtocol."@en ;
-    skos:prefLabel "Molecular Protocol ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/month>
     rdfs:label "Month"@en ;
-    rdfs:comment "The integer month in which the dwc:Event occurred."@en ;
     skos:definition "The integer month in which the dwc:Event occurred."@en ;
-    skos:prefLabel "Month"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/municipality>
     rdfs:label "Third Order Division"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
-    rdfs:comment "The full, unabbreviated name of the next smaller administrative region than county (city, municipality, etc.) in which the dcterms:Location occurs. Do not use this term for a nearby named place that does not contain the actual dcterms:Location."@en ;
     skos:definition "The full, unabbreviated name of the next smaller administrative region than county (city, municipality, etc.) in which the dcterms:Location occurs. Do not use this term for a nearby named place that does not contain the actual dcterms:Location."@en ;
-    skos:prefLabel "Third Order Division"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/nameAccordingTo>
     rdfs:label "Name According To"@en ;
-    dcterms:description "This term provides context to the dwc:scientificName. Together with the dwc:scientificName, separated by `sensu` or `sec.`, it forms the taxon concept label, which may be seen as having the same relationship to dwc:taxonConceptID as, for example, dwc:acceptedNameUsage has to dwc:acceptedNameUsageID. When not provided, in Taxon Core data sets the dwc:nameAccordingTo can be taken to be the data set. In this case the data set mostly provides sufficient context to infer the delimitation of the taxon and its relationship with other taxa. In Occurrence Core data sets, when not provided, dwc:nameAccordingTo can be an underlying taxonomy of the data set, e.g., Plants of the World Online (http://powo.science.kew.org/) for vascular plant records in iNaturalist (in which case it should be provided), or, which is the case for most dwc:PreservedSpecimen data sets, the dwc:Identification, in which case there is no further context."@en ;
-    rdfs:comment "The reference to the source in which the specific taxon concept circumscription is defined or implied - traditionally signified by the Latin \"sensu\" or \"sec.\" (from secundum, meaning \"according to\"). For taxa that result from identifications, a reference to the keys, monographs, experts and other sources should be given."@en ;
     skos:definition "The reference to the source in which the specific taxon concept circumscription is defined or implied - traditionally signified by the Latin \"sensu\" or \"sec.\" (from secundum, meaning \"according to\"). For taxa that result from identifications, a reference to the keys, monographs, experts and other sources should be given."@en ;
-    skos:prefLabel "Name According To"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/nameAccordingToID>
     rdfs:label "Name According To ID"@en ;
-    rdfs:comment "An identifier for the source in which the specific taxon concept circumscription is defined or implied. See dwc:nameAccordingTo."@en ;
     skos:definition "An identifier for the source in which the specific taxon concept circumscription is defined or implied. See dwc:nameAccordingTo."@en ;
-    skos:prefLabel "Name According To ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/namePublicationID>
     rdfs:label "Name Publication ID"@en ;
-    dcterms:description "Example: \"http://hdl.handle.net/10199/7\""@en ;
-    rdfs:comment "A resolvable globally unique identifier for the original publication of the scientificName."@en ;
     skos:definition "A resolvable globally unique identifier for the original publication of the scientificName."@en ;
-    skos:prefLabel "Name Publication ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/namePublishedIn>
     rdfs:label "Name Published In"@en ;
-    dcterms:description "A citation of the first publication of the name in its given combination, not the basionym / original name. Recombinations are often not published in zoology, in which case dwc:namePublishedIn should be empty."@en ;
-    rdfs:comment "A reference for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
     skos:definition "A reference for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
-    skos:prefLabel "Name Published In"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/namePublishedInID>
     rdfs:label "Name Published In ID"@en ;
-    dcterms:description "A citation of the first publication of the name in its given combination, not the basionym / original name. Recombinations are often not published in zoology, in which case dwc:namePublishedInID should be empty."@en ;
-    rdfs:comment "An identifier for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
     skos:definition "An identifier for the publication in which the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
-    skos:prefLabel "Name Published In ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/namePublishedInYear>
     rdfs:label "Name Published In Year"@en ;
-    rdfs:comment "The four-digit year in which the dwc:scientificName was published."@en ;
     skos:definition "The four-digit year in which the dwc:scientificName was published."@en ;
-    skos:prefLabel "Name Published In Year"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/nomenclaturalCode>
     rdfs:label "Nomenclatural Code"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
-    rdfs:comment "The nomenclatural code (or codes in the case of an ambiregnal name) under which the dwc:scientificName is constructed."@en ;
     skos:definition "The nomenclatural code (or codes in the case of an ambiregnal name) under which the dwc:scientificName is constructed."@en ;
-    skos:prefLabel "Nomenclatural Code"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/nomenclaturalStatus>
     rdfs:label "Nomenclatural Status"@en ;
-    rdfs:comment "The status related to the original publication of the name and its conformance to the relevant rules of nomenclature. It is based essentially on an algorithm according to the business rules of the code. It requires no taxonomic opinion."@en ;
     skos:definition "The status related to the original publication of the name and its conformance to the relevant rules of nomenclature. It is based essentially on an algorithm according to the business rules of the code. It requires no taxonomic opinion."@en ;
-    skos:prefLabel "Nomenclatural Status"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/nucleotideSequenceRemarks>
     rdfs:label "Nucleotide Sequence Remarks"@en ;
-    rdfs:comment "Comments or notes about a dwc:NucleotideSequence."@en ;
     skos:definition "Comments or notes about a dwc:NucleotideSequence."@en ;
-    skos:prefLabel "Nucleotide Sequence Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/objectQuantity>
     rdfs:label "Object Quantity"@en ;
-    dcterms:description "An dwc:objectQuantity must have a corresponding dwc:objectQuantityType."@en ;
-    rdfs:comment "A number or enumeration value for the quantity of differentiable dwc:MaterialEntities comprising this dwc:MaterialEntity."@en ;
     skos:definition "A number or enumeration value for the quantity of differentiable dwc:MaterialEntities comprising this dwc:MaterialEntity."@en ;
-    skos:prefLabel "Object Quantity"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/objectQuantityType>
     rdfs:label "Object Quantity Type"@en ;
-    dcterms:description "An dwc:objectQuantityType must have a corresponding dwc:objectQuantity. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
     skos:definition "The type of quantification system used for the quantity of dwc:MaterialEntities."@en ;
-    skos:prefLabel "Object Quantity Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceAttributes>
     rdfs:label "Occurrence Attributes"@en ;
-    dcterms:description "Examples: \"Tragus length: 14mm; Weight: 120g\", \"Height: 1-1.5 meters tall; flowers yellow; uncommon\"."@en ;
-    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Occurrence."@en ;
     skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the Occurrence."@en ;
-    skos:prefLabel "Occurrence Attributes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceDetails>
     rdfs:label "Occurrence Details"@en ;
-    dcterms:description "Example: \"http://mvzarctos.berkeley.edu/guid/MVZ:Mamm:165861\""@en ;
-    rdfs:comment "A reference (publication, URI) to the most detailed information available about the Occurrence."@en ;
     skos:definition "A reference (publication, URI) to the most detailed information available about the Occurrence."@en ;
-    skos:prefLabel "Occurrence Details"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceID>
     rdfs:label "Occurrence ID"@en ;
-    dcterms:description "In the absence of a persistent global unique identifier, construct one from a combination of identifiers in the record that will most closely make the dwc:occurrenceID globally unique."@en ;
-    rdfs:comment "An identifier for a dwc:Occurrence (as opposed to a particular digital record of a dwc:Occurrence)."@en ;
     skos:definition "An identifier for a dwc:Occurrence (as opposed to a particular digital record of a dwc:Occurrence)."@en ;
-    skos:prefLabel "Occurrence ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementAccuracy>
     rdfs:label "Occurrence Measurement Accuracy"@en ;
-    dcterms:description "Example: \"0.01\", \"normal distribution with variation of 2 m\""@en ;
-    rdfs:comment "The description of the error associated with the occurrenceAttributeValue."@en ;
     skos:definition "The description of the error associated with the occurrenceAttributeValue."@en ;
-    skos:prefLabel "Occurrence Measurement Accuracy"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementDeterminedBy>
     rdfs:label "Occurrence Measurement Determined By"@en ;
-    dcterms:description "Example: \"Javier de la Torre\""@en ;
-    rdfs:comment "The agent responsible for having determined the value of the measurement or characteristic of the occurrence."@en ;
     skos:definition "The agent responsible for having determined the value of the measurement or characteristic of the occurrence."@en ;
-    skos:prefLabel "Occurrence Measurement Determined By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementDeterminedDate>
     rdfs:label "Occurrence Measurement Determined Date"@en ;
-    dcterms:description "Examples: \"1963-03-08T14:07-0600\" is 8 Mar 1963 2:07pm in the time zone six hours earlier than UTC, \"2009-02-20T08:40Z\" is 20 Feb 2009 8:40am UTC, \"1809-02-12\" is 12 Feb 1809, \"1906-06\" is Jun 1906, \"1971\" is just that year, \"2007-03-01T13:00:00Z/2008-05-11T15:30:00Z\" is the interval between 1 Mar 2007 1pm UTC and 11 May 2008 3:30pm UTC, \"2007-11-13/15\" is the interval between 13 Nov 2007 and 15 Nov 2007."@en ;
-    rdfs:comment "The date on which the the measurement or characteristic of the occurrence was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
     skos:definition "The date on which the the measurement or characteristic of the occurrence was made. Recommended best practice is to use an encoding scheme, such as ISO 8601:2004(E)."@en ;
-    skos:prefLabel "Occurrence Measurement Determined Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementID>
     rdfs:label "Occurrence Measurement ID"@en ;
-    rdfs:comment "An identifier for the occurrence attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the occurrence attribute. May be a global unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Occurrence Measurement ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementRemarks>
     rdfs:label "Occurrence Measurement Remarks"@en ;
-    dcterms:description "Example: \"tip of tail missing\""@en ;
-    rdfs:comment "Comments or notes accompanying the measurement or characteristic of the occurrence."@en ;
     skos:definition "Comments or notes accompanying the measurement or characteristic of the occurrence."@en ;
-    skos:prefLabel "Occurrence Measurement Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementType>
     rdfs:label "Occurrence Measurement Type"@en ;
-    dcterms:description "Example: \"tail length\""@en ;
-    rdfs:comment "The nature of the measurement or characteristic of the occurrence. Recommended best practice is to use a controlled vocabulary."@en ;
     skos:definition "The nature of the measurement or characteristic of the occurrence. Recommended best practice is to use a controlled vocabulary."@en ;
-    skos:prefLabel "Occurrence Measurement Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementUnit>
     rdfs:label "Occurrence Measurement Unit"@en ;
-    dcterms:description "Example: \"mm\""@en ;
-    rdfs:comment "The units for the value of the measurement or characteristic of the occurrence. Recommended best practice is to use International System of Units (SI) units."@en ;
     skos:definition "The units for the value of the measurement or characteristic of the occurrence. Recommended best practice is to use International System of Units (SI) units."@en ;
-    skos:prefLabel "Occurrence Measurement Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceMeasurementValue>
     rdfs:label "Occurrence Measurement Value"@en ;
-    dcterms:description "Example: \"45\""@en ;
-    rdfs:comment "The value of the measurement or characteristic of the occurrence."@en ;
     skos:definition "The value of the measurement or characteristic of the occurrence."@en ;
-    skos:prefLabel "Occurrence Measurement Value"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceRemarks>
     rdfs:label "Occurrence Remarks"@en ;
-    rdfs:comment "Comments or notes about the dwc:Occurrence."@en ;
     skos:definition "Comments or notes about the dwc:Occurrence."@en ;
-    skos:prefLabel "Occurrence Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/occurrenceStatus>
     rdfs:label "Occurrence Status"@en ;
-    dcterms:description "For dwc:Occurrences, the default vocabulary is recommended to consist of detected and notDetected, but can be extended by implementers with good justification. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
     skos:definition "A statement about the detection or non-detection of a dwc:Organism during a dwc:Event."@en ;
-    skos:prefLabel "Occurrence Status"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/order>
     rdfs:label "Order"@en ;
-    rdfs:comment "The full scientific name of the order in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the order in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Order"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismID>
     rdfs:label "Organism ID"@en ;
-    rdfs:comment "An identifier for the dwc:Organism instance (as opposed to a particular digital record of the dwc:Organism). May be a globally unique identifier or an identifier specific to the data set."@en ;
     skos:definition "An identifier for the dwc:Organism instance (as opposed to a particular digital record of the dwc:Organism). May be a globally unique identifier or an identifier specific to the data set."@en ;
-    skos:prefLabel "Organism ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismInteractionDescription>
     rdfs:label "Organism Interaction Description"@en ;
-    rdfs:comment "A verbatim description of a dwc:OrganismInteraction."@en ;
     skos:definition "A verbatim description of a dwc:OrganismInteraction."@en ;
-    skos:prefLabel "Organism Interaction Description"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismInteractionID>
     rdfs:label "Organism Interaction ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dwc:OrganismInteraction."@en ;
     skos:definition "An identifier for a dwc:OrganismInteraction."@en ;
-    skos:prefLabel "Organism Interaction ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismInteractionType>
     rdfs:label "Organism Interaction Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
     skos:definition "A category that best matches the nature of a dwc:OrganismInteraction."@en ;
-    skos:prefLabel "Organism Interaction Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismName>
     rdfs:label "Organism Name"@en ;
-    rdfs:comment "A textual name or label assigned to a dwc:Organism instance."@en ;
     skos:definition "A textual name or label assigned to a dwc:Organism instance."@en ;
-    skos:prefLabel "Organism Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismQuantity>
     rdfs:label "Organism Quantity"@en ;
-    dcterms:description "A dwc:organismQuantity must have a corresponding dwc:organismQuantityType."@en ;
-    rdfs:comment "A number or enumeration value for the quantity of dwc:Organisms."@en ;
     skos:definition "A number or enumeration value for the quantity of dwc:Organisms."@en ;
-    skos:prefLabel "Organism Quantity"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismQuantityType>
     rdfs:label "Organism Quantity Type"@en ;
-    dcterms:description "A dwc:organismQuantityType must have a corresponding dwc:organismQuantity. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The type of quantification system used for the quantity of dwc:Organisms."@en ;
     skos:definition "The type of quantification system used for the quantity of dwc:Organisms."@en ;
-    skos:prefLabel "Organism Quantity Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismRemarks>
     rdfs:label "Organism Remarks"@en ;
-    rdfs:comment "Comments or notes about the dwc:Organism instance."@en ;
     skos:definition "Comments or notes about the dwc:Organism instance."@en ;
-    skos:prefLabel "Organism Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/organismScope>
     rdfs:label "Organism Scope"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term is not intended to be used to specify a type of dwc:Taxon. To describe the kind of dwc:Organism using a URI object in RDF, use rdf:type (http://www.w3.org/1999/02/22-rdf-syntax-ns#type) instead."@en ;
-    rdfs:comment "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
     skos:definition "A description of the kind of dwc:Organism instance. Can be used to indicate whether the dwc:Organism instance represents a discrete organism or if it represents a particular type of aggregation."@en ;
-    skos:prefLabel "Organism Scope"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/originalNameUsage>
     rdfs:label "Original Name Usage"@en ;
-    dcterms:description "The full scientific name, with authorship and date information if known, of the name usage in which the terminal element of the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode. For example, for names governed by the ICNafp, this term would indicate the basionym of a record representing a subsequent combination. Unlike basionyms, however, this term can apply to scientific names at all ranks."@en ;
-    rdfs:comment "The taxon name, with authorship and date information if known, as it originally appeared when first established under the rules of the associated dwc:nomenclaturalCode. The basionym (botany) or basonym (bacteriology) of the dwc:scientificName or the senior/earlier homonym for replaced names."@en ;
     skos:definition "The taxon name, with authorship and date information if known, as it originally appeared when first established under the rules of the associated dwc:nomenclaturalCode. The basionym (botany) or basonym (bacteriology) of the dwc:scientificName or the senior/earlier homonym for replaced names."@en ;
-    skos:prefLabel "Original Name Usage"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/originalNameUsageID>
     rdfs:label "Original Name Usage ID"@en ;
-    dcterms:description "This term should be used to refer to the dwc:taxonID of a dwc:Taxon record that represents the usage of the terminal element of the dwc:scientificName as originally established under the rules of the associated dwc:nomenclaturalCode. For example, for names governed by the ICNafp, this term would establish the relationship between a record representing a subsequent combination and the record for its corresponding basionym. Unlike basionyms, however, this term can apply to scientific names at all ranks. For Darwin Core Archives the related record should be present locally in the same archive."@en ;
-    rdfs:comment "An identifier for the name usage (documented meaning of the name according to a source) in which the terminal element of the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
     skos:definition "An identifier for the name usage (documented meaning of the name according to a source) in which the terminal element of the dwc:scientificName was originally established under the rules of the associated dwc:nomenclaturalCode."@en ;
-    skos:prefLabel "Original Name Usage ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/otherCatalogNumbers>
     rdfs:label "Other Catalog Numbers"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of previous or alternate fully qualified catalog numbers or other human-used identifiers for the same dwc:MaterialEntity, whether in the current or any other data set or collection."@en ;
     skos:definition "A list (concatenated and separated) of previous or alternate fully qualified catalog numbers or other human-used identifiers for the same dwc:MaterialEntity, whether in the current or any other data set or collection."@en ;
-    skos:prefLabel "Other Catalog Numbers"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/ownerInstitutionCode>
     rdfs:label "Owner Institution Code"@en ;
-    rdfs:comment "A name (or acronym) in use by an institution having ownership of a resource."@en ;
     skos:definition "A name (or acronym) in use by an institution having ownership of a resource."@en ;
-    skos:prefLabel "Owner Institution Code"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/parentEventID>
     rdfs:label "Parent Event ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a broader dwc:Event that contains this and potentially other dwc:Events."@en ;
     skos:definition "An identifier for a broader dwc:Event that contains this and potentially other dwc:Events."@en ;
-    skos:prefLabel "Parent Event ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/parentMeasurementID>
     rdfs:label "Parent Measurement ID"@en ;
-    dcterms:description "May be a globally unique identifier or an identifier specific to the data set."@en ;
-    rdfs:comment "An identifier for a broader dwc:MeasurementOrFact that groups this and potentially other dwc:MeasurementOrFacts."@en ;
     skos:definition "An identifier for a broader dwc:MeasurementOrFact that groups this and potentially other dwc:MeasurementOrFacts."@en ;
-    skos:prefLabel "Parent Measurement ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/parentNameUsage>
     rdfs:label "Parent Name Usage"@en ;
-    rdfs:comment "The full name, with authorship and date information if known, of the direct, most proximate higher-rank parent dwc:Taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
     skos:definition "The full name, with authorship and date information if known, of the direct, most proximate higher-rank parent dwc:Taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
-    skos:prefLabel "Parent Name Usage"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/parentNameUsageID>
     rdfs:label "Parent Name Usage ID"@en ;
-    dcterms:description "This term should be used for accepted names to refer to the dwc:taxonID of a dwc:Taxon record that represents the next higher taxon rank in the same taxonomic classification. For Darwin Core Archives the related record should be present locally in the same archive."@en ;
-    rdfs:comment "An identifier for the name usage (documented meaning of the name according to a source) of the direct, most proximate higher-rank parent taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
     skos:definition "An identifier for the name usage (documented meaning of the name according to a source) of the direct, most proximate higher-rank parent taxon (in a classification) of the most specific element of the dwc:scientificName."@en ;
-    skos:prefLabel "Parent Name Usage ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/pathway>
     rdfs:label "Pathway"@en ;
-    dcterms:description "Recommended best practice is to use controlled value strings from the controlled vocabulary designated for use with this term, listed at http://rs.tdwg.org/dwc/doc/pw/. For details, refer to https://doi.org/10.3897/biss.3.38084. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
     skos:definition "The process by which a dwc:Organism came to be in a given place at a given time."@en ;
-    skos:prefLabel "Pathway"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/phylum>
     rdfs:label "Phylum"@en ;
-    rdfs:comment "The full scientific name of the phylum or division in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the phylum or division in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Phylum"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/pointRadiusSpatialFit>
     rdfs:label "Point Radius Spatial Fit"@en ;
-    dcterms:description "Legal values are 0, greater than or equal to 1, or undefined. A value of 1 is an exact match or 100% overlap. A value of 0 should be used if the given point-radius does not completely contain the original representation. The pointRadiusSpatialFit is undefined (and should be left empty) if the original representation is any geometry without area (e.g., a point or polyline) and without uncertainty and the given georeference is not that same geometry (without uncertainty). If both the original and the given georeference are the same point, the pointRadiusSpatialFit is 1. Detailed explanations with graphical examples can be found in the Georeferencing Best Practices, Chapman and Wieczorek, 2020 (https://doi.org/10.15468/doc-gg7h-s853)."@en ;
-    rdfs:comment "A ratio of the area of a point-radius (dwc:decimalLatitude, dwc:decimalLongitude, dwc:coordinateUncertaintyInMeters) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
     skos:definition "A ratio of the area of a point-radius (dwc:decimalLatitude, dwc:decimalLongitude, dwc:coordinateUncertaintyInMeters) to the area of a true (original, or most specific) spatial representation of a dcterms:Location."@en ;
-    skos:prefLabel "Point Radius Spatial Fit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/preferredSpatialRepresentation>
     rdfs:label "Preferred Spatial Representation"@en ;
-    rdfs:comment "An indication of which spatial representation best represents the dcterms:Location."@en ;
     skos:definition "An indication of which spatial representation best represents the dcterms:Location."@en ;
-    skos:prefLabel "Preferred Spatial Representation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/preparations>
     rdfs:label "Preparations"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A list (concatenated and separated) of preparations and preservation methods for a dwc:MaterialEntity."@en ;
     skos:definition "A list (concatenated and separated) of preparations and preservation methods for a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Preparations"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/previousIdentifications>
     rdfs:label "Previous Identifications"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of previous assignments of names to the dwc:Organism."@en ;
     skos:definition "A list (concatenated and separated) of previous assignments of names to the dwc:Organism."@en ;
-    skos:prefLabel "Previous Identifications"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/processedTotalReadCount>
     rdfs:label "Processed Total Read Count"@en ;
-    rdfs:comment "The total number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
     skos:definition "The total number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
-    skos:prefLabel "Processed Total Read Count"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/projectID>
     rdfs:label "Project ID"@en ;
-    dcterms:description "A projectID may be shared in multiple distinct datasets. The nature of the association can be described in the metadata project description element. This term should be used to provide a globally unique identifier (GUID) for a project, if available. This could be a DOI, URI, or any other persistent identifier that ensures a project can be uniquely distinguished from others. The Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of identifiers for projects that contributed to a dwc:Event."@en ;
     skos:definition "A list (concatenated and separated) of identifiers for projects that contributed to a dwc:Event."@en ;
-    skos:prefLabel "Project ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/projectTitle>
     rdfs:label "Project Title"@en ;
-    dcterms:description "Use this term to provide the official name or title of a project as it is commonly known and cited. Avoid abbreviations unless they are widely understood. The recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of titles or names for projects that contributed to a dwc:Event."@en ;
     skos:definition "A list (concatenated and separated) of titles or names for projects that contributed to a dwc:Event."@en ;
-    skos:prefLabel "Project Title"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/protocolDescription>
     rdfs:label "Protocol Description"@en ;
-    rdfs:comment "A detailed description of a dwc:Protocol."@en ;
     skos:definition "A detailed description of a dwc:Protocol."@en ;
-    skos:prefLabel "Protocol Description"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/protocolID>
     rdfs:label "Protocol ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dwc:Protocol."@en ;
     skos:definition "An identifier for a dwc:Protocol."@en ;
-    skos:prefLabel "Protocol ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/protocolReferences>
     rdfs:label "Protocol References"@en ;
-    dcterms:description "Recommended best practice is to separate multiple values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Protocol."@en ;
     skos:definition "A list (concatenated and separated) of dcterms:BibliographicResources used in a dwc:Protocol."@en ;
-    skos:prefLabel "Protocol References"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/protocolRemarks>
     rdfs:label "Protocol Remarks"@en ;
-    rdfs:comment "Comments or notes about a dwc:Protocol."@en ;
     skos:definition "Comments or notes about a dwc:Protocol."@en ;
-    skos:prefLabel "Protocol Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/protocolType>
     rdfs:label "Protocol Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category that best matches the nature of a dwc:Protocol."@en ;
     skos:definition "A category that best matches the nature of a dwc:Protocol."@en ;
-    skos:prefLabel "Protocol Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/readCount>
     rdfs:label "Read Count"@en ;
-    rdfs:comment "The number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
     skos:definition "The number of reads obtained for a processed dwc:NucleotideSequence during a dwc:NucleotideAnalysis."@en ;
-    skos:prefLabel "Read Count"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/recordNumber>
     rdfs:label "Record Number"@en ;
-    dcterms:description "This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
     skos:definition "An identifier given to the dwc:Occurrence at the time it was recorded. Often serves as a link between field notes and a dwc:Occurrence record, such as a specimen collector's number."@en ;
-    skos:prefLabel "Record Number"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/recordedBy>
     rdfs:label "Recorded By"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A name for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
     skos:definition "A name for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
-    skos:prefLabel "Recorded By"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/recordedByID>
     rdfs:label "Recorded By ID"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `)."@en ;
-    rdfs:comment "An identifier for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
     skos:definition "An identifier for a dcterms:Agent responsible for recording a dwc:Occurrence."@en ;
-    skos:prefLabel "Recorded By ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/referenceID>
     rdfs:label "Reference ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dcterms:BibliographicResource."@en ;
     skos:definition "An identifier for a dcterms:BibliographicResource."@en ;
-    skos:prefLabel "Reference ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/referenceRemarks>
     rdfs:label "Reference Remarks"@en ;
-    rdfs:comment "Comments or notes about a dcterms:BibliographicResource."@en ;
     skos:definition "Comments or notes about a dcterms:BibliographicResource."@en ;
-    skos:prefLabel "Reference Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/referenceType>
     rdfs:label "Reference Type"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
-    rdfs:comment "A category that best matches the nature of a dcterms:BibliographicResource."@en ;
     skos:definition "A category that best matches the nature of a dcterms:BibliographicResource."@en ;
-    skos:prefLabel "Reference Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relatedResourceID>
     rdfs:label "Related Resource ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for the related resource (the object) of a dwc:ResourceRelationship."@en ;
     skos:definition "An identifier for the related resource (the object) of a dwc:ResourceRelationship."@en ;
-    skos:prefLabel "Related Resource ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relatedResourceType>
     rdfs:label "Related Resource Type"@en ;
-    dcterms:description "Examples: \"StillImage\", \"MovingImage\", \"Sound\", PhysicalObject\", \"PreservedSpecimen\", FossilSpecimen\", LivingSpecimen\", \"HumanObservation\", \"MachineObservation\", \"Location\", \"Taxonomy\", \"NomeclaturalChecklist\", \"Publication\""@en ;
-    rdfs:comment "The type of the related resource. Recommended best practice is to use a controlled vocabulary."@en ;
     skos:definition "The type of the related resource. Recommended best practice is to use a controlled vocabulary."@en ;
-    skos:prefLabel "Related Resource Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relationshipAccordingTo>
     rdfs:label "Relationship According To"@en ;
-    rdfs:comment "The source (person, organization, publication, reference) establishing the relationship between the two resources."@en ;
     skos:definition "The source (person, organization, publication, reference) establishing the relationship between the two resources."@en ;
-    skos:prefLabel "Relationship According To"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relationshipEstablishedDate>
     rdfs:label "Relationship Established Date"@en ;
-    dcterms:description "Recommended best practice is to use a date that conforms to ISO 8601-1:2019."@en ;
-    rdfs:comment "The date-time on which the relationship between the two resources was established."@en ;
     skos:definition "The date-time on which the relationship between the two resources was established."@en ;
-    skos:prefLabel "Relationship Established Date"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relationshipOfResource>
     rdfs:label "Relationship Of Resource"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
-    rdfs:comment "The relationship of the subject (identified by dwc:resourceID) to the object (identified by dwc:relatedResourceID)."@en ;
     skos:definition "The relationship of the subject (identified by dwc:resourceID) to the object (identified by dwc:relatedResourceID)."@en ;
-    skos:prefLabel "Relationship Of Resource"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relationshipOfResourceID>
     rdfs:label "Relationship Of Resource ID"@en ;
-    dcterms:description "Recommended best practice is to use the identifiers of the terms in a controlled vocabulary, such as the OBO Relation Ontology."@en ;
-    rdfs:comment "An identifier for the relationship type (predicate) that connects the subject identified by dwc:resourceID to its object identified by dwc:relatedResourceID."@en ;
     skos:definition "An identifier for the relationship type (predicate) that connects the subject identified by dwc:resourceID to its object identified by dwc:relatedResourceID."@en ;
-    skos:prefLabel "Relationship Of Resource ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/relationshipRemarks>
     rdfs:label "Relationship Remarks"@en ;
-    rdfs:comment "Comments or notes about the relationship between the two resources."@en ;
     skos:definition "Comments or notes about the relationship between the two resources."@en ;
-    skos:prefLabel "Relationship Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/reproductiveCondition>
     rdfs:label "Reproductive Condition"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A reproductive condition of a dwc:Organism."@en ;
     skos:definition "A reproductive condition of a dwc:Organism."@en ;
-    skos:prefLabel "Reproductive Condition"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/resourceID>
     rdfs:label "Resource ID"@en ;
-    rdfs:comment "An identifier for the resource that is the subject of the relationship."@en ;
     skos:definition "An identifier for the resource that is the subject of the relationship."@en ;
-    skos:prefLabel "Resource ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/resourceRelationshipID>
     rdfs:label "Resource Relationship ID"@en ;
-    dcterms:description "Recommended best practice is to use a globally unique identifier."@en ;
-    rdfs:comment "An identifier for a dwc:ResourceRelationship."@en ;
     skos:definition "An identifier for a dwc:ResourceRelationship."@en ;
-    skos:prefLabel "Resource Relationship ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/sampleSizeUnit>
     rdfs:label "Sample Size Unit"@en ;
-    dcterms:description "A dwc:sampleSizeUnit must have a corresponding dwc:sampleSizeValue, e.g., `5` for dwc:sampleSizeValue with `m` for dwc:sampleSizeUnit. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
     skos:definition "The unit of measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
-    skos:prefLabel "Sample Size Unit"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/sampleSizeValue>
     rdfs:label "Sample Size Value"@en ;
-    dcterms:description "A dwc:sampleSizeValue must have a corresponding dwc:sampleSizeUnit."@en ;
-    rdfs:comment "A numeric value for a measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
     skos:definition "A numeric value for a measurement of the size (time duration, length, area, or volume) of a sample in a sampling dwc:Event."@en ;
-    skos:prefLabel "Sample Size Value"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/sampledSubstrateCategory>
     rdfs:label "Sampled Substrate Category"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary and separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category or type of substrate sampled during a dwc:Event."@en ;
     skos:definition "A category or type of substrate sampled during a dwc:Event."@en ;
-    skos:prefLabel "Sampled Substrate Category"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/sampledSubstrateLayer>
     rdfs:label "Sampled Substrate Layer"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary and separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A list (concatenated and separated) of substrate layers sampled during a dwc:Event."@en ;
     skos:definition "A list (concatenated and separated) of substrate layers sampled during a dwc:Event."@en ;
-    skos:prefLabel "Sampled Substrate Layer"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/samplingEffort>
     rdfs:label "Sampling Effort"@en ;
-    rdfs:comment "The amount of effort expended during a dwc:Event."@en ;
     skos:definition "The amount of effort expended during a dwc:Event."@en ;
-    skos:prefLabel "Sampling Effort"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/samplingProtocol>
     rdfs:label "Sampling Protocol"@en ;
-    dcterms:description "Recommended best practice is to describe a dwc:Event with no more than one sampling protocol. In the case of a summary Event with multiple protocols, in which a specific protocol can not be attributed to specific dwc:Occurrences, the recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The names of, references to, or descriptions of the methods or protocols used during a dwc:Event."@en ;
     skos:definition "The names of, references to, or descriptions of the methods or protocols used during a dwc:Event."@en ;
-    skos:prefLabel "Sampling Protocol"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/scientificName>
     rdfs:label "Scientific Name"@en ;
-    dcterms:description "This term should not contain identification qualifications, which should instead be supplied in the IdentificationQualifier term. When applied to an Organism or Occurrence, this term should be used to represent the scientific name that was applied to the associated Organism in accordance with the Taxon to which it was or is currently identified. Names should be compliant to the most recent nomenclatural code. For example, names of hybrids for algae, fungi and plants should follow the rules of the International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code Articles H.1, H.2 and H.3). Thus, use the multiplication sign `×` (Unicode `U+00D7`, HTML `&times;`) to identify a hybrid, not `x` or `X`, if possible."@en ;
-    rdfs:comment "The full scientific name, with authorship and date information if known. When forming part of a dwc:Identification, this should be the name in lowest level taxonomic rank that can be determined."@en ;
     skos:definition "The full scientific name, with authorship and date information if known. When forming part of a dwc:Identification, this should be the name in lowest level taxonomic rank that can be determined."@en ;
-    skos:prefLabel "Scientific Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/scientificNameAuthorship>
     rdfs:label "Scientific Name Authorship"@en ;
-    rdfs:comment "The authorship information for the dwc:scientificName formatted according to the conventions of the applicable dwc:nomenclaturalCode."@en ;
     skos:definition "The authorship information for the dwc:scientificName formatted according to the conventions of the applicable dwc:nomenclaturalCode."@en ;
-    skos:prefLabel "Scientific Name Authorship"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/scientificNameID>
     rdfs:label "Scientific Name ID"@en ;
-    rdfs:comment "An identifier for the nomenclatural (not taxonomic) details of a scientific name."@en ;
     skos:definition "An identifier for the nomenclatural (not taxonomic) details of a scientific name."@en ;
-    skos:prefLabel "Scientific Name ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/scientificNameRank>
     rdfs:label "Scientific Name Rank"@en ;
-    dcterms:description "Examples: \"subsp.\", \"var.\", \"forma\", \"species\", \"genus\""@en ;
-    rdfs:comment "The taxonomic rank of the most specific name in the scientificName. Recommended best practice is to use a controlled vocabulary."@en ;
     skos:definition "The taxonomic rank of the most specific name in the scientificName. Recommended best practice is to use a controlled vocabulary."@en ;
-    skos:prefLabel "Scientific Name Rank"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/sequence>
     rdfs:label "Sequence"@en ;
-    dcterms:description "Recommended best practice is to use IUPAC single character symbols (https://www.bioinformatics.org/sms/iupac.html). Use \"N\" for an unknown or missing nucleotide, and avoid using \"?\". The sequence should be written in the 5' to 3' direction."@en ;
-    rdfs:comment "A string representing nucleotide base pairs."@en ;
     skos:definition "A string representing nucleotide base pairs."@en ;
-    skos:prefLabel "Sequence"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/sex>
     rdfs:label "Sex"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A sex of a dwc:Organism."@en ;
     skos:definition "A sex of a dwc:Organism."@en ;
-    skos:prefLabel "Sex"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/siteNumber>
     rdfs:label "Site Number"@en ;
-    dcterms:description "Usually an institutional identifier for a specific named place as opposed to dwc:locationID, which is an identifier for the entire set of distinct information for an instance of dcterms:Location. This term differs from dwc:fieldNumber in that dwc:siteNumber is not related strictly to one dwc:Event. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "An identifier for a named site."@en ;
     skos:definition "An identifier for a named site."@en ;
-    skos:prefLabel "Site Number"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/specificEpithet>
     rdfs:label "Specific Epithet"@en ;
-    rdfs:comment "The name of the first or species epithet of the dwc:scientificName."@en ;
     skos:definition "The name of the first or species epithet of the dwc:scientificName."@en ;
-    skos:prefLabel "Specific Epithet"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/startDayOfYear>
     rdfs:label "Start Day Of Year"@en ;
-    dcterms:description "The value is 1 for January 1 and 365 for December 31, except in a leap year, in which case it is 366."@en ;
-    rdfs:comment "The earliest integer day of the year on which a dwc:Event occurred."@en ;
     skos:definition "The earliest integer day of the year on which a dwc:Event occurred."@en ;
-    skos:prefLabel "Start Day Of Year"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/stateProvince>
     rdfs:label "First Order Division"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names. Recommended best practice is to leave this field blank if the dcterms:Location spans multiple entities at this administrative level or if the dcterms:Location might be in one or another of multiple possible entities at this level. Multiplicity and uncertainty of the geographic entity can be captured either in the term dwc:higherGeography or in the term dwc:locality, or both."@en ;
-    rdfs:comment "The name of the next smaller administrative region than country (state, province, canton, department, region, etc.) in which the dcterms:Location occurs."@en ;
     skos:definition "The name of the next smaller administrative region than country (state, province, canton, department, region, etc.) in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "First Order Division"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/subfamily>
     rdfs:label "Subfamily"@en ;
-    rdfs:comment "The full scientific name of the subfamily in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the subfamily in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Subfamily"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/subgenus>
     rdfs:label "Subgenus"@en ;
-    dcterms:description "A value for this term should be a complete subgenus name as required by the appropriate nomenclatural code."@en ;
-    rdfs:comment "The full scientific name of the subgenus in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the subgenus in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Subgenus"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/subtribe>
     rdfs:label "Subtribe"@en ;
-    rdfs:comment "The full scientific name of the subtribe in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the subtribe in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Subtribe"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/superfamily>
     rdfs:label "Superfamily"@en ;
-    dcterms:description "A taxonomic category subordinate to an order and superior to a family. According to ICZN article 29.2, the suffix `-oidea` is used for a superfamily name."@en ;
-    rdfs:comment "The full scientific name of the superfamily in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the superfamily in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Superfamily"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonAccordingTo>
     rdfs:label "Taxon According To"@en ;
-    rdfs:comment "Information about the authorship of this taxon concept which uses the scientificName in their sense (secundum, sensu). Could be a publication (identification key), institution or team of individuals."@en ;
     skos:definition "Information about the authorship of this taxon concept which uses the scientificName in their sense (secundum, sensu). Could be a publication (identification key), institution or team of individuals."@en ;
-    skos:prefLabel "Taxon According To"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonAttributes>
     rdfs:label "Taxon Attributes"@en ;
-    dcterms:description "Example: \"iucnstatus=vulnerable; distribution=Neuquen, Argentina\""@en ;
-    rdfs:comment "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the taxon."@en ;
     skos:definition "A list (concatenated and separated) of additional measurements, facts, characteristics, or assertions about the taxon."@en ;
-    skos:prefLabel "Taxon Attributes"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonConceptID>
     rdfs:label "Taxon Concept ID"@en ;
-    rdfs:comment "An identifier for the taxonomic concept to which the record refers - not for the nomenclatural details of a dwc:Taxon."@en ;
     skos:definition "An identifier for the taxonomic concept to which the record refers - not for the nomenclatural details of a dwc:Taxon."@en ;
-    skos:prefLabel "Taxon Concept ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonFormula>
     rdfs:label "Taxon Formula"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
-    rdfs:comment "A string representing the pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
     skos:definition "A string representing the pattern to use to construct a dwc:Identification from dwc:Taxon names and identification qualifiers."@en ;
-    skos:prefLabel "Taxon Formula"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonID>
     rdfs:label "Taxon ID"@en ;
-    rdfs:comment "An identifier for a dwc:Taxon."@en ;
     skos:definition "An identifier for a dwc:Taxon."@en ;
-    skos:prefLabel "Taxon ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonNameID>
     rdfs:label "Taxon Name ID"@en ;
-    rdfs:comment "A unique identifier for the scientificName."@en ;
     skos:definition "A unique identifier for the scientificName."@en ;
-    skos:prefLabel "Taxon Name ID"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonRank>
     rdfs:label "Taxon Rank"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. The taxon ranks of algae, fungi and plants are defined in the International Code of Nomenclature for algae, fungi, and plants (Shenzhen Code Articles H3.2, H4.4 and H.3.1)."@en ;
-    rdfs:comment "The taxonomic rank of the most specific name in the dwc:scientificName."@en ;
     skos:definition "The taxonomic rank of the most specific name in the dwc:scientificName."@en ;
-    skos:prefLabel "Taxon Rank"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonRemarks>
     rdfs:label "Taxon Remarks"@en ;
-    rdfs:comment "Comments or notes about the taxon or name."@en ;
     skos:definition "Comments or notes about the taxon or name."@en ;
-    skos:prefLabel "Taxon Remarks"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/taxonomicStatus>
     rdfs:label "Taxonomic Status"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary."@en ;
-    rdfs:comment "The status of the use of the dwc:scientificName as a label for a taxon. Requires taxonomic opinion to define the scope of a dwc:Taxon. Rules of priority then are used to define the taxonomic status of the nomenclature contained in that scope, combined with the experts opinion. It must be linked to a specific taxonomic reference that defines the concept."@en ;
     skos:definition "The status of the use of the dwc:scientificName as a label for a taxon. Requires taxonomic opinion to define the scope of a dwc:Taxon. Rules of priority then are used to define the taxonomic status of the nomenclature contained in that scope, combined with the experts opinion. It must be linked to a specific taxonomic reference that defines the concept."@en ;
-    skos:prefLabel "Taxonomic Status"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/tribe>
     rdfs:label "Tribe"@en ;
-    rdfs:comment "The full scientific name of the tribe in which the dwc:Taxon is classified."@en ;
     skos:definition "The full scientific name of the tribe in which the dwc:Taxon is classified."@en ;
-    skos:prefLabel "Tribe"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/typeOfType>
     rdfs:label "Type Of Type"@en ;
-    dcterms:description "The term dwc:typeOfType must be used in combination with dwc:typifiedName. Together they make up the type status of a specimen. Note that relatively very few specimens are nomenclatural types (types of names), so in most cases this term will have no value. Unlike dwc:typeStatus, dwc:typeOfType can only have a single value. Recommended best practice is to use a controlled vocabulary such as the GBIF Nomenclatural Type Status Vocabulary. This term has an equivalent in the tcs: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A category of nomenclatural type of a dwc:MaterialEntity."@en ;
     skos:definition "A category of nomenclatural type of a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Type Of Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/typeStatus>
     rdfs:label "Type Status"@en ;
-    dcterms:description "Recommended best practice is to separate the values in a list with space vertical bar space (` | `). This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A list (concatenated and separated) of nomenclatural types (type status, typified scientific name, publication) applied to the subject."@en ;
     skos:definition "A list (concatenated and separated) of nomenclatural types (type status, typified scientific name, publication) applied to the subject."@en ;
-    skos:prefLabel "Type Status"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/typifiedName>
     rdfs:label "Typified Name"@en ;
-    dcterms:description "The term dwc:typifiedName must be used in combination with dwc:typeOfType. Together they make up the type status of a specimen. Note that relatively very few specimens are nomenclatural types (types of names), so in most cases this term will have no value. Unlike dwc:typeStatus, dwc:typifiedName can only have a single value, so a dwc:MaterialEntity can only have a single dwc:typifiedName."@en ;
-    rdfs:comment "A scientific name for which a specimen or other name is the type."@en ;
     skos:definition "A scientific name for which a specimen or other name is the type."@en ;
-    skos:prefLabel "Typified Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimAssertionType>
     rdfs:label "Verbatim Assertion Type"@en ;
-    dcterms:description "This term is meant to allow the capture of an unaltered original name for a dwc:assertionType. This term is meant to be used in addition to dwc:assertionType, not instead of it."@en ;
-    rdfs:comment "A string representing the type of dwc:Assertion as it appeared in an original record."@en ;
     skos:definition "A string representing the type of dwc:Assertion as it appeared in an original record."@en ;
-    skos:prefLabel "Verbatim Assertion Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimCoordinateSystem>
     rdfs:label "Verbatim Coordinate System"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
     skos:definition "A coordinate format for dwc:verbatimLatitude and dwc:verbatimLongitude or dwc:verbatimCoordinates."@en ;
-    skos:prefLabel "Verbatim Coordinate System"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimCoordinates>
     rdfs:label "Verbatim Coordinates"@en ;
-    dcterms:description "The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in dwc:verbatimSRS and the coordinate system should be stored in dwc:verbatimCoordinateSystem."@en ;
-    rdfs:comment "Verbatim original spatial coordinates of a dcterms:Location."@en ;
     skos:definition "Verbatim original spatial coordinates of a dcterms:Location."@en ;
-    skos:prefLabel "Verbatim Coordinates"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimDepth>
     rdfs:label "Verbatim Depth"@en ;
-    rdfs:comment "The original description of the depth below the local surface."@en ;
     skos:definition "The original description of the depth below the local surface."@en ;
-    skos:prefLabel "Verbatim Depth"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimElevation>
     rdfs:label "Verbatim Elevation"@en ;
-    rdfs:comment "An original description of the elevation of a dcterms:Location."@en ;
     skos:definition "An original description of the elevation of a dcterms:Location."@en ;
-    skos:prefLabel "Verbatim Elevation"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimEventDate>
     rdfs:label "Verbatim EventDate"@en ;
-    rdfs:comment "The verbatim original representation of the date and time information for a dwc:Event."@en ;
     skos:definition "The verbatim original representation of the date and time information for a dwc:Event."@en ;
-    skos:prefLabel "Verbatim EventDate"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimIdentification>
     rdfs:label "Verbatim Identification"@en ;
-    dcterms:description "This term is meant to allow the capture of an unaltered original identification/determination, including identification qualifiers, hybrid formulas, uncertainties, etc. This term is meant to be used in addition to dwc:scientificName (and dwc:identificationQualifier etc.), not instead of it."@en ;
-    rdfs:comment "A string representing the taxonomic identification as it appeared in the original record."@en ;
     skos:definition "A string representing the taxonomic identification as it appeared in the original record."@en ;
-    skos:prefLabel "Verbatim Identification"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimLabel>
     rdfs:label "Verbatim Label"@en ;
-    dcterms:description "The content of this term should include no embellishments, prefixes, headers or other additions made to the text. Abbreviations must not be expanded and supposed misspellings must not be corrected. Lines or breakpoints between blocks of text that could be verified by seeing the original labels or images of them may be used. Examples of material entities include preserved specimens, fossil specimens, and material samples. Best practice is to use UTF-8 for all characters. Best practice is to add comment “verbatimLabel derived from human transcription” in dwc:materialEntityRemarks. Examples can be found at https://dwc.tdwg.org/examples/verbatimLabel."@en ;
-    rdfs:comment "A verbatim original representation of the written information affixed or related to a dwc:MaterialEntity."@en ;
     skos:definition "A verbatim original representation of the written information affixed or related to a dwc:MaterialEntity."@en ;
-    skos:prefLabel "Verbatim Label"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimLatitude>
     rdfs:label "Verbatim Latitude"@en ;
-    dcterms:description "The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in dwc:verbatimSRS and the coordinate system should be stored in dwc:verbatimCoordinateSystem."@en ;
-    rdfs:comment "A verbatim original latitude of a dcterms:Location."@en ;
     skos:definition "A verbatim original latitude of a dcterms:Location."@en ;
-    skos:prefLabel "Verbatim Latitude"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimLocality>
     rdfs:label "Verbatim Locality"@en ;
-    rdfs:comment "An original textual description of a dcterms:Location."@en ;
     skos:definition "An original textual description of a dcterms:Location."@en ;
-    skos:prefLabel "Verbatim Locality"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimLongitude>
     rdfs:label "Verbatim Longitude"@en ;
-    dcterms:description "The coordinate ellipsoid, geodeticDatum, or full Spatial Reference System (SRS) for these coordinates should be stored in dwc:verbatimSRS and the coordinate system should be stored in dwc:verbatimCoordinateSystem."@en ;
-    rdfs:comment "A verbatim original longitude of a dcterms:Location."@en ;
     skos:definition "A verbatim original longitude of a dcterms:Location."@en ;
-    skos:prefLabel "Verbatim Longitude"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimMeasurementType>
     rdfs:label "Verbatim Measurement Type"@en ;
-    dcterms:description "This term is meant to allow the capture of an unaltered original name for a measurement or fact type. This term is meant to be used in addition to dwc:measurementType, not instead of it."@en ;
-    rdfs:comment "A string representing the type of measurement or fact as it appeared in the original record."@en ;
     skos:definition "A string representing the type of measurement or fact as it appeared in the original record."@en ;
-    skos:prefLabel "Verbatim Measurement Type"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimSRS>
     rdfs:label "Verbatim SRS"@en ;
-    dcterms:description "Recommended best practice is to use the EPSG code of the SRS, if known. Otherwise use a controlled vocabulary for the name or code of the geodetic datum, if known. Otherwise use a controlled vocabulary for the name or code of the ellipsoid, if known. If none of these is known, use the value `not recorded`. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
     skos:definition "The ellipsoid, geodetic datum, or spatial reference system (SRS) upon which coordinates given in dwc:verbatimLatitude and dwc:verbatimLongitude, or dwc:verbatimCoordinates are based."@en ;
-    skos:prefLabel "Verbatim SRS"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimScientificNameRank>
     rdfs:label "Verbatim Scientific Name Rank"@en ;
-    dcterms:description "Examples: \"Agamospecies\", \"sub-lesus\", \"prole\", \"apomict\", \"nothogrex\"."@en ;
-    rdfs:comment "The taxonomic rank of the most specific name in the scientificName as it appears in the original record."@en ;
     skos:definition "The taxonomic rank of the most specific name in the scientificName as it appears in the original record."@en ;
-    skos:prefLabel "Verbatim Scientific Name Rank"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verbatimTaxonRank>
     rdfs:label "Verbatim Taxon Rank"@en ;
-    rdfs:comment "The taxonomic rank of the most specific name in the dwc:scientificName as it appears in the original record."@en ;
     skos:definition "The taxonomic rank of the most specific name in the dwc:scientificName as it appears in the original record."@en ;
-    skos:prefLabel "Verbatim Taxon Rank"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/vernacularName>
     rdfs:label "Vernacular Name"@en ;
-    rdfs:comment "A common or vernacular name."@en ;
     skos:definition "A common or vernacular name."@en ;
-    skos:prefLabel "Vernacular Name"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/verticalDatum>
     rdfs:label "Vertical Datum"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
     skos:definition "The vertical datum used as the reference upon which the values in the elevation terms are based."@en ;
-    skos:prefLabel "Vertical Datum"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/vitality>
     rdfs:label "Vitality"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary. This term has an equivalent in the dwciri: namespace that allows only an IRI as a value, whereas this term allows for any string literal value."@en ;
-    rdfs:comment "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
     skos:definition "An indication of whether a dwc:Organism was alive or dead at the time of collection or observation."@en ;
-    skos:prefLabel "Vitality"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/waterBody>
     rdfs:label "Water Body"@en ;
-    dcterms:description "Recommended best practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names."@en ;
-    rdfs:comment "The name of the water body in which the dcterms:Location occurs."@en ;
     skos:definition "The name of the water body in which the dcterms:Location occurs."@en ;
-    skos:prefLabel "Water Body"@en ;
 .
 
 <http://rs.tdwg.org/dwc/terms/year>
     rdfs:label "Year"@en ;
-    rdfs:comment "The four-digit year in which the dwc:Event occurred, according to the Common Era Calendar."@en ;
     skos:definition "The four-digit year in which the dwc:Event occurred, according to the Common Era Calendar."@en ;
-    skos:prefLabel "Year"@en ;
 .


### PR DESCRIPTION
Not sure about using language tags for labels and descriptions, there seems to be a bit of inconsistency across the repo - not sure if that's normalised in downstream systems (for ref, these additions arrive out of an audit for the Biodiversity Data Repository  https://github.com/dcceew-bdr/bdr-ops/issues/217).