### PR TITLE
fix: push CQL filters down to Jena Lucene on all listing endpoints

### DIFF
--- a/docs/2026-03-23-lucene-cql-queryables.md
+++ b/docs/2026-03-23-lucene-cql-queryables.md
@@ -280,6 +280,23 @@ That means this is the intended form:
 
 and not a separate domain predicate IRI that Prez would remap later. The current implementation validates the IRI and passes it through unchanged into the Lucene filter JSON.
 
+## Where Filter Pushdown Applies
+
+With `enable_cql_jena_lucene_json` on, a CQL filter is pushed down to `luc:query` on any listing endpoint, including custom `ont:ListingEndpoint`s, on GET and POST alike.
+
+Which path a filter takes depends on its `property` values:
+
+| filter properties | path |
+|---|---|
+| all absolute IRIs | pushed down to `luc:query` |
+| any queryable identifier (e.g. `"rdf-type"`) | evaluated as SPARQL by `CQLParser` |
+
+Mixed filters take the SPARQL path in full — the two are not combined.
+
+`/search` and `/search-post` are unconditional: with the setting on, their filters are always pushed down, and a non-IRI property is a `400` rather than a fallback. OGC Features listings never push down; they build no search query, so a pushed-down filter would be dropped.
+
+A pushed-down filter can only return resources present in the Lucene index, and pagination and ordering move into `luc:query` — a Lucene sort overrides SPARQL `ORDER BY`.
+
 ## Representative SPARQL Shape
 
 This is the readable main query shape generated inside the Prez listing pipeline for the POST example above:

--- a/prez/dependencies.py
+++ b/prez/dependencies.py
@@ -285,7 +285,9 @@ async def cql_get_parser_dependency(
     endpoint_uri_type: str = Depends(get_endpoint_uri_type),
     runtime_settings: Settings = Depends(get_runtime_settings),
 ) -> CQLParser:
-    if _search_uses_jena_lucene(endpoint_uri_type[0], runtime_settings):
+    if _search_uses_jena_lucene(
+        endpoint_uri_type[0], runtime_settings, query_params._filter
+    ):
         if query_params._filter:
             _parse_lucene_filter_json(query_params._filter, "GET")
         return None
@@ -360,19 +362,24 @@ def _is_absolute_iri(value: str) -> bool:
     return bool(parsed.scheme and (parsed.netloc or parsed.path))
 
 
-def _collect_non_iri_cql_properties(node, invalid_properties: list[str]) -> None:
+def _collect_cql_properties(node, properties: list) -> None:
     if isinstance(node, dict):
         property_value = node.get("property")
         if property_value is not None:
-            if not isinstance(property_value, str) or not _is_absolute_iri(
-                property_value
-            ):
-                invalid_properties.append(str(property_value))
+            properties.append(property_value)
         for value in node.values():
-            _collect_non_iri_cql_properties(value, invalid_properties)
+            _collect_cql_properties(value, properties)
     elif isinstance(node, list):
         for item in node:
-            _collect_non_iri_cql_properties(item, invalid_properties)
+            _collect_cql_properties(item, properties)
+
+
+def _collect_non_iri_cql_properties(node, invalid_properties: list[str]) -> None:
+    properties: list = []
+    _collect_cql_properties(node, properties)
+    invalid_properties.extend(
+        str(p) for p in properties if not isinstance(p, str) or not _is_absolute_iri(p)
+    )
 
 
 def _validate_lucene_cql_filter(filter_json: dict | None) -> None:
@@ -562,11 +569,77 @@ def _resolve_lucene_search_fields(
     return runtime_settings.lucene_search_fields
 
 
-def _search_uses_jena_lucene(endpoint_uri: URIRef, runtime_settings: Settings) -> bool:
-    return runtime_settings.enable_cql_jena_lucene_json and endpoint_uri in {
-        EP["extended-ogc-records/search"],
-        EP["extended-ogc-records/search-post"],
-    }
+_SEARCH_EP_URIS = {
+    EP["extended-ogc-records/search"],
+    EP["extended-ogc-records/search-post"],
+}
+
+
+def _filter_properties_are_lucene_fields(filter_value) -> bool:
+    """Whether every ``property`` in a CQL filter names a Lucene field.
+
+    Lucene field names are absolute IRIs; queryable identifiers are not. A filter
+    that names only IRIs can be pushed down to ``luc:query``, anything else has to
+    be evaluated as SPARQL against the registered queryables.
+    """
+    if not filter_value:
+        return False
+    if isinstance(filter_value, str):
+        try:
+            filter_json = json.loads(filter_value)
+        except json.JSONDecodeError:
+            return False
+    else:
+        filter_json = filter_value
+    properties: list = []
+    _collect_cql_properties(filter_json, properties)
+    return bool(properties) and all(
+        isinstance(p, str) and _is_absolute_iri(p) for p in properties
+    )
+
+
+def _endpoint_builds_search_query(endpoint_uri: URIRef) -> bool:
+    """OGC Features listings have no search query dependency, so a filter pushed
+    down there would simply be dropped. They stay on the SPARQL CQL path."""
+    return not str(endpoint_uri).startswith(str(OGCFEAT))
+
+
+def _search_uses_jena_lucene(
+    endpoint_uri: URIRef,
+    runtime_settings: Settings,
+    filter_value=None,
+) -> bool:
+    if not runtime_settings.enable_cql_jena_lucene_json:
+        return False
+    if endpoint_uri in _SEARCH_EP_URIS:
+        return True
+    if not _endpoint_builds_search_query(endpoint_uri):
+        return False
+    return _filter_properties_are_lucene_fields(filter_value)
+
+
+def _build_lucene_search_query(
+    query_params,
+    runtime_settings: Settings,
+    filter_json: dict | None,
+    search_fields,
+    term: str | None = None,
+    facets: list[str] | None = None,
+) -> SearchQueryJenaLucene:
+    return SearchQueryJenaLucene(
+        term=term,
+        facets=facets,
+        filter_json=filter_json,
+        limit=int(query_params.limit),
+        offset=_calculate_listing_offset(query_params),
+        lucene_index_name=runtime_settings.lucene_index_name,
+        search_fields=search_fields,
+        lucene_hit_limit=_resolve_lucene_hit_limit(query_params, runtime_settings),
+        order_by=query_params.order_by,
+        order_by_direction=query_params.order_by_direction,
+        include_matches=bool(term),
+        pagination_pushed_down=_lucene_uses_limit_offset_pushdown(runtime_settings),
+    )
 
 
 async def lucene_cql_get_parser_dependency(
@@ -840,7 +913,9 @@ async def cql_post_listing_parser_dependency(
     runtime_settings: Settings = Depends(get_runtime_settings),
 ) -> "CQLParser | None":
     """CQL parser for listing POST endpoints (filter is optional)."""
-    if _search_uses_jena_lucene(endpoint_uri_type[0], runtime_settings):
+    if _search_uses_jena_lucene(
+        endpoint_uri_type[0], runtime_settings, query_params._filter
+    ):
         if query_params._filter:
             _parse_lucene_filter_json(query_params._filter, "POST")
         return None
@@ -886,41 +961,29 @@ async def generate_search_query_post(
             return True
         return False
 
-    _search_ep_uris = {
-        EP["extended-ogc-records/search"],
-        EP["extended-ogc-records/search-post"],
-    }
+    uses_lucene = _search_uses_jena_lucene(
+        endpoint_uri_type[0], runtime_settings, query_params._filter
+    )
+
+    async def build_lucene_query() -> SearchQueryJenaLucene:
+        body = await _parse_post_body(request)
+        return _build_lucene_search_query(
+            query_params,
+            runtime_settings,
+            _parse_lucene_filter_json(query_params._filter, "POST"),
+            _resolve_lucene_search_fields(
+                body.get("fields"),
+                runtime_settings,
+                "POST",
+            ),
+            term=term,
+        )
+
     if not term:
-        if endpoint_uri_type[0] in _search_ep_uris:
+        if endpoint_uri_type[0] in _SEARCH_EP_URIS:
             if has_filtering_params():
-                if _search_uses_jena_lucene(endpoint_uri_type[0], runtime_settings):
-                    body = await _parse_post_body(request)
-                    filter_json = _parse_lucene_filter_json(
-                        query_params._filter, "POST"
-                    )
-                    search_fields = _resolve_lucene_search_fields(
-                        body.get("fields"),
-                        runtime_settings,
-                        "POST",
-                    )
-                    return SearchQueryJenaLucene(
-                        term=query_params.q,
-                        facets=None,
-                        filter_json=filter_json,
-                        limit=int(query_params.limit),
-                        offset=_calculate_listing_offset(query_params),
-                        lucene_index_name=runtime_settings.lucene_index_name,
-                        search_fields=search_fields,
-                        lucene_hit_limit=_resolve_lucene_hit_limit(
-                            query_params, runtime_settings
-                        ),
-                        order_by=query_params.order_by,
-                        order_by_direction=query_params.order_by_direction,
-                        include_matches=bool(query_params.q),
-                        pagination_pushed_down=_lucene_uses_limit_offset_pushdown(
-                            runtime_settings
-                        ),
-                    )
+                if uses_lucene:
+                    return await build_lucene_query()
                 return DummySearchMarker()
             raise HTTPException(
                 status_code=400,
@@ -929,30 +992,14 @@ async def generate_search_query_post(
                     "or use filtering parameters (facet_profile, filter, bbox, datetime)."
                 ),
             )
+        # Other listing endpoints: a filter naming only Lucene fields is pushed
+        # down to luc:query rather than evaluated as SPARQL.
+        if uses_lucene:
+            return await build_lucene_query()
         return None
 
-    if _search_uses_jena_lucene(endpoint_uri_type[0], runtime_settings):
-        body = await _parse_post_body(request)
-        filter_json = _parse_lucene_filter_json(query_params._filter, "POST")
-        search_fields = _resolve_lucene_search_fields(
-            body.get("fields"),
-            runtime_settings,
-            "POST",
-        )
-        return SearchQueryJenaLucene(
-            term=term,
-            facets=None,
-            filter_json=filter_json,
-            limit=int(query_params.limit),
-            offset=_calculate_listing_offset(query_params),
-            lucene_index_name=runtime_settings.lucene_index_name,
-            search_fields=search_fields,
-            lucene_hit_limit=_resolve_lucene_hit_limit(query_params, runtime_settings),
-            order_by=query_params.order_by,
-            order_by_direction=query_params.order_by_direction,
-            include_matches=bool(term),
-            pagination_pushed_down=_lucene_uses_limit_offset_pushdown(runtime_settings),
-        )
+    if uses_lucene:
+        return await build_lucene_query()
 
     predicates = query_params.predicates if hasattr(query_params, "predicates") else []
     page = query_params.page or 1
@@ -1200,37 +1247,31 @@ async def generate_search_query(
             return True
         return False
 
+    uses_lucene = _search_uses_jena_lucene(
+        endpoint_uri_type[0], runtime_settings, query_params._filter
+    )
+
+    def build_lucene_query() -> SearchQueryJenaLucene:
+        return _build_lucene_search_query(
+            query_params,
+            runtime_settings,
+            _parse_lucene_filter_json(query_params._filter, "GET"),
+            _resolve_lucene_search_fields(
+                request.query_params.getlist("fields") or None,
+                runtime_settings,
+                "GET",
+            ),
+            term=query_params.q,
+        )
+
     # Check if the search term 'q' is provided
     if not term:
         # If 'q' is missing or empty, check if we're on the search endpoint
         if endpoint_uri_type[0] == EP["extended-ogc-records/search"]:
             # Allow empty search term if filtering/faceting parameters are present
             if has_filtering_params():
-                if _search_uses_jena_lucene(endpoint_uri_type[0], runtime_settings):
-                    filter_json = _parse_lucene_filter_json(query_params._filter, "GET")
-                    search_fields = _resolve_lucene_search_fields(
-                        request.query_params.getlist("fields") or None,
-                        runtime_settings,
-                        "GET",
-                    )
-                    return SearchQueryJenaLucene(
-                        term=query_params.q,
-                        facets=None,
-                        filter_json=filter_json,
-                        limit=int(query_params.limit),
-                        offset=_calculate_listing_offset(query_params),
-                        lucene_index_name=runtime_settings.lucene_index_name,
-                        search_fields=search_fields,
-                        lucene_hit_limit=_resolve_lucene_hit_limit(
-                            query_params, runtime_settings
-                        ),
-                        order_by=query_params.order_by,
-                        order_by_direction=query_params.order_by_direction,
-                        include_matches=bool(query_params.q),
-                        pagination_pushed_down=_lucene_uses_limit_offset_pushdown(
-                            runtime_settings
-                        ),
-                    )
+                if uses_lucene:
+                    return build_lucene_query()
                 # Return marker to indicate dummy search results needed
                 return DummySearchMarker()
             else:
@@ -1239,34 +1280,15 @@ async def generate_search_query(
                     detail="Search query parameter 'q' must be provided, or use filtering parameters (facet_profile, filter, bbox, datetime).",
                 )
         else:
-            # For other endpoints, 'q' is optional, return None if not provided
+            # On other listing endpoints a filter naming only Lucene fields is
+            # pushed down to luc:query; otherwise 'q' is optional and the filter
+            # is evaluated as SPARQL by the CQL parser dependency.
+            if uses_lucene:
+                return build_lucene_query()
             return None
     else:
-        if _search_uses_jena_lucene(endpoint_uri_type[0], runtime_settings):
-            filter_json = _parse_lucene_filter_json(query_params._filter, "GET")
-            search_fields = _resolve_lucene_search_fields(
-                request.query_params.getlist("fields") or None,
-                runtime_settings,
-                "GET",
-            )
-            search_query = SearchQueryJenaLucene(
-                term=query_params.q,
-                facets=None,
-                filter_json=filter_json,
-                limit=int(query_params.limit),
-                offset=_calculate_listing_offset(query_params),
-                lucene_index_name=runtime_settings.lucene_index_name,
-                search_fields=search_fields,
-                lucene_hit_limit=_resolve_lucene_hit_limit(
-                    query_params, runtime_settings
-                ),
-                order_by=query_params.order_by,
-                order_by_direction=query_params.order_by_direction,
-                include_matches=bool(query_params.q),
-                pagination_pushed_down=_lucene_uses_limit_offset_pushdown(
-                    runtime_settings
-                ),
-            )
+        if uses_lucene:
+            search_query = build_lucene_query()
             logger.debug(f"Generated search query: {search_query}")
             return search_query
 

--- a/tests/test_cql_lucene.py
+++ b/tests/test_cql_lucene.py
@@ -1885,3 +1885,220 @@ def test_lucene_cql_facet_profile_resolves_lucene_facets():
     assert "urn:jena:lucene:index#facet" in sparql
     assert "urn:field:commodity" in sparql
     assert "urn:field:state" in sparql
+
+
+########################################################################################
+# Issue 479: filter pushdown on listing endpoints other than /search
+########################################################################################
+
+CUSTOM_LISTING_EP = (
+    URIRef("https://prez.dev/endpoint/data-types"),
+    ONT["ListingEndpoint"],
+)
+
+IRI_FILTER = {
+    "op": "=",
+    "args": [{"property": "urn:jena:lucene:field#entityType"}, "Borehole"],
+}
+QUERYABLE_FILTER = {
+    "op": "=",
+    "args": [{"property": "rdf-type"}, "Borehole"],
+}
+
+
+def _lucene_settings() -> Settings:
+    return Settings(
+        enable_cql_jena_lucene_json=True,
+        lucene_index_name="default",
+        sparql_repo_type="remote",
+        sparql_endpoint="http://example.com/dataset/sparql",
+    )
+
+
+@pytest.mark.asyncio
+async def test_iri_filter_on_custom_listing_endpoint_is_pushed_down(test_repo: Repo):
+    query_params = ListingQueryParams(
+        page=1, limit=10, q=None, _filter=json.dumps(IRI_FILTER)
+    )
+
+    search_query = await generate_search_query(
+        request=_make_request("/data-types?filter=%7B%7D"),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+    cql_parser = await cql_get_parser_dependency(
+        query_params=query_params,
+        queryable_props=[],
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert isinstance(search_query, SearchQueryJenaLucene)
+    assert "urn:jena:lucene:field#entityType" in lucene_call(search_query)
+    assert cql_parser is None
+
+
+@pytest.mark.asyncio
+async def test_queryable_filter_on_custom_listing_endpoint_stays_on_sparql(
+    test_repo: Repo,
+):
+    query_params = ListingQueryParams(
+        page=1, limit=10, _filter=json.dumps(QUERYABLE_FILTER)
+    )
+
+    search_query = await generate_search_query(
+        request=_make_request("/data-types?filter=%7B%7D"),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert search_query is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_filter_on_custom_listing_endpoint_stays_on_sparql(
+    test_repo: Repo,
+):
+    mixed_filter = {"op": "and", "args": [IRI_FILTER, QUERYABLE_FILTER]}
+    query_params = ListingQueryParams(
+        page=1, limit=10, q=None, _filter=json.dumps(mixed_filter)
+    )
+
+    search_query = await generate_search_query(
+        request=_make_request("/data-types?filter=%7B%7D"),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert search_query is None
+
+
+@pytest.mark.asyncio
+async def test_no_filter_on_custom_listing_endpoint_is_not_a_search(test_repo: Repo):
+    search_query = await generate_search_query(
+        request=_make_request("/data-types"),
+        query_params=ListingQueryParams(page=1, limit=10, q=None),
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert search_query is None
+
+
+@pytest.mark.asyncio
+async def test_iri_filter_on_ogc_features_endpoint_stays_on_sparql(test_repo: Repo):
+    """OGC Features listings build no search query, so a pushed-down filter would
+    be dropped entirely."""
+    from prez.reference_data.prez_ns import OGCFEAT
+
+    query_params = ListingQueryParams(
+        page=1, limit=10, q=None, _filter=json.dumps(IRI_FILTER)
+    )
+
+    cql_parser = await cql_get_parser_dependency(
+        query_params=query_params,
+        queryable_props=[],
+        endpoint_uri_type=(OGCFEAT["features"], ONT["ListingEndpoint"]),
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert cql_parser is not None
+
+
+@pytest.mark.asyncio
+async def test_iri_filter_on_custom_listing_endpoint_is_ignored_when_flag_off(
+    test_repo: Repo,
+):
+    runtime_settings = Settings(
+        enable_cql_jena_lucene_json=False,
+        sparql_repo_type="remote",
+        sparql_endpoint="http://example.com/dataset/sparql",
+    )
+    query_params = ListingQueryParams(
+        page=1, limit=10, q=None, _filter=json.dumps(IRI_FILTER)
+    )
+
+    search_query = await generate_search_query(
+        request=_make_request("/data-types?filter=%7B%7D"),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=runtime_settings,
+    )
+
+    assert search_query is None
+
+
+@pytest.mark.asyncio
+async def test_iri_filter_with_term_on_custom_listing_endpoint_is_pushed_down(
+    test_repo: Repo,
+):
+    query_params = ListingQueryParams(
+        page=1, limit=10, q="ore", _filter=json.dumps(IRI_FILTER)
+    )
+
+    search_query = await generate_search_query(
+        request=_make_request("/data-types?q=ore&filter=%7B%7D"),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert isinstance(search_query, SearchQueryJenaLucene)
+    assert '"ore"' in lucene_call(search_query)
+
+
+@pytest.mark.asyncio
+async def test_iri_filter_on_custom_listing_endpoint_post_is_pushed_down(
+    test_repo: Repo,
+):
+    body = {"filter": IRI_FILTER, "limit": 10}
+    query_params = ListingQueryParams(
+        page=1, limit=10, q=None, _filter=json.dumps(IRI_FILTER)
+    )
+
+    search_query = await generate_search_query_post(
+        request=_make_request("/data-types", method="POST", json_body=body),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+    cql_parser = await cql_post_listing_parser_dependency(
+        query_params=query_params,
+        queryable_props=[],
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert isinstance(search_query, SearchQueryJenaLucene)
+    assert "urn:jena:lucene:field#entityType" in lucene_call(search_query)
+    assert cql_parser is None
+
+
+@pytest.mark.asyncio
+async def test_queryable_filter_on_custom_listing_endpoint_post_stays_on_sparql(
+    test_repo: Repo,
+):
+    body = {"filter": QUERYABLE_FILTER, "limit": 10}
+    query_params = ListingQueryParams(
+        page=1, limit=10, q=None, _filter=json.dumps(QUERYABLE_FILTER)
+    )
+
+    search_query = await generate_search_query_post(
+        request=_make_request("/data-types", method="POST", json_body=body),
+        query_params=query_params,
+        system_repo=test_repo,
+        endpoint_uri_type=CUSTOM_LISTING_EP,
+        runtime_settings=_lucene_settings(),
+    )
+
+    assert search_query is None


### PR DESCRIPTION
Addresses #479. Based on #478 — this PR targets `edmond/gswa/cql`.

## The bug

With `enable_cql_jena_lucene_json` on, `_search_uses_jena_lucene` ANDed the setting with an endpoint allowlist of `/search` and `/search-post`. On every other listing endpoint the same filter JSON was parsed against the registered queryables and evaluated as SPARQL, so a filter naming Lucene fields returned 200 with zero members rather than an error.

## The fix

`_search_uses_jena_lucene` now takes the filter and decides per request:

| filter properties | path |
|---|---|
| all absolute IRIs | pushed down to `luc:query` |
| any queryable identifier (e.g. `"rdf-type"`) | `CQLParser`, evaluated as SPARQL |

Applies on GET and POST alike, to custom `ont:ListingEndpoint`s included. `/search` and `/search-post` keep their unconditional pushdown, including the `400` on a non-IRI property.

Falling back rather than pushing down unconditionally is deliberate: Jena drops an unknown field silently, so a filter naming a field the running index config lacks would return *everything*.

**One thing the issue did not cover:** OGC Features listings use `cql_get_parser_dependency` but have no `generate_search_query` dependency. Returning `None` from the parser there would drop the filter entirely, so `_endpoint_builds_search_query` keeps them on the SPARQL path.

The four `SearchQueryJenaLucene` construction sites are now one `_build_lucene_search_query` helper, and `_collect_non_iri_cql_properties` is built on a plain `_collect_cql_properties` walk that the pushdown decision reuses.

## Tests

9 new tests in `tests/test_cql_lucene.py` covering IRI / queryable / mixed / absent filters on a custom listing endpoint, GET and POST, the flag off, a filter alongside `q`, and the OGC Features exclusion. `tests/` (excl. integration): 620 passed, 4 xfailed. The 2 failures in `test_issue_236_link_generation.py` are pre-existing and order-dependent — identical on the base branch, and both pass in isolation.

## Left open

The three design calls the issue raises alongside are unchanged by this PR and still open:

- **Unindexed resources.** A pushed-down filter can only return what is in the Lucene index. Where an endpoint's target classes have no index shape, pushdown turns a working filter into an empty result. Falling back when the target classes are not indexed would need the endpoint nodeshape at filter-parse time, which the dependency does not currently have.
- **Pagination and ordering** move into `luc:query` when pushdown applies, so a Lucene sort overrides SPARQL `ORDER BY` on endpoints that currently sort in SPARQL.
- No integration test against a live Fuseki for the non-`/search` path; the coverage here is at the dependency level.

Documented in `docs/2026-03-23-lucene-cql-queryables.md` under "Where Filter Pushdown Applies".

🤖 Generated with [Claude Code](https://claude.com/claude-code)